### PR TITLE
Update ES and plugin version and fix broken test and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ After doing this, you need to restart the Elasticsearch server. Otherwise you ma
 The package uses the [Gradle](https://docs.gradle.org/4.10.2/userguide/userguide.html) build system.
 
 1. Checkout this package from version control.
-2. To build from command line set `JAVA_HOME` to point to a JDK >=11 
+2. To build from command line set `JAVA_HOME` to point to a JDK >=12
 3. Run `./gradlew build`
 
 You may note that some Maven configuration file is present in the source too. That is because we were using Maven and the migration to Gradle is still in progress.

--- a/build.gradle
+++ b/build.gradle
@@ -127,9 +127,9 @@ forbiddenPatterns {
 // TODO: fix license. skip dependency license checks
 dependencyLicenses.enabled = false
 
-// We don't need to following ES naming conventions.
-// see https://github.com/elastic/elasticsearch/blob/5ca6f312058ec8c7fbac072c4648246e7dfb4957/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/NamingConventionsTask.java
-// enable namingConvention check will cause errors like:  "Classes ending with [Tests] must subclass [LuceneTestCase]"
+// We don't need to following ES testing naming conventions.
+// see https://github.com/elastic/elasticsearch/blob/323f312bbc829a63056a79ebe45adced5099f6e6/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionsTasks.java
+// enable testingConventions check will cause errors like:  "Classes ending with [Tests] must subclass [LuceneTestCase]"
 testingConventions.enabled = false
 
 // TODO: need to verify the thirdPartyAudi

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ forbiddenPatterns {
 // TODO: fix license. skip dependency license checks
 dependencyLicenses.enabled = false
 
-// We don't need to following ES testing naming conventions.
+// We don't need to follow ES testing naming conventions.
 // see https://github.com/elastic/elasticsearch/blob/323f312bbc829a63056a79ebe45adced5099f6e6/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/TestingConventionsTasks.java
 // enable testingConventions check will cause errors like:  "Classes ending with [Tests] must subclass [LuceneTestCase]"
 testingConventions.enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 buildscript {
 
     ext {
-        es_version = System.getProperty("es.version", "6.6.2")
+        es_version = System.getProperty("es.version", "6.7.1")
     }
     // This isn't applying from repositories.gradle so repeating it here
     repositories {
@@ -46,7 +46,7 @@ repositories {
 }
 
 ext {
-    opendistroVersion = '0.8.0'
+    opendistroVersion = '0.9.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -130,7 +130,7 @@ dependencyLicenses.enabled = false
 // We don't need to following ES naming conventions.
 // see https://github.com/elastic/elasticsearch/blob/5ca6f312058ec8c7fbac072c4648246e7dfb4957/buildSrc/src/main/java/org/elasticsearch/gradle/precommit/NamingConventionsTask.java
 // enable namingConvention check will cause errors like:  "Classes ending with [Tests] must subclass [LuceneTestCase]"
-namingConventions.enabled = false
+testingConventions.enabled = false
 
 // TODO: need to verify the thirdPartyAudi
 // currently it complains missing classes like ibatis, mysql etc, should not be a problem

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazon.opendistroforelasticsearch</groupId>
     <artifactId>opendistro-sql</artifactId>
-    <version>6.6.2.0</version>
+    <version>6.7.1.0</version>
     <packaging>jar</packaging>
     <description>Open Distro for Elasticsearch SQL</description>
     <name>opendistro-sql</name>
@@ -27,7 +27,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <runSuite>**/MainTestSuite.class</runSuite>
         <elasticsearch.plugin.name>opendistro-sql</elasticsearch.plugin.name>
-        <elasticsearch.version>6.6.2</elasticsearch.version>
+        <elasticsearch.version>6.7.1</elasticsearch.version>
         <elasticsearch.plugin.classname>com.amazon.opendistroforelasticsearch.sql.plugin.SqlPlug</elasticsearch.plugin.classname>
     </properties>
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/PreparedStatementTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/PreparedStatementTest.java
@@ -118,7 +118,7 @@ public class PreparedStatementTest {
         }
 
         @Override
-        public BytesReference content() {
+        public BytesReference innerContent() {
             return new BytesArray(this.payload);
         }
     }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/29

*Description of changes:* Updated ES version to 6.7.1 as well as plugin version to 0.9. Fixed broken test and Gradle task. And also changed README accordingly since JDK 12 is required.

All unit tests and integration tests in Gradle and Maven passed. Deployed in ES 6.7.1 and did manual check on DbVisualizer for both updated JDBC driver and this backend.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
