### PR TITLE
Adding an integ test to check unicode characters in GET request

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/AsyncRestExecutor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/AsyncRestExecutor.java
@@ -43,7 +43,7 @@ public class AsyncRestExecutor implements RestExecutor {
     /** Custom thread pool name managed by ES */
     public static final String SQL_WORKER_THREAD_POOL_NAME = "sql-worker";
 
-    private static final Logger LOG = LogManager.getLogger();
+    private static final Logger LOG = LogManager.getLogger(AsyncRestExecutor.class);
 
     /** Treat all actions as blocking which means async all actions, ex. execute() in csv executor or pretty format executor */
     private static final Predicate<QueryAction> ALL_ACTION_IS_BLOCKING = anyAction -> true;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/ElasticDefaultRestExecutor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/ElasticDefaultRestExecutor.java
@@ -51,7 +51,7 @@ public class ElasticDefaultRestExecutor implements RestExecutor {
     /** Request builder to generate ES DSL */
     private final SqlElasticRequestBuilder requestBuilder;
 
-    private static final Logger LOG = LogManager.getLogger();
+    private static final Logger LOG = LogManager.getLogger(ElasticDefaultRestExecutor.class);
 
     public ElasticDefaultRestExecutor(QueryAction queryAction) {
         // Put explain() here to make it run in NIO thread

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/GetEndpointQueryIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/GetEndpointQueryIT.java
@@ -1,0 +1,53 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.esintgtest;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests to cover requests with "?format=csv" parameter
+ */
+public class GetEndpointQueryIT extends SQLIntegTestCase {
+
+    @Override
+    protected void init() throws Exception {
+        loadIndex(Index.ACCOUNT);
+    }
+
+    @Test
+    public void unicodeTermInQuery() throws IOException  {
+
+        // NOTE: There are unicode characters in name, not just whitespace.
+        final String name = "盛虹";
+        final String query = String.format(Locale.ROOT, "SELECT id, firstname FROM %s " +
+                "WHERE firstname=matchQuery('%s') LIMIT 2", TEST_INDEX_ACCOUNT, name);
+
+        final JSONObject result = executeQueryWithGetRequest(query);
+        final JSONArray hits = getHits(result);
+        Assert.assertThat(hits.length(), equalTo(1));
+        Assert.assertThat(hits.query("/0/_id"), equalTo("919"));
+        Assert.assertThat(hits.query("/0/_source/firstname"), equalTo(name));
+    }
+}

--- a/src/test/resources/accounts.json
+++ b/src/test/resources/accounts.json
@@ -1965,7 +1965,7 @@
 {"index":{"_type": "account", "_id":"914"}}
 {"account_number":914,"balance":7120,"firstname":"Esther","lastname":"Bean","age":32,"gender":"F","address":"583 Macon Street","employer":"Applica","email":"estherbean@applica.com","city":"Homeworth","state":"MN"}
 {"index":{"_type": "account", "_id":"919"}}
-{"account_number":919,"balance":39655,"firstname":"Shauna","lastname":"Hanson","age":27,"gender":"M","address":"557 Hart Place","employer":"Exospace","email":"shaunahanson@exospace.com","city":"Outlook","state":"LA"}
+{"account_number":919,"balance":39655,"firstname":"盛虹","lastname":"Hanson","age":27,"gender":"M","address":"557 Hart Place","employer":"Exospace","email":"shaunahanson@exospace.com","city":"Outlook","state":"LA"}
 {"index":{"_type": "account", "_id":"921"}}
 {"account_number":921,"balance":49119,"firstname":"Barbara","lastname":"Wade","age":29,"gender":"M","address":"687 Hoyts Lane","employer":"Roughies","email":"barbarawade@roughies.com","city":"Sattley","state":"CO"}
 {"index":{"_type": "account", "_id":"926"}}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 
New integ test to execute sql query by calling the GET endpoint
as well as passing unicode characters (this is to verify we don't have
NLPchina/elasticsearch-sql#781 issue). + Minor update in loggin setup.

*How tested:* successful build with all tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
