### PR TITLE
Fixing failing integ tests for mvn build

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/NestedFieldQueryTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/NestedFieldQueryTest.java
@@ -15,8 +15,8 @@
 
 package com.amazon.opendistroforelasticsearch.sql.intgtest;
 
-import com.amazon.opendistroforelasticsearch.sql.plugin.SearchDao;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
+import com.amazon.opendistroforelasticsearch.sql.plugin.SearchDao;
 import com.amazon.opendistroforelasticsearch.sql.query.SqlElasticRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.SearchHit;
@@ -27,11 +27,15 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.Avg;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.metrics.ValueCount;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import java.sql.SQLFeatureNotSupportedException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -118,6 +122,16 @@ public class NestedFieldQueryTest {
                         hit(
                             author("i"),
                             info("a")
+                        )
+                    )
+                ),
+                hit(
+                    myNum(new int[]{3, 4}),
+                    someField("a"),
+                    innerHits("message",
+                        hit(
+                            author("zz"),
+                            info("zz")
                         )
                     )
                 )
@@ -273,8 +287,8 @@ public class NestedFieldQueryTest {
         assertThat(
             getAgg(resp, "someField"),
             buckets(
-                bucket("a", sum("message.dayOfWeek", "sumDay", isCloseTo(3))),
-                bucket("b", sum("message.dayOfWeek", "sumDay", isCloseTo(10)))
+                bucket("a", sum("message.dayOfWeek", "sumDay", isCloseTo(9.0))),
+                bucket("b", sum("message.dayOfWeek", "sumDay", isCloseTo(10.0)))
             )
         );
     }
@@ -339,6 +353,40 @@ public class NestedFieldQueryTest {
 
     private Matcher<SearchHit> myNum(int value) {
         return kv("myNum", is(value));
+    }
+
+    private Matcher<SearchHit> myNum(int[] values) {
+
+        return new BaseMatcher<SearchHit>() {
+
+            @Override
+            public boolean matches(Object item) {
+
+                if (item instanceof SearchHit) {
+                    final SearchHit hit = (SearchHit)item;
+                    List<Integer> actualValues = (ArrayList<Integer>)hit.getSourceAsMap().get("myNum");
+
+                    if (actualValues.size() != values.length) {
+                        return false;
+                    }
+
+                    for (int value : values) {
+                        if (!actualValues.contains(value)) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+
+                return false;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+
+            }
+        };
     }
 
     private Matcher<SearchHit> someField(String value) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/NestedFieldQueryTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/NestedFieldQueryTest.java
@@ -363,19 +363,17 @@ public class NestedFieldQueryTest {
             public boolean matches(Object item) {
 
                 if (item instanceof SearchHit) {
-                    final SearchHit hit = (SearchHit)item;
-                    List<Integer> actualValues = (ArrayList<Integer>)hit.getSourceAsMap().get("myNum");
+                    final SearchHit hit = (SearchHit) item;
+                    List<Integer> actualValues = (ArrayList<Integer>) hit.getSourceAsMap().get("myNum");
 
                     if (actualValues.size() != values.length) {
                         return false;
                     }
-
                     for (int value : values) {
                         if (!actualValues.contains(value)) {
                             return false;
                         }
                     }
-
                     return true;
                 }
 
@@ -384,7 +382,6 @@ public class NestedFieldQueryTest {
 
             @Override
             public void describeTo(Description description) {
-
             }
         };
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/NestedFieldQueryTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/NestedFieldQueryTest.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Function;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -364,13 +363,13 @@ public class NestedFieldQueryTest {
 
                 if (item instanceof SearchHit) {
                     final SearchHit hit = (SearchHit) item;
-                    List<Integer> actualValues = (ArrayList<Integer>) hit.getSourceAsMap().get("myNum");
+                    ArrayList<Integer> actualValues = (ArrayList<Integer>) hit.getSourceAsMap().get("myNum");
 
                     if (actualValues.size() != values.length) {
                         return false;
                     }
-                    for (int value : values) {
-                        if (!actualValues.contains(value)) {
+                    for (int i = 0; i < values.length; ++i) {
+                        if (values[i] != actualValues.get(i)) {
                             return false;
                         }
                     }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* After introducing new data in test indexes (see #42 ), some of the integ tests were broken. This change fixes those.

We didn't notice this, since we rely on gradle build mostly, which does not run the mvn integ tests. Once #20 is fixed all the remaining mvn tests can be migrated to the new ESIntegTest subclasses and we can deprecate mvn. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
