### PR TITLE
Fixing unicode character handling in tests

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
@@ -163,7 +163,7 @@ public abstract class SQLIntegTestCase extends ESIntegTestCase {
         final StringBuilder sb = new StringBuilder();
 
         try (final InputStream is = response.getEntity().getContent();
-             final BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
+             final BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
 
             String line;
             while ((line = br.readLine()) != null) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -28,7 +28,11 @@ import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 public class TestUtils {
 
@@ -298,10 +302,14 @@ public class TestUtils {
         String absJsonPath = getResourceFilePath(jsonPath);
 
         BulkRequest bulkRequest = new BulkRequest();
-        try (BufferedReader br = new BufferedReader(new FileReader(absJsonPath))) {
+        try (final InputStream stream =  new FileInputStream(absJsonPath);
+             final Reader streamReader = new InputStreamReader(stream, StandardCharsets.UTF_8);
+             final BufferedReader br = new BufferedReader(streamReader)) {
+
             while (true) {
+
                 String actionLine = br.readLine();
-                if (actionLine == null || actionLine.trim().length() == 0) {
+                if (actionLine == null || actionLine.trim().isEmpty()) {
                     break;
                 }
                 String sourceLine = br.readLine();


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The GetEndpointQueryIT::unicodeTermInQuery test was failing on windows machine, because the value retrieved from a search query and the value stored during indexing were different. This change enforces treating all values as UTF_8 encoded, to avoid dependence on environment.

*How Tested:* ran the tests on linux and windows, as well as manually tested the query on local cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
