### PR TITLE
Detaching request id from SqlRequest

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/AsyncRestExecutor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/AsyncRestExecutor.java
@@ -21,6 +21,7 @@ import com.amazon.opendistroforelasticsearch.sql.metrics.MetricName;
 import com.amazon.opendistroforelasticsearch.sql.metrics.Metrics;
 import com.amazon.opendistroforelasticsearch.sql.query.QueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.join.BackOffRetryStrategy;
+import com.amazon.opendistroforelasticsearch.sql.utils.LogUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Client;
@@ -72,14 +73,14 @@ public class AsyncRestExecutor implements RestExecutor {
         if (isBlockingAction(queryAction) && isRunningInTransportThread()) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("[{}] Async blocking query action [{}] for executor [{}] in current thread [{}]",
-                    requestId(queryAction), name(executor), name(queryAction), Thread.currentThread().getName());
+                    LogUtils.getRequestId(), name(executor), name(queryAction), Thread.currentThread().getName());
             }
             async(client, params, queryAction, channel);
         }
         else {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("[{}] Continue running query action [{}] for executor [{}] in current thread [{}]",
-                    requestId(queryAction), name(executor), name(queryAction), Thread.currentThread().getName());
+                    LogUtils.getRequestId(), name(executor), name(queryAction), Thread.currentThread().getName());
             }
             doExecuteWithTimeMeasured(client, params, queryAction, channel);
         }
@@ -105,18 +106,19 @@ public class AsyncRestExecutor implements RestExecutor {
         ThreadPool threadPool = client.threadPool();
         Runnable runnable = () -> {
             try {
+                LOG.info("[{}] starting processing of request blablabla", LogUtils.getRequestId());
                 doExecuteWithTimeMeasured(client, params, queryAction, channel);
             } catch (IOException | SqlParseException e) {
                 Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_SYS).increment();
-                LOG.warn("[{}] [MCB] async task got an IO/SQL exception: {}", requestId(queryAction), e.getMessage());
+                LOG.warn("[{}] [MCB] async task got an IO/SQL exception: {}", LogUtils.getRequestId(), e.getMessage());
                 channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, e.getMessage()));
             } catch (IllegalStateException e) {
                 Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_SYS).increment();
-                LOG.warn("[{}] [MCB] async task got a runtime exception: {}", requestId(queryAction), e.getMessage());
+                LOG.warn("[{}] [MCB] async task got a runtime exception: {}", LogUtils.getRequestId(), e.getMessage());
                 channel.sendResponse(new BytesRestResponse(RestStatus.INSUFFICIENT_STORAGE, "Memory circuit is broken."));
             } catch (Throwable t) {
                 Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_SYS).increment();
-                LOG.warn("[{}] [MCB] async task got an unknown throwable: {}", requestId(queryAction), t.getMessage());
+                LOG.warn("[{}] [MCB] async task got an unknown throwable: {}", LogUtils.getRequestId(), t.getMessage());
                 channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, String.valueOf(t.getMessage())));
             } finally {
                 BackOffRetryStrategy.releaseMem(executor);
@@ -125,7 +127,7 @@ public class AsyncRestExecutor implements RestExecutor {
 
         // Preserve context of calling thread to ensure headers of requests are forwarded when running blocking actions
         threadPool.schedule(
-            threadPool.preserveContext(runnable),
+            threadPool.preserveContext(LogUtils.withCurrentContext(runnable)),
             new TimeValue(0L),
             SQL_WORKER_THREAD_POOL_NAME
         );
@@ -144,17 +146,12 @@ public class AsyncRestExecutor implements RestExecutor {
             Duration elapsed = Duration.ofNanos(System.nanoTime() - startTime);
             int slowLogThreshold = LocalClusterState.state().getSettingValue(QUERY_SLOWLOG);
             if (elapsed.getSeconds() >= slowLogThreshold) {
-                LOG.warn("[{}] Slow query: elapsed={} (ms)", requestId(action), elapsed.toMillis());
+                LOG.warn("[{}] Slow query: elapsed={} (ms)", LogUtils.getRequestId(), elapsed.toMillis());
             }
         }
-    }
-
-    private String requestId(QueryAction action) {
-        return action.getSqlRequest().getId();
     }
 
     private String name(Object object) {
         return object.getClass().getSimpleName();
     }
-
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlStatsAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlStatsAction.java
@@ -17,6 +17,7 @@ package com.amazon.opendistroforelasticsearch.sql.plugin;
 
 import com.amazon.opendistroforelasticsearch.sql.executor.format.ErrorMessage;
 import com.amazon.opendistroforelasticsearch.sql.metrics.Metrics;
+import com.amazon.opendistroforelasticsearch.sql.utils.LogUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.node.NodeClient;
@@ -56,6 +57,9 @@ public class RestSqlStatsAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+
+        LogUtils.addRequestId();
+
         try {
             return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.OK, Metrics.getInstance().collectToJSON()));
         } catch (Exception e) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/request/SqlRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/request/SqlRequest.java
@@ -33,23 +33,16 @@ import java.util.UUID;
 
 public class SqlRequest {
 
-    public static final SqlRequest NULL = new SqlRequest("Unassigned", "", null);
-
-    /** Unique request ID for tracking */
-    private final String id;
+    public static final SqlRequest NULL = new SqlRequest("", null);
 
     String sql;
     JSONObject jsonContent;
 
 
-    public SqlRequest(String id, String sql, JSONObject jsonContent) {
-        this.id = id;
+    public SqlRequest(final String sql, final JSONObject jsonContent) {
+
         this.sql = sql;
         this.jsonContent = jsonContent;
-    }
-
-    public SqlRequest(String sql, JSONObject jsonContent) {
-        this(UUID.randomUUID().toString(), sql, jsonContent);
     }
 
     private static boolean isValidJson(String json) {
@@ -65,8 +58,6 @@ public class SqlRequest {
     public JSONObject getJsonContent() {
         return this.jsonContent;
     }
-
-    public String getId() { return id; }
 
     /**
      * JSONObject's getJSONObject method will return just the value, this helper method is to extract the key and

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/LogUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/LogUtils.java
@@ -32,12 +32,16 @@ public class LogUtils {
 
     /**
      * Generates a random UUID and adds to the {@link ThreadContext} as the request id.
+     * <p>
+     * Note: If a request id already present, this method will overwrite it with a new
+     * one. This is to pre-vent re-using the same request id for different requests in
+     * case the same thread handles both of them. But this also means one should not
+     * call this method twice on the same thread within the lifetime of the request.
+     * </p>
      */
     public static void addRequestId() {
 
-        if (ThreadContext.get(REQUEST_ID_KEY) == null) {
-            ThreadContext.put(REQUEST_ID_KEY, UUID.randomUUID().toString());
-        }
+        ThreadContext.put(REQUEST_ID_KEY, UUID.randomUUID().toString());
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/LogUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/LogUtils.java
@@ -28,7 +28,7 @@ public class LogUtils {
     /**
      * The key of the request id in the context map
      */
-    public static final String REQUEST_ID_KEY = "request_id";
+    private static final String REQUEST_ID_KEY = "request_id";
 
     /**
      * Generates a random UUID and adds to the {@link ThreadContext} as the request id.

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/LogUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/LogUtils.java
@@ -1,0 +1,77 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.utils;
+
+import org.apache.logging.log4j.ThreadContext;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Utility class for generating/accessing the request id from logging context.
+ */
+public class LogUtils {
+
+    /**
+     * The key of the request id in the context map
+     */
+    public static final String REQUEST_ID_KEY = "request_id";
+
+    /**
+     * Generates a random UUID and adds to the {@link ThreadContext} as the request id.
+     */
+    public static void addRequestId() {
+
+        if (ThreadContext.get(REQUEST_ID_KEY) == null) {
+            ThreadContext.put(REQUEST_ID_KEY, UUID.randomUUID().toString());
+        }
+    }
+
+    /**
+     * @return the current request id from {@link ThreadContext}
+     */
+    public static String getRequestId() {
+
+        final String requestId = ThreadContext.get(REQUEST_ID_KEY);
+        if (requestId == null) {
+            throw new IllegalStateException("Request id not present in current context");
+        }
+
+        return requestId;
+    }
+
+    /**
+     * Wraps a given instance of {@link Runnable} into a new one which gets all the
+     * entries from current ThreadContext map.
+     *
+     * @param task
+     *          the instance of Runnable to wrap
+     * @return the new task
+     */
+    public static Runnable withCurrentContext(final Runnable task) {
+
+        final Map<String, String> currentContext = ThreadContext.getImmutableContext();
+        return () -> {
+            ThreadContext.putAll(currentContext);
+            task.run();
+        };
+    }
+
+    private LogUtils() {
+
+        throw new AssertionError(getClass().getCanonicalName() + " is a utility class and must not be initialized");
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/LogUtilsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/LogUtilsTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -53,7 +54,7 @@ public class LogUtilsTest {
         final String requestId = ThreadContext.get(REQUEST_ID_KEY);
         LogUtils.addRequestId();
         final String requestId2 = ThreadContext.get(REQUEST_ID_KEY);
-        Assert.assertThat(requestId2, equalTo(requestId));
+        Assert.assertThat(requestId2, not(equalTo(requestId)));
     }
 
     @Test(expected = IllegalStateException.class)

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/LogUtilsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/LogUtilsTest.java
@@ -1,0 +1,83 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.utils;
+
+import com.amazon.opendistroforelasticsearch.sql.utils.LogUtils;
+import org.apache.logging.log4j.ThreadContext;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class LogUtilsTest {
+
+    @After
+    public void cleanUpContext() {
+
+        ThreadContext.clearMap();
+    }
+
+    @Test
+    public void addRequestId() {
+
+        Assert.assertNull(ThreadContext.get(LogUtils.REQUEST_ID_KEY));
+        LogUtils.addRequestId();
+        final String requestId = ThreadContext.get(LogUtils.REQUEST_ID_KEY);
+        Assert.assertNotNull(requestId);
+    }
+
+    @Test
+    public void addRequestId_alreadyExists() {
+
+        LogUtils.addRequestId();
+        final String requestId = ThreadContext.get(LogUtils.REQUEST_ID_KEY);
+        LogUtils.addRequestId();
+        final String requestId2 = ThreadContext.get(LogUtils.REQUEST_ID_KEY);
+        Assert.assertThat(requestId2, equalTo(requestId));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void getRequestId_doesNotExist() {
+
+        LogUtils.getRequestId();
+    }
+
+    @Test
+    public void getRequestId() {
+
+        final String test_request_id = "test_id_111";
+        ThreadContext.put(LogUtils.REQUEST_ID_KEY, test_request_id);
+        final String requestId = LogUtils.getRequestId();
+        Assert.assertThat(requestId, equalTo(test_request_id));
+    }
+
+    @Test
+    public void withCurrentContext() throws InterruptedException {
+
+        Runnable task = () -> {
+            Assert.assertTrue(ThreadContext.containsKey("test11"));
+            Assert.assertTrue(ThreadContext.containsKey("test22"));
+        };
+        ThreadContext.put("test11", "value11");
+        ThreadContext.put("test22", "value11");
+        new Thread(LogUtils.withCurrentContext(task)).join();
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/LogUtilsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/LogUtilsTest.java
@@ -29,6 +29,8 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class LogUtilsTest {
 
+    private static final String REQUEST_ID_KEY = "request_id";
+
     @After
     public void cleanUpContext() {
 
@@ -38,9 +40,9 @@ public class LogUtilsTest {
     @Test
     public void addRequestId() {
 
-        Assert.assertNull(ThreadContext.get(LogUtils.REQUEST_ID_KEY));
+        Assert.assertNull(ThreadContext.get(REQUEST_ID_KEY));
         LogUtils.addRequestId();
-        final String requestId = ThreadContext.get(LogUtils.REQUEST_ID_KEY);
+        final String requestId = ThreadContext.get(REQUEST_ID_KEY);
         Assert.assertNotNull(requestId);
     }
 
@@ -48,9 +50,9 @@ public class LogUtilsTest {
     public void addRequestId_alreadyExists() {
 
         LogUtils.addRequestId();
-        final String requestId = ThreadContext.get(LogUtils.REQUEST_ID_KEY);
+        final String requestId = ThreadContext.get(REQUEST_ID_KEY);
         LogUtils.addRequestId();
-        final String requestId2 = ThreadContext.get(LogUtils.REQUEST_ID_KEY);
+        final String requestId2 = ThreadContext.get(REQUEST_ID_KEY);
         Assert.assertThat(requestId2, equalTo(requestId));
     }
 
@@ -64,7 +66,7 @@ public class LogUtilsTest {
     public void getRequestId() {
 
         final String test_request_id = "test_id_111";
-        ThreadContext.put(LogUtils.REQUEST_ID_KEY, test_request_id);
+        ThreadContext.put(REQUEST_ID_KEY, test_request_id);
         final String requestId = LogUtils.getRequestId();
         Assert.assertThat(requestId, equalTo(test_request_id));
     }


### PR DESCRIPTION
*Issue #, if available:* #34 

*Description of changes:* Removed `id` field from `SqlRequest` class. Using logging library's ThreadContext to store the request id as soon as we get it, and passing it around to make it available in case new threads are started from the main one. Provided a utility class to make the access to the ThreadContext simpler.

The current layout pattern of elasticsearch log messages is `[%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n`, if we pre-pend `[%X{request_id}]` all the messages will automatically be pre-pended with the request id. However, the plugin code does not manage the log configuration, and I didn't want to modify it at run-time.

*How tested:* Made some requests on local cluster, made sure request id is getting properly populated. Tested for tasks running on worker threads as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
