### PR TITLE
Fix index pattern issue for JDBC format

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/From.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/From.java
@@ -78,8 +78,15 @@ public class From {
         this.alias = alias;
     }
 
-	@Override
-	public String toString() {
-        return index + (type == null ? "" : "/" + type) + (alias == null ? "" : " " + type);
-	}
+    @Override
+    public String toString() {
+        StringBuilder str = new StringBuilder(index);
+        if (type != null) {
+            str.append('/').append(type);
+        }
+        if (alias != null) {
+            str.append(" AS ").append(alias);
+        }
+        return str.toString();
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/From.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/From.java
@@ -77,4 +77,9 @@ public class From {
     public void setAlias(String alias) {
         this.alias = alias;
     }
+
+	@Override
+	public String toString() {
+        return index + (type == null ? "" : "/" + type) + (alias == null ? "" : " " + type);
+	}
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -102,12 +102,14 @@ public class SelectResultSet extends ResultSet {
         GetFieldMappingsResponse response = client.admin().indices()
                 .getFieldMappings(request)
                 .actionGet();
-        Map<String, Map<String, FieldMappingMetaData>> indexMappings = response.mappings().get(indexName);
 
-        // If the incorrect typeName was given, indexMappings will be null so Schema's columns will not be populated
-        if (indexMappings == null) {
-            throw new IllegalArgumentException(String.format("Index type %s does not exist", typeName));
+        Map<String, Map<String, Map<String, FieldMappingMetaData>>> mappings = response.mappings();
+        if (mappings.isEmpty()) {
+            throw new IllegalArgumentException(String.format("Index type %s does not exist", query.getFrom()));
         }
+
+        // Assumption is all indices share the same mapping which is validated in TermFieldRewriter.
+        Map<String, Map<String, FieldMappingMetaData>> indexMappings = mappings.values().iterator().next();
 
         /*
          * There are three cases regarding type name to consider:

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/PrettyFormatResponseTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/PrettyFormatResponseTest.java
@@ -98,7 +98,7 @@ public class PrettyFormatResponseTest {
     public void indexPattern() {
         String query = "SELECT * FROM " + TestsConstants.TEST_INDEX + "_loc*";
         Protocol protocol = CheckPrettyFormatContents.execute(query, "jdbc");
-        assertThat(4L, equalTo(protocol.getResultSet().getDataRows().getSize()));
+        assertThat(protocol.getResultSet().getDataRows().getSize(), equalTo(4L));
     }
 
     /** Test Protocol as a whole */

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/PrettyFormatResponseTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/PrettyFormatResponseTest.java
@@ -90,8 +90,15 @@ public class PrettyFormatResponseTest {
             String query = String.format("SELECT * FROM %s/%s", TestsConstants.TEST_INDEX_ACCOUNT, type);
             Protocol protocol = CheckPrettyFormatContents.execute(query, "jdbc");
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is(String.format("Index type %s does not exist", type)));
+            assertThat(e.getMessage(), is(String.format("Index type [%s/%s] does not exist", TestsConstants.TEST_INDEX_ACCOUNT, type)));
         }
+    }
+
+    @Test
+    public void indexPattern() {
+        String query = "SELECT * FROM " + TestsConstants.TEST_INDEX + "_loc*";
+        Protocol protocol = CheckPrettyFormatContents.execute(query, "jdbc");
+        assertThat(4L, equalTo(protocol.getResultSet().getDataRows().getSize()));
     }
 
     /** Test Protocol as a whole */


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/9

*Description of changes:* Use the first one in index mapping rather than look up by index name/pattern which caused the mismatch. This works because all mappings found are exactly the same and there is validation for this assumption in rewriter.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
