### PR TITLE
Empty line or query without spaces now throws error with more informative message

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
@@ -60,7 +60,9 @@ public class ESActionFactory {
      * @return Query object.
      */
     public static QueryAction create(Client client, String sql) throws SqlParseException, SQLFeatureNotSupportedException {
-        sql = sql.replaceAll(System.lineSeparator()," ").trim();
+
+        // Linebreak matcher
+        sql = sql.replaceAll("\\R"," ").trim();
 
         switch (getFirstWord(sql)) {
             case "SELECT":

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
@@ -60,9 +60,9 @@ public class ESActionFactory {
      * @return Query object.
      */
     public static QueryAction create(Client client, String sql) throws SqlParseException, SQLFeatureNotSupportedException {
-        sql = sql.replaceAll("\n"," ");
-        String firstWord = sql.substring(0, sql.indexOf(' '));
-        switch (firstWord.toUpperCase()) {
+        sql = sql.replaceAll(System.lineSeparator()," ").trim();
+
+        switch (getFirstWord(sql)) {
             case "SELECT":
                 SQLQueryExpr sqlExpr = (SQLQueryExpr) toSqlExpr(sql);
                 sqlExpr.accept(new NestedFieldRewriter());
@@ -98,8 +98,16 @@ public class ESActionFactory {
                 IndexStatement describeStatement = new IndexStatement(StatementType.DESCRIBE, sql);
                 return new DescribeQueryAction(client, describeStatement);
             default:
-                throw new SQLFeatureNotSupportedException(String.format("Unsupported query: %s", sql));
+                throw new SQLFeatureNotSupportedException(
+                        String.format("Query must start with SELECT, DELETE, SHOW or DESCRIBE: %s", sql));
         }
+    }
+
+    private static String getFirstWord(String sql) {
+        int endOfFirstWord = sql.indexOf(' ');
+        return sql
+                .substring(0, endOfFirstWord > 0 ? endOfFirstWord : sql.length())
+                .toUpperCase();
     }
 
     private static boolean isMulti(SQLQueryExpr sqlExpr) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/QueryFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/QueryFunctionsTest.java
@@ -198,6 +198,26 @@ public class QueryFunctionsTest {
         );
     }
 
+    @Test(expected = SQLFeatureNotSupportedException.class)
+    public void emptyQueryShouldThrowSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+        ESActionFactory.create(Mockito.mock(Client.class), "");
+    }
+
+    @Test(expected = SQLFeatureNotSupportedException.class)
+    public void emptyNewLineQueryShouldThrowSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+        ESActionFactory.create(Mockito.mock(Client.class), "\n");
+    }
+
+    @Test(expected = SQLFeatureNotSupportedException.class)
+    public void queryWithoutSpaceShouldSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+        ESActionFactory.create(Mockito.mock(Client.class), "SELE");
+    }
+
+    @Test(expected = SQLFeatureNotSupportedException.class)
+    public void spacesOnlyQueryShouldThrowSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+        ESActionFactory.create(Mockito.mock(Client.class), "      ");
+    }
+
     private String query(String from, String... statements) {
         return explain(SELECT_ALL + " " + from + " " + String.join(" ", statements));
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/QueryFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/QueryFunctionsTest.java
@@ -209,6 +209,11 @@ public class QueryFunctionsTest {
     }
 
     @Test(expected = SQLFeatureNotSupportedException.class)
+    public void emptyNewLineQueryShouldThrowSQLFeatureNotSupportedException2() throws SQLFeatureNotSupportedException, SqlParseException {
+        ESActionFactory.create(Mockito.mock(Client.class), "\r\n");
+    }
+
+    @Test(expected = SQLFeatureNotSupportedException.class)
     public void queryWithoutSpaceShouldSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
         ESActionFactory.create(Mockito.mock(Client.class), "SELE");
     }


### PR DESCRIPTION
*Issue #, if available:*
*Description of changes: Previously empty string or string without spaces could cause IndexOutOfBoundsException, now the exception and the message will state clearly what was the problem.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.