### PR TITLE
Fix improper handling of the table expression

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
@@ -120,12 +120,14 @@ public class RestSqlAction extends BaseRestHandler {
             }
         } catch (Exception e) {
             if (isClientError(e)) {
+                LOG.error(String.format(Locale.ROOT, "[%s] Client side error during query execution", LogUtils.getRequestId()), e);
                 Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_CUS).increment();
+                return reportError(e, BAD_REQUEST);
             } else {
+                LOG.error(String.format(Locale.ROOT, "[%s] Server side error during query execution", LogUtils.getRequestId()), e);
                 Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_SYS).increment();
+                return reportError(e, SERVICE_UNAVAILABLE);
             }
-            LOG.error(String.format(Locale.ROOT, "[%s] Failed during query execution", LogUtils.getRequestId()), e);
-            return reportError(e, isClientError(e) ? BAD_REQUEST : SERVICE_UNAVAILABLE);
         }
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/matchtoterm/TermFieldRewriter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/matchtoterm/TermFieldRewriter.java
@@ -167,8 +167,8 @@ public class TermFieldRewriter extends MySqlASTVisitorAdapter {
                     SQLIdentifierExpr right = (SQLIdentifierExpr) rightSideOfExpression;
                     indexToType.put(table, right.getName());
                 } else {
-                    throw new ParserException("Right side of the expression  " + rightSideOfExpression.toString() +
-                            " is expected to be an identifier");
+                    throw new ParserException("Right side of the expression [" + rightSideOfExpression.toString() +
+                            "] is expected to be an identifier");
                 }
             }
             if (tableSource.getAlias() != null) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/matchtoterm/TermFieldRewriter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/matchtoterm/TermFieldRewriter.java
@@ -150,31 +150,31 @@ public class TermFieldRewriter extends MySqlASTVisitorAdapter {
     public void collect(SQLTableSource tableSource, Map<String, String> indexToType,  Map<String, String> aliases) {
         if (tableSource instanceof SQLExprTableSource) {
 
-            String table = null;
+            String tableName = null;
             SQLExprTableSource sqlExprTableSource = (SQLExprTableSource) tableSource;
 
             if (sqlExprTableSource.getExpr() instanceof SQLIdentifierExpr) {
                 SQLIdentifierExpr sqlIdentifier = (SQLIdentifierExpr) sqlExprTableSource.getExpr();
-                table = sqlIdentifier.getName();
-                indexToType.put(table, null);
+                tableName = sqlIdentifier.getName();
+                indexToType.put(tableName, null);
             } else if (sqlExprTableSource.getExpr() instanceof SQLBinaryOpExpr) {
                 SQLBinaryOpExpr sqlBinaryOpExpr = (SQLBinaryOpExpr) sqlExprTableSource.getExpr();
-                table = ((SQLIdentifierExpr) sqlBinaryOpExpr.getLeft()).getName();
+                tableName = ((SQLIdentifierExpr) sqlBinaryOpExpr.getLeft()).getName();
                 SQLExpr rightSideOfExpression = sqlBinaryOpExpr.getRight();
 
                 // This assumes that right side of the expression is different name in query
                 if (rightSideOfExpression instanceof SQLIdentifierExpr) {
                     SQLIdentifierExpr right = (SQLIdentifierExpr) rightSideOfExpression;
-                    indexToType.put(table, right.getName());
+                    indexToType.put(tableName, right.getName());
                 } else {
                     throw new ParserException("Right side of the expression [" + rightSideOfExpression.toString() +
                             "] is expected to be an identifier");
                 }
             }
             if (tableSource.getAlias() != null) {
-                aliases.put(tableSource.getAlias(), table);
+                aliases.put(tableSource.getAlias(), tableName);
             } else {
-                aliases.put(table, table);
+                aliases.put(tableName, tableName);
             }
 
         } else if (tableSource instanceof SQLJoinTableSource) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/matchtoterm/TermFieldRewriter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/matchtoterm/TermFieldRewriter.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.rewriter.matchtoterm;
 
+import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
 import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
@@ -28,6 +29,7 @@ import com.alibaba.druid.sql.ast.statement.SQLTableSource;
 import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlSelectGroupByExpr;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitorAdapter;
+import com.alibaba.druid.sql.parser.ParserException;
 import com.amazon.opendistroforelasticsearch.sql.esdomain.LocalClusterState;
 import org.elasticsearch.client.Client;
 import org.json.JSONObject;
@@ -147,19 +149,27 @@ public class TermFieldRewriter extends MySqlASTVisitorAdapter {
 
     public void collect(SQLTableSource tableSource, Map<String, String> indexToType,  Map<String, String> aliases) {
         if (tableSource instanceof SQLExprTableSource) {
+
             String table = null;
-            if (((SQLExprTableSource) tableSource).getExpr() instanceof SQLIdentifierExpr) {
-                table = ((SQLIdentifierExpr) ((SQLExprTableSource) tableSource).getExpr()).getName();
-                indexToType.put(
-                    table,
-                    null
-                );
-            } else if (((SQLExprTableSource) tableSource).getExpr() instanceof SQLBinaryOpExpr) {
-                table = ((SQLIdentifierExpr)((SQLBinaryOpExpr) ((SQLExprTableSource) tableSource).getExpr()).getLeft()).getName();
-                indexToType.put(
-                    table,
-                    ((SQLIdentifierExpr)((SQLBinaryOpExpr) ((SQLExprTableSource) tableSource).getExpr()).getRight()).getName()
-                );
+            SQLExprTableSource sqlExprTableSource = (SQLExprTableSource) tableSource;
+
+            if (sqlExprTableSource.getExpr() instanceof SQLIdentifierExpr) {
+                SQLIdentifierExpr sqlIdentifier = (SQLIdentifierExpr) sqlExprTableSource.getExpr();
+                table = sqlIdentifier.getName();
+                indexToType.put(table, null);
+            } else if (sqlExprTableSource.getExpr() instanceof SQLBinaryOpExpr) {
+                SQLBinaryOpExpr sqlBinaryOpExpr = (SQLBinaryOpExpr) sqlExprTableSource.getExpr();
+                table = ((SQLIdentifierExpr) sqlBinaryOpExpr.getLeft()).getName();
+                SQLExpr rightSideOfExpression = sqlBinaryOpExpr.getRight();
+
+                // This assumes that right side of the expression is different name in query
+                if (rightSideOfExpression instanceof SQLIdentifierExpr) {
+                    SQLIdentifierExpr right = (SQLIdentifierExpr) rightSideOfExpression;
+                    indexToType.put(table, right.getName());
+                } else {
+                    throw new ParserException("Right side of the expression  " + rightSideOfExpression.toString() +
+                            " is expected to be an identifier");
+                }
             }
             if (tableSource.getAlias() != null) {
                 aliases.put(tableSource.getAlias(), table);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/bugs/BuggedQueries.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/bugs/BuggedQueries.java
@@ -30,8 +30,7 @@ import java.sql.SQLFeatureNotSupportedException;
 public class BuggedQueries {
 
     @Test(expected = ParserException.class)
-
     public void missingWhereAndFieldName() throws SQLFeatureNotSupportedException, SqlParseException {
-        ESActionFactory.create(Mockito.mock(Client.class), "select * from products like 'CompassPoint*' limit 10");
+        ESActionFactory.create(Mockito.mock(Client.class), "select * from products like 'SomeProduct*' limit 10");
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/bugs/BuggedQueries.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/bugs/BuggedQueries.java
@@ -1,3 +1,18 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
 package com.amazon.opendistroforelasticsearch.sql.unittest.bugs;
 
 import com.alibaba.druid.sql.parser.ParserException;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/bugs/BuggedQueries.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/bugs/BuggedQueries.java
@@ -1,0 +1,22 @@
+package com.amazon.opendistroforelasticsearch.sql.unittest.bugs;
+
+import com.alibaba.druid.sql.parser.ParserException;
+import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
+import com.amazon.opendistroforelasticsearch.sql.query.ESActionFactory;
+import org.elasticsearch.client.Client;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.SQLFeatureNotSupportedException;
+
+/**
+ * Special cases for queries that had broken our parser in past.
+ */
+public class BuggedQueries {
+
+    @Test(expected = ParserException.class)
+
+    public void missingWhereAndFieldName() throws SQLFeatureNotSupportedException, SqlParseException {
+        ESActionFactory.create(Mockito.mock(Client.class), "select * from products like 'CompassPoint*' limit 10");
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/regression/RegressionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/regression/RegressionTest.java
@@ -13,24 +13,30 @@
  *   permissions and limitations under the License.
  */
 
-package com.amazon.opendistroforelasticsearch.sql.unittest.bugs;
+package com.amazon.opendistroforelasticsearch.sql.unittest.regression;
 
 import com.alibaba.druid.sql.parser.ParserException;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.query.ESActionFactory;
 import org.elasticsearch.client.Client;
 import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.sql.SQLFeatureNotSupportedException;
 
 /**
  * Special cases for queries that had broken our parser in past.
  */
-public class BuggedQueries {
+@RunWith(MockitoJUnitRunner.class)
+public class RegressionTest {
+
+    @Mock
+    Client client;
 
     @Test(expected = ParserException.class)
     public void missingWhereAndFieldName() throws SQLFeatureNotSupportedException, SqlParseException {
-        ESActionFactory.create(Mockito.mock(Client.class), "select * from products like 'SomeProduct*' limit 10");
+        ESActionFactory.create(client, "select * from products like 'SomeProduct*' limit 10");
     }
 }


### PR DESCRIPTION
*Description of changes:* 
The wrong query, such as "select * from abc like 'zzz'" was throwing server error instead of ParserError, fixing that.

Introduced variables and simplified some very long casts for easier debugging

Testing: unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
