### PR TITLE
[#44] Fixing the order of fields in csv output

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/AggregationQueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/AggregationQueryAction.java
@@ -350,7 +350,7 @@ public class AggregationQueryAction extends QueryAction {
                 if (field.getName().equals("script")) {
                     request.addStoredField(field.getAlias());
                     DefaultQueryAction defaultQueryAction = new DefaultQueryAction(client, select);
-                    defaultQueryAction.intialize(request);
+                    defaultQueryAction.initialize(request);
                     List<Field> tempFields = Lists.newArrayList(field);
                     defaultQueryAction.setFields(tempFields);
                     continue;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/QueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/QueryAction.java
@@ -35,7 +35,9 @@ import com.amazon.opendistroforelasticsearch.sql.domain.QueryStatement;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Abstract class. used to transform Select object (Represents SQL query) to
@@ -59,6 +61,12 @@ public abstract class QueryAction {
     public void setSqlRequest(SqlRequest sqlRequest) { this.sqlRequest = sqlRequest; }
 
     public SqlRequest getSqlRequest() { return sqlRequest; }
+
+    /**
+     *
+     * @return List of field names produced by the query
+     */
+    public Optional<List<String>> getFieldNames() { return Optional.empty(); }
 
     protected void updateRequestWithCollapse(Select select, SearchRequestBuilder request) throws SqlParseException {
         JsonFactory jsonFactory = new JsonFactory();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -459,6 +460,40 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
         List<String> fields = Arrays.asList("b1.age");
         assertContainsColumns(getSchema(response), fields);
         assertContainsData(getDataRows(response), fields);
+    }
+
+    @Test
+    public void fieldOrder() throws IOException {
+
+        final String[] expectedFields = {"age", "firstname", "address", "gender", "email"};
+        final Object[] expectedValues = {32, "Amber", "880 Holmes Lane", "M", "amberduke@pyrami.com"};
+
+        testFieldOrder(expectedFields, expectedValues);
+    }
+
+    @Test
+    public void fieldOrderOther() throws IOException {
+
+        final String[] expectedFields = {"email", "firstname", "age", "gender", "address"};
+        final Object[] expectedValues = {"amberduke@pyrami.com", "Amber", 32, "M", "880 Holmes Lane"};
+
+        testFieldOrder(expectedFields, expectedValues);
+    }
+
+    private void testFieldOrder(final String[] expectedFields, final Object[] expectedValues) throws IOException {
+
+        final String fields = String.join(", ", expectedFields);
+        final String query = String.format(Locale.ROOT, "SELECT %s FROM %s " +
+                "WHERE email='amberduke@pyrami.com'", fields, TestsConstants.TEST_INDEX_ACCOUNT);
+        final JSONObject result = executeQuery(query);
+
+        for (int i = 0; i < expectedFields.length; ++i) {
+
+            final String fieldName = (String)result.query(String.format(Locale.ROOT, "/schema/%d/name", i));
+            assertThat(fieldName, equalTo(expectedFields[i]));
+            final Object fieldValue = result.query(String.format(Locale.ROOT, "/datarows/0/%d", i));
+            assertThat(fieldValue, equalTo(expectedValues[i]));
+        }
     }
 
     private JSONArray getSchema(JSONObject jdbcResponse) { return jdbcResponse.getJSONArray("schema"); }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/CSVResultsExtractorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/CSVResultsExtractorTests.java
@@ -477,8 +477,10 @@ public class CSVResultsExtractorTests {
     private CSVResult getCsvResult(boolean flat, String query,boolean includeScore , boolean includeType,boolean includeId,String seperator) throws Exception {
         SearchDao searchDao = MainTestSuite.getSearchDao();
         QueryAction queryAction = searchDao.explain(query);
-        Object execution =  QueryActionElasticExecutor.executeAnyAction(searchDao.getClient(), queryAction);
-        return new CSVResultsExtractor(includeScore,includeType, includeId).extractResults(execution, flat, seperator);
+        Object execution = QueryActionElasticExecutor.executeAnyAction(searchDao.getClient(), queryAction);
+        final List<String> fieldNames = queryAction.getFieldNames().orElse(null);
+        return new CSVResultsExtractor(includeScore,includeType, includeId)
+                .extractResults(execution, flat, seperator, fieldNames);
     }
 
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/SQLFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/intgtest/SQLFunctionsTest.java
@@ -293,7 +293,9 @@ public class SQLFunctionsTest {
         SearchDao searchDao = MainTestSuite.getSearchDao() != null ? MainTestSuite.getSearchDao() : getSearchDao();
         QueryAction queryAction = searchDao.explain(query);
         Object execution = QueryActionElasticExecutor.executeAnyAction(searchDao.getClient(), queryAction);
-        return new CSVResultsExtractor(includeScore, includeType, includeId).extractResults(execution, flat, ",");
+        final List<String> fieldNames = queryAction.getFieldNames().orElse(null);
+        return new CSVResultsExtractor(includeScore, includeType, includeId)
+                .extractResults(execution, flat, ",", fieldNames);
     }
 
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/NestedFieldProjectionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/NestedFieldProjectionTest.java
@@ -328,7 +328,7 @@ public class NestedFieldProjectionTest {
             Select select = new SqlParser().parseSelect(expr);
 
             DefaultQueryAction action = new DefaultQueryAction(mockClient, select);
-            action.intialize(request);
+            action.initialize(request);
             action.setFields(select.getFields());
 
             if (select.getWhere() != null) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/query/DefaultQueryActionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/query/DefaultQueryActionTest.java
@@ -1,0 +1,144 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.query;
+
+import com.amazon.opendistroforelasticsearch.sql.domain.Field;
+import com.amazon.opendistroforelasticsearch.sql.domain.KVValue;
+import com.amazon.opendistroforelasticsearch.sql.domain.MethodField;
+import com.amazon.opendistroforelasticsearch.sql.domain.Select;
+import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
+import com.amazon.opendistroforelasticsearch.sql.query.DefaultQueryAction;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.script.Script;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class DefaultQueryActionTest {
+
+    private DefaultQueryAction queryAction;
+
+    private Client mockClient;
+
+    private Select mockSelect;
+
+    private SearchRequestBuilder mockRequestBuilder;
+
+    @Before
+    public void initDefaultQueryAction() {
+
+        mockClient = mock(Client.class);
+        mockSelect = mock(Select.class);
+        mockRequestBuilder = mock(SearchRequestBuilder.class);
+
+        List<Field> fields = new LinkedList<>();
+        fields.add(new Field("balance", "bbb"));
+
+        doReturn(fields).when(mockSelect).getFields();
+        doReturn(null).when(mockRequestBuilder).setFetchSource(any(String[].class), any(String[].class));
+        doReturn(null).when(mockRequestBuilder).addScriptField(anyString(), any(Script.class));
+
+        queryAction = new DefaultQueryAction(mockClient, mockSelect);
+        queryAction.initialize(mockRequestBuilder);
+    }
+
+    @Test
+    public void scriptFieldWithTwoParams() throws SqlParseException {
+
+        List<Field> fields = new LinkedList<>();
+        fields.add(createScriptField("script1", "doc['balance'] * 2",
+                false, true, false));
+
+        queryAction.setFields(fields);
+
+        final Optional<List<String>> fieldNames = queryAction.getFieldNames();
+        Assert.assertTrue("Field names have not been set", fieldNames.isPresent());
+        Assert.assertThat(fieldNames.get().size(), equalTo(1));
+        Assert.assertThat(fieldNames.get().get(0), equalTo("script1"));
+
+        Mockito.verify(mockRequestBuilder).addScriptField(eq("script1"), any(Script.class));
+    }
+
+    @Test
+    public void scriptFieldWithThreeParams() throws SqlParseException {
+
+        List<Field> fields = new LinkedList<>();
+        fields.add(createScriptField("script1", "doc['balance'] * 2",
+                true, true, false));
+
+        queryAction.setFields(fields);
+
+        final Optional<List<String>> fieldNames = queryAction.getFieldNames();
+        Assert.assertTrue("Field names have not been set", fieldNames.isPresent());
+        Assert.assertThat(fieldNames.get().size(), equalTo(1));
+        Assert.assertThat(fieldNames.get().get(0), equalTo("script1"));
+
+        Mockito.verify(mockRequestBuilder).addScriptField(eq("script1"), any(Script.class));
+    }
+
+    @Test(expected = SqlParseException.class)
+    public void scriptFieldWithLessThanTwoParams() throws SqlParseException {
+
+        List<Field> fields = new LinkedList<>();
+        fields.add(createScriptField("script1", "doc['balance'] * 2",
+                false, false, false));
+
+        queryAction.setFields(fields);
+    }
+
+    @Test
+    public void scriptFieldWithMoreThanThreeParams() throws SqlParseException {
+
+        List<Field> fields = new LinkedList<>();
+        fields.add(createScriptField("script1", "doc['balance'] * 2",
+                false, true, true));
+
+        queryAction.setFields(fields);
+    }
+
+    private Field createScriptField(final String name, final String script, final boolean addScriptLanguage,
+                                    final boolean addScriptParam, final boolean addRedundantParam) {
+
+        final List<KVValue> params = new ArrayList<>();
+
+        params.add(new KVValue("alias", name));
+        if (addScriptLanguage) {
+            params.add(new KVValue("painless"));
+        }
+        if (addScriptParam) {
+            params.add(new KVValue(script));
+        }
+        if (addRedundantParam) {
+            params.add(new KVValue("Fail the test"));
+        }
+
+        return new MethodField("script", params, null, null);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #44 

*Description of changes:* The order of fields in the query was not considered
when returning the results in csv format. This change fixes that problem.

*How tested:* tested manually on a local cluster, plus added unit/integ
tests to cover the use case + added code Build with all tests succeeds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
