### PR TITLE
Moving subquery execution to a worker thread

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/request/SqlRequestFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/request/SqlRequestFactory.java
@@ -22,6 +22,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class SqlRequestFactory {
 
@@ -32,29 +33,31 @@ public class SqlRequestFactory {
     private static final String PARAM_TYPE_FIELD_NAME = "type";
     private static final String PARAM_VALUE_FIELD_NAME = "value";
 
-    public static SqlRequest getSqlRequest(RestRequest request) {
+    public static SqlRequest getSqlRequest(final RestRequest request) {
         switch (request.method()) {
             case GET:
                 return parseSqlRequestFromUrl(request);
             case POST:
                 return parseSqlRequestFromPayload(request);
             default:
-                throw new IllegalArgumentException("ES SQL doesn't supported HTTP " + request.method().name());
+                throw new IllegalArgumentException(String.format(Locale.ROOT, "ES SQL does not support HTTP %s method",
+                        request.method().name()));
         }
     }
 
-    private static SqlRequest parseSqlRequestFromUrl(RestRequest restRequest) {
-        String sql;
+    private static SqlRequest parseSqlRequestFromUrl(final RestRequest restRequest) {
 
-        sql = restRequest.param(SQL_URL_PARAM_KEY);
-        if(sql == null) {
+        final String sql = restRequest.param(SQL_URL_PARAM_KEY);
+
+        if (sql == null) {
             throw new IllegalArgumentException("Cannot find sql parameter from the URL");
         }
         return new SqlRequest(sql, null);
     }
 
-    private static SqlRequest parseSqlRequestFromPayload(RestRequest restRequest) {
-        String content = restRequest.content().utf8ToString();
+    private static SqlRequest parseSqlRequestFromPayload(final RestRequest restRequest) {
+
+        final String content = restRequest.content().utf8ToString();
 
         JSONObject jsonContent;
         try {
@@ -62,65 +65,80 @@ public class SqlRequestFactory {
         } catch (JSONException e) {
             throw new IllegalArgumentException("Failed to parse request payload", e);
         }
-        String sql = jsonContent.getString(SQL_FIELD_NAME);
-        if(jsonContent.has(PARAM_FIELD_NAME)) { // is a PreparedStatement
+
+        final String sql = jsonContent.getString(SQL_FIELD_NAME);
+        if (jsonContent.has(PARAM_FIELD_NAME)) { // is a PreparedStatement
             JSONArray paramArray = jsonContent.getJSONArray(PARAM_FIELD_NAME);
             List<PreparedStatementRequest.PreparedStatementParameter> parameters = parseParameters(paramArray);
             return new PreparedStatementRequest(sql, jsonContent, parameters);
         }
+
         return new SqlRequest(sql, jsonContent);
     }
 
-    private static List<PreparedStatementRequest.PreparedStatementParameter> parseParameters(JSONArray paramsJsonArray) {
+    private static List<PreparedStatementRequest.PreparedStatementParameter> parseParameters(
+            final JSONArray paramsJsonArray) {
+
         List<PreparedStatementRequest.PreparedStatementParameter> parameters = new ArrayList<>();
-        for (int i = 0; i<paramsJsonArray.length(); i++) {
-            JSONObject paramJson = paramsJsonArray.getJSONObject(i);
-            String typeString = paramJson.getString(PARAM_TYPE_FIELD_NAME);
+        for (int i = 0; i < paramsJsonArray.length(); i++) {
+
+            final JSONObject paramJson = paramsJsonArray.getJSONObject(i);
+            final String typeString = paramJson.getString(PARAM_TYPE_FIELD_NAME);
             if (typeString == null) {
-                throw new IllegalArgumentException("Parameter type cannot be null. parameter json: " + paramJson.toString());
+                throw new IllegalArgumentException("Parameter type cannot be null. parameter json: " +
+                        paramJson.toString());
             }
-            PreparedStatementRequest.ParameterType type;
+
+            final PreparedStatementRequest.ParameterType type;
             try {
                 type = PreparedStatementRequest.ParameterType.valueOf(typeString.toUpperCase());
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Unsupported parameter type " + typeString, e);
             }
-            try {
-                PreparedStatementRequest.PreparedStatementParameter parameter;
-                switch (type) {
-                    case BOOLEAN:
-                        parameter = new PreparedStatementRequest.PreparedStatementParameter<>(paramJson.getBoolean(PARAM_VALUE_FIELD_NAME));
-                        parameters.add(parameter);
-                        break;
-                    case KEYWORD:
-                    case STRING:
-                    case DATE:
-                        parameter = new PreparedStatementRequest.StringParameter(paramJson.getString(PARAM_VALUE_FIELD_NAME));
-                        parameters.add(parameter);
-                        break;
-                    case BYTE:
-                    case SHORT:
-                    case INTEGER:
-                    case LONG:
-                        parameter = new PreparedStatementRequest.PreparedStatementParameter<>(paramJson.getLong(PARAM_VALUE_FIELD_NAME));
-                        parameters.add(parameter);
-                        break;
-                    case FLOAT:
-                    case DOUBLE:
-                        parameter = new PreparedStatementRequest.PreparedStatementParameter<>(paramJson.getDouble(PARAM_VALUE_FIELD_NAME));
-                        parameters.add(parameter);
-                        break;
-                    case NULL:
-                        parameter = new PreparedStatementRequest.NullParameter();
-                        parameters.add(parameter);
-                        break;
-                    default:
-                        throw new IllegalArgumentException("Failed to handle parameter type " + type.name());
-                }
-            } catch(JSONException e) {
-                throw new IllegalArgumentException("Failed to parse PreparedStatement parameters", e);
-            }
+
+            parameters.add(buildPreparedStatementParameterFromJson(paramJson, type));
         }
         return parameters;
+    }
+
+    private static PreparedStatementRequest.PreparedStatementParameter buildPreparedStatementParameterFromJson(
+            final JSONObject paramJson, final PreparedStatementRequest.ParameterType parameterType) {
+
+        final PreparedStatementRequest.PreparedStatementParameter parameter;
+        try {
+            switch (parameterType) {
+                case BOOLEAN:
+                    parameter = new PreparedStatementRequest.PreparedStatementParameter<>(
+                            paramJson.getBoolean(PARAM_VALUE_FIELD_NAME));
+                    break;
+                case KEYWORD:
+                case STRING:
+                case DATE:
+                    parameter = new PreparedStatementRequest.StringParameter(
+                            paramJson.getString(PARAM_VALUE_FIELD_NAME));
+                    break;
+                case BYTE:
+                case SHORT:
+                case INTEGER:
+                case LONG:
+                    parameter = new PreparedStatementRequest.PreparedStatementParameter<>(
+                            paramJson.getLong(PARAM_VALUE_FIELD_NAME));
+                    break;
+                case FLOAT:
+                case DOUBLE:
+                    parameter = new PreparedStatementRequest.PreparedStatementParameter<>(
+                            paramJson.getDouble(PARAM_VALUE_FIELD_NAME));
+                    break;
+                case NULL:
+                    parameter = new PreparedStatementRequest.NullParameter();
+                    break;
+                default:
+                    throw new IllegalArgumentException("Failed to handle parameter type " + parameterType.name());
+            }
+        } catch (final JSONException e) {
+            throw new IllegalArgumentException("Failed to parse PreparedStatement parameters", e);
+        }
+
+        return parameter;
     }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Run queries including a subquery on a worker thread. This change does not affect the execution of other types of queries. This is just a first step to unblock the queries with `WHERE field IN (subquery)` syntax, but still needs improvement including but not limited to the following:
 1. the condition of whether the query has a subquery should ideally be derived from the Sql parser, not by string manipulation,
 1. the explain call should not execute the subquery, but should just explain how it will be executed.

*How tested:* All integ tests pass, manually tested on queries that failed previously (with jvm assertions enabled) and they pass with this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
