### PR TITLE
Fix for PERCENTILES query result in csv output

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/maker/AggMaker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/maker/AggMaker.java
@@ -153,6 +153,8 @@ public class AggMaker {
                 BigDecimal percentile = (BigDecimal) kValue.value;
                 percentiles.add(percentile.doubleValue());
 
+            } else if (kValue.value instanceof Integer) {
+                percentiles.add(((Integer)kValue.value).doubleValue());
             }
         }
         if (percentiles.size() > 0) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/CsvFormatResponseIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/CsvFormatResponseIT.java
@@ -1,0 +1,72 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.esintgtest;
+
+import org.elasticsearch.client.Request;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Tests to cover requests with "?format=csv" parameter
+ */
+public class CsvFormatResponseIT extends SQLIntegTestCase {
+
+    @Override
+    protected void init() throws Exception {
+        loadIndex(Index.ACCOUNT);
+    }
+
+    @Override
+    protected Request getSqlRequest(String request, boolean explain) {
+
+        Request sqlRequest = super.getSqlRequest(request, explain);
+        sqlRequest.addParameter("format", "csv");
+        return sqlRequest;
+    }
+
+    @Test
+    public void allPercentilesByDefault() throws IOException  {
+
+        final String query = String.format(Locale.ROOT, "SELECT PERCENTILES(age) FROM %s", TEST_INDEX_ACCOUNT);
+        final String result = executeQueryWithStringOutput(query);
+
+        final String expectedHeaders = "PERCENTILES(age).1.0,PERCENTILES(age).5.0,PERCENTILES(age).25.0," +
+                "PERCENTILES(age).50.0,PERCENTILES(age).75.0,PERCENTILES(age).95.0,PERCENTILES(age).99.0";
+        Assert.assertThat(result, containsString(expectedHeaders));
+    }
+
+    @Test
+    public void specificPercentilesIntAndDouble() throws IOException  {
+
+        final String query = String.format(Locale.ROOT, "SELECT PERCENTILES(age,10,49.0) FROM %s",
+                TEST_INDEX_ACCOUNT);
+        final String result = executeQueryWithStringOutput(query);
+
+        final String[] unexpectedPercentiles = {"1.0", "5.0", "25.0", "50.0", "75.0", "95.0", "99.0"};
+        final String expectedHeaders = "PERCENTILES(age,10,49.0).10.0,PERCENTILES(age,10,49.0).49.0";
+        Assert.assertThat(result, containsString(expectedHeaders));
+        for (final String unexpectedPercentile : unexpectedPercentiles) {
+            Assert.assertThat(result, not(containsString("PERCENTILES(age,10,49.0)." + unexpectedPercentile)));
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
@@ -111,6 +111,12 @@ public abstract class SQLIntegTestCase extends ESIntegTestCase {
         return executeExplainRequest(requestBody);
     }
 
+    protected String executeQueryWithStringOutput(final String sqlQuery) throws IOException {
+
+        final String requestString = makeRequest(sqlQuery);
+        return executeRequest(requestString, false);
+    }
+
     protected JSONObject executeRequest(final String requestBody) throws IOException {
 
         return new JSONObject(executeRequest(requestBody, false));


### PR DESCRIPTION
*Issue #, if available:* NLPchina/elasticsearch-sql#734

*Description of changes:* If the query specified percentiles and the output was
requested in CSV format, the default set of percentiles was always
returned and the specified percentiles were ignored. This change fixes
that.

*How tested:* Tested manually on local cluster + added integ tests to cover this
use case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
