### PR TITLE
Upgrade com.alibaba:fastjson for security fix CVE-2017-18349

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ licenseHeaders.enabled = true
 javadoc.enabled = false
 esplugin {
     name 'opendistro_sql' // zip file name and plugin name in ${elasticsearch.plugin.name} read by ES when plugin loading
-    description 'Amazon Open Distribution for Elasticsearch SQL Access'
+    description 'Open Distro for Elasticsearch SQL'
     classname 'com.amazon.opendistroforelasticsearch.sql.plugin.SqlPlug'
 }
 
@@ -159,7 +159,7 @@ dependencies {
 
     // testCompile group: 'org.hamcrest', name: 'hamcrest-all', version:'1.3'
     // testCompile group: 'junit', name: 'junit', version:'4.11'
-    // testCompile group: 'com.alibaba', name: 'fastjson', version:'1.1.41'
+    // testCompile group: 'com.alibaba', name: 'fastjson', version:'1.2.56'
     // testCompile group: 'org.mockito', name: 'mockito-core', version:'2.23.4'
     testCompile group: "org.elasticsearch.client", name: 'transport', version: "${es_version}"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>opendistro-sql</artifactId>
     <version>6.5.4.0</version>
     <packaging>jar</packaging>
-    <description>Amazon Open Distribution for Elasticsearch SQL Access</description>
+    <description>Open Distro for Elasticsearch SQL</description>
     <name>opendistro-sql</name>
 
     <properties>
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.1.41</version>
+            <version>1.2.56</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Upgrade test dependency com.alibaba:fastjson to latest version 1.2.56 for security fix CVE-2017-18349 in both gradle and maven build files. Also changed plugin description.
All existing unit and integration tests passing.

https://github.com/opendistro-for-elasticsearch/sql/network/alert/pom.xml/com.alibaba:fastjson/open

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
