### PR TITLE
Fix Issue for SELECT * in Nested Field Query

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Field.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Field.java
@@ -28,6 +28,9 @@ import java.util.Objects;
  */
 public class Field implements Cloneable{
 
+    /** Constant for '*' field in SELECT for reuse */
+    public static final Field STAR = new Field("*", "");
+
 	protected String name;
 	private String alias;
     private NestedType nested;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Field.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Field.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  */
 public class Field implements Cloneable{
 
-    /** Constant for '*' field in SELECT for reuse */
+    /** Constant for '*' field in SELECT */
     public static final Field STAR = new Field("*", "");
 
 	protected String name;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
@@ -68,6 +68,7 @@ public class Select extends Query {
 
 	public void addGroupBy(List<Field> fields) {
 		isAgg = true;
+		selectAll = false;
 		this.groupBys.add(fields);
 	}
 
@@ -107,8 +108,9 @@ public class Select extends Query {
 		if (field == null ) {
 			return;
 		}
-        if(field.getName().equals("*")){
+        if (field.getName().equals("*") && !isAgg) { // Ignore * for GROUP BY
             this.selectAll = true;
+            return;
         }
 
 		if(field instanceof  MethodField && aggsFunctions.contains(field.getName().toUpperCase())) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.amazon.opendistroforelasticsearch.sql.domain.Field.STAR;
+
 /**
  * 将sql语句转换为select 对象
  * 
@@ -108,7 +110,7 @@ public class Select extends Query {
 		if (field == null ) {
 			return;
 		}
-        if (field.getName().equals("*") && !isAgg) { // Ignore GROUP BY since columns present in result are decided by column list in GROUP BY
+        if (field == STAR && !isAgg) { // Ignore GROUP BY since columns present in result are decided by column list in GROUP BY
             this.selectAll = true;
             return;
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
@@ -108,7 +108,7 @@ public class Select extends Query {
 		if (field == null ) {
 			return;
 		}
-        if (field.getName().equals("*") && !isAgg) { // Ignore * for GROUP BY
+        if (field.getName().equals("*") && !isAgg) { // Ignore GROUP BY since columns present in result are decided by column list in GROUP BY
             this.selectAll = true;
             return;
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
@@ -31,52 +31,52 @@ import static com.amazon.opendistroforelasticsearch.sql.domain.Field.STAR;
  */
 public class Select extends Query {
 
-	// Using this functions, will cause query to execute as aggregation.
-	private final List<String> aggsFunctions = Arrays.asList("SUM", "MAX", "MIN", "AVG", "TOPHITS", "COUNT", "STATS","EXTENDED_STATS","PERCENTILES","SCRIPTED_METRIC");
+    // Using this functions, will cause query to execute as aggregation.
+    private final List<String> aggsFunctions = Arrays.asList("SUM", "MAX", "MIN", "AVG", "TOPHITS", "COUNT", "STATS","EXTENDED_STATS","PERCENTILES","SCRIPTED_METRIC");
     private List<Hint> hints = new ArrayList<>();
-	private List<Field> fields = new ArrayList<>();
-	private List<List<Field>> groupBys = new ArrayList<>();
-	private Having having;
-	private List<Order> orderBys = new ArrayList<>();
-	private int offset;
-	private int rowCount = 200;
+    private List<Field> fields = new ArrayList<>();
+    private List<List<Field>> groupBys = new ArrayList<>();
+    private Having having;
+    private List<Order> orderBys = new ArrayList<>();
+    private int offset;
+    private int rowCount = 200;
     private boolean containsSubQueries;
     private List<SubQueryExpression> subQueries;
-	public boolean isQuery = false;
+    public boolean isQuery = false;
     private boolean selectAll = false;
 
-	public boolean isAgg = false;
+    public boolean isAgg = false;
 
-	public Select() {
-	}
+    public Select() {
+    }
 
-	public List<Field> getFields() {
-		return fields;
-	}
+    public List<Field> getFields() {
+        return fields;
+    }
 
-	public void setOffset(int offset) {
-		this.offset = offset;
-	}
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
 
-	public void setRowCount(int rowCount) {
-		this.rowCount = rowCount;
-	}
+    public void setRowCount(int rowCount) {
+        this.rowCount = rowCount;
+    }
 
-	public void addGroupBy(Field field) {
-		List<Field> wrapper = new ArrayList<>();
-		wrapper.add(field);
-		addGroupBy(wrapper);
-	}
+    public void addGroupBy(Field field) {
+        List<Field> wrapper = new ArrayList<>();
+        wrapper.add(field);
+        addGroupBy(wrapper);
+    }
 
-	public void addGroupBy(List<Field> fields) {
-		isAgg = true;
-		selectAll = false;
-		this.groupBys.add(fields);
-	}
+    public void addGroupBy(List<Field> fields) {
+        isAgg = true;
+        selectAll = false;
+        this.groupBys.add(fields);
+    }
 
-	public List<List<Field>> getGroupBys() {
-		return groupBys;
-	}
+    public List<List<Field>> getGroupBys() {
+        return groupBys;
+    }
 
     public Having getHaving() {
         return having;
@@ -86,41 +86,41 @@ public class Select extends Query {
         this.having = having;
     }
 
-	public List<Order> getOrderBys() {
-		return orderBys;
-	}
+    public List<Order> getOrderBys() {
+        return orderBys;
+    }
 
-	public int getOffset() {
-		return offset;
-	}
+    public int getOffset() {
+        return offset;
+    }
 
-	public int getRowCount() {
-		return rowCount;
-	}
+    public int getRowCount() {
+        return rowCount;
+    }
 
-	public void addOrderBy(String nestedPath, String name, String type, boolean isScriptField) {
-		if ("_score".equals(name)) {
-			isQuery = true;
-		}
-		this.orderBys.add(new Order(nestedPath, name, type, isScriptField));
-	}
+    public void addOrderBy(String nestedPath, String name, String type, boolean isScriptField) {
+        if ("_score".equals(name)) {
+            isQuery = true;
+        }
+        this.orderBys.add(new Order(nestedPath, name, type, isScriptField));
+    }
 
 
-	public void addField(Field field) {
-		if (field == null ) {
-			return;
-		}
+    public void addField(Field field) {
+        if (field == null ) {
+            return;
+        }
         if (field == STAR && !isAgg) { // Ignore GROUP BY since columns present in result are decided by column list in GROUP BY
             this.selectAll = true;
             return;
         }
 
-		if(field instanceof  MethodField && aggsFunctions.contains(field.getName().toUpperCase())) {
-			isAgg = true;
-		}
+        if(field instanceof  MethodField && aggsFunctions.contains(field.getName().toUpperCase())) {
+            isAgg = true;
+        }
 
-		fields.add(field);
-	}
+        fields.add(field);
+    }
 
     public List<Hint> getHints() {
         return hints;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.action.admin.indices.mapping.get.GetFieldMapping
  */
 public class FieldMapping {
 
-    /** Field (name) to be parsed */
+    /** Name of the Field to be parsed */
     private final String fieldName;
 
     /** Native mapping information returned from ES */
@@ -118,7 +118,7 @@ public class FieldMapping {
          * When it is nested or contains "." in general (ex. fieldName.nestedName) the source is nestedName -> type
          */
         Map<String, Object> fieldMapping;
-        if (fieldPath.length < 2) {
+        if (fieldPath.length == 1) {
             fieldMapping = (Map<String, Object>) source.get(fieldName);
         } else {
             fieldMapping = (Map<String, Object>) source.get(fieldPath[1]);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
@@ -26,7 +26,7 @@ import static org.elasticsearch.action.admin.indices.mapping.get.GetFieldMapping
 /**
  * Field mapping that parse native ES mapping.
  *
- * NOTE that approaches in this class is NOT reliable because of the ES mapping query API used.
+ * NOTE that approaches in this class are NOT reliable because of the ES mapping query API used.
  * We should deprecate this in future and parse field mapping in more solid way.
  */
 public class FieldMapping {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
@@ -63,29 +63,20 @@ public class FieldMapping {
     }
 
     /**
+     * Verify if property field matches wildcard pattern specified in query
+     * @return true if matched
+     */
+    public boolean isWildcardSpecified() {
+        return specifiedFieldsByName.containsKey(path() + ".*");
+    }
+
+    /**
      * Is field a property field, which means either object field or nested field.
      * @return true for property field
      */
     public boolean isPropertyField() {
         int numOfDots = StringUtils.countMatches(fieldName, '.');
         return numOfDots > 1 || (numOfDots == 1 && !isMultiField());
-    }
-
-    /**
-     * Path of property field, for example "employee" in "employee.manager"
-     * @return path of property field
-     */
-    public String path() {
-        int lastDot = fieldName.lastIndexOf(".");
-        return fieldName.substring(0, lastDot);
-    }
-
-    /**
-     * Verify if property field matches wildcard pattern specified in query
-     * @return true if matched
-     */
-    public boolean isWildcardSpecified() {
-        return specifiedFieldsByName.containsKey(path() + ".*");
     }
 
     /**
@@ -102,6 +93,15 @@ public class FieldMapping {
      */
     public boolean isMetaField() {
         return fieldName.startsWith("_");
+    }
+
+    /**
+     * Path of property field, for example "employee" in "employee.manager"
+     * @return path of property field
+     */
+    public String path() {
+        int lastDot = fieldName.lastIndexOf(".");
+        return fieldName.substring(0, lastDot);
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
@@ -117,13 +117,7 @@ public class FieldMapping {
          * When field is not nested the metaData source is fieldName -> type
          * When it is nested or contains "." in general (ex. fieldName.nestedName) the source is nestedName -> type
          */
-        Map<String, Object> fieldMapping;
-        if (fieldPath.length == 1) {
-            fieldMapping = (Map<String, Object>) source.get(fieldName);
-        } else {
-            fieldMapping = (Map<String, Object>) source.get(fieldPath[1]);
-        }
-
+        Map<String, Object> fieldMapping = (Map<String, Object>) source.get(fieldPath.length == 1 ? fieldName : fieldPath[1]);
         for (int i = 2; i < fieldPath.length; i++) {
             fieldMapping = (Map<String, Object>) fieldMapping.get(fieldPath[i]);
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
@@ -16,7 +16,7 @@
 package com.amazon.opendistroforelasticsearch.sql.esdomain.mapping;
 
 import com.amazon.opendistroforelasticsearch.sql.domain.Field;
-import com.google.common.base.CharMatcher;
+import com.amazon.opendistroforelasticsearch.sql.utils.StringUtils;
 
 import java.util.Map;
 
@@ -67,7 +67,7 @@ public class FieldMapping {
      * @return true for property field
      */
     public boolean isPropertyField() {
-        int numOfDots = CharMatcher.is('.').countIn(fieldName); // Move to our own StringUtils
+        int numOfDots = StringUtils.countMatches(fieldName, '.');
         return numOfDots > 1 || (numOfDots == 1 && !isMultiField());
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
@@ -40,7 +40,6 @@ public class FieldMapping {
     /** Maps a field name to Field object that specified in query explicitly */
     private final Map<String, Field> specifiedFieldsByName;
 
-
     public FieldMapping(String fieldName) {
         this(fieldName, emptyMap(), emptyMap());
     }
@@ -102,7 +101,7 @@ public class FieldMapping {
     public String path() {
         int lastDot = fieldName.lastIndexOf(".");
         if (lastDot == -1) {
-            throw new IllegalStateException("path() is being invoked on wrong field");
+            throw new IllegalStateException("path() is being invoked on the wrong field [" + fieldName + "]");
         }
         return fieldName.substring(0, lastDot);
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
@@ -101,6 +101,9 @@ public class FieldMapping {
      */
     public String path() {
         int lastDot = fieldName.lastIndexOf(".");
+        if (lastDot == -1) {
+            throw new IllegalStateException("path() is being invoked on wrong field");
+        }
         return fieldName.substring(0, lastDot);
     }
 
@@ -117,7 +120,8 @@ public class FieldMapping {
          * When field is not nested the metaData source is fieldName -> type
          * When it is nested or contains "." in general (ex. fieldName.nestedName) the source is nestedName -> type
          */
-        Map<String, Object> fieldMapping = (Map<String, Object>) source.get(fieldPath.length == 1 ? fieldName : fieldPath[1]);
+        String root = (fieldPath.length == 1) ? fieldName : fieldPath[1];
+        Map<String, Object> fieldMapping = (Map<String, Object>) source.get(root);
         for (int i = 2; i < fieldPath.length; i++) {
             fieldMapping = (Map<String, Object>) fieldMapping.get(fieldPath[i]);
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
@@ -24,7 +24,7 @@ import static java.util.Collections.emptyMap;
 import static org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetaData;
 
 /**
- * Field mapping that parse native ES mapping.
+ * Field mapping that parses native ES mapping.
  *
  * NOTE that approaches in this class are NOT reliable because of the ES mapping query API used.
  * We should deprecate this in future and parse field mapping in more solid way.
@@ -37,8 +37,8 @@ public class FieldMapping {
     /** Native mapping information returned from ES */
     private final Map<String, FieldMappingMetaData> typeMappings;
 
-    /** Map of field name to Field object that specified in query explicitly */
-    private final Map<String, Field> specifiedFieldByNames;
+    /** Maps a field name to Field object that specified in query explicitly */
+    private final Map<String, Field> specifiedFieldsByName;
 
 
     public FieldMapping(String fieldName) {
@@ -51,7 +51,7 @@ public class FieldMapping {
 
         this.fieldName = fieldName;
         this.typeMappings = typeMappings;
-        this.specifiedFieldByNames = specifiedFieldByNames;
+        this.specifiedFieldsByName = specifiedFieldByNames;
     }
 
     /**
@@ -59,7 +59,7 @@ public class FieldMapping {
      * @return true if specified
      */
     public boolean isSpecified() {
-        return specifiedFieldByNames.containsKey(fieldName);
+        return specifiedFieldsByName.containsKey(fieldName);
     }
 
     /**
@@ -85,7 +85,7 @@ public class FieldMapping {
      * @return true if matched
      */
     public boolean isWildcardSpecified() {
-        return specifiedFieldByNames.containsKey(path() + ".*");
+        return specifiedFieldsByName.containsKey(path() + ".*");
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMapping.java
@@ -1,0 +1,134 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.esdomain.mapping;
+
+import com.amazon.opendistroforelasticsearch.sql.domain.Field;
+import com.google.common.base.CharMatcher;
+
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetaData;
+
+/**
+ * Field mapping that parse native ES mapping.
+ *
+ * NOTE that approaches in this class is NOT reliable because of the ES mapping query API used.
+ * We should deprecate this in future and parse field mapping in more solid way.
+ */
+public class FieldMapping {
+
+    /** Field (name) to be parsed */
+    private final String fieldName;
+
+    /** Native mapping information returned from ES */
+    private final Map<String, FieldMappingMetaData> typeMappings;
+
+    /** Map of field name to Field object that specified in query explicitly */
+    private final Map<String, Field> specifiedFieldByNames;
+
+
+    public FieldMapping(String fieldName) {
+        this(fieldName, emptyMap(), emptyMap());
+    }
+
+    public FieldMapping(String fieldName,
+                        Map<String, FieldMappingMetaData> typeMappings,
+                        Map<String, Field> specifiedFieldByNames) {
+
+        this.fieldName = fieldName;
+        this.typeMappings = typeMappings;
+        this.specifiedFieldByNames = specifiedFieldByNames;
+    }
+
+    /**
+     * Is field specified explicitly in query
+     * @return true if specified
+     */
+    public boolean isSpecified() {
+        return specifiedFieldByNames.containsKey(fieldName);
+    }
+
+    /**
+     * Is field a property field, which means either object field or nested field.
+     * @return true for property field
+     */
+    public boolean isPropertyField() {
+        int numOfDots = CharMatcher.is('.').countIn(fieldName); // Move to our own StringUtils
+        return numOfDots > 1 || (numOfDots == 1 && !isMultiField());
+    }
+
+    /**
+     * Path of property field, for example "employee" in "employee.manager"
+     * @return path of property field
+     */
+    public String path() {
+        int lastDot = fieldName.lastIndexOf(".");
+        return fieldName.substring(0, lastDot);
+    }
+
+    /**
+     * Verify if property field matches wildcard pattern specified in query
+     * @return true if matched
+     */
+    public boolean isWildcardSpecified() {
+        return specifiedFieldByNames.containsKey(path() + ".*");
+    }
+
+    /**
+     * Is field a/in multi-field, for example, field "a.keyword" in field "a"
+     * @return true for multi field
+     */
+    public boolean isMultiField() {
+        return fieldName.endsWith(".keyword");
+    }
+
+    /**
+     * Is field meta field, such as _id, _index, _source etc.
+     * @return true for meta field
+     */
+    public boolean isMetaField() {
+        return fieldName.startsWith("_");
+    }
+
+    /**
+     * Used to retrieve the type of fields from metaData map structures for both regular and nested fields
+     */
+    @SuppressWarnings("unchecked")
+    public String type() {
+        FieldMappingMetaData metaData = typeMappings.get(fieldName);
+        Map<String, Object> source = metaData.sourceAsMap();
+        String[] fieldPath = fieldName.split("\\.");
+
+        /*
+         * When field is not nested the metaData source is fieldName -> type
+         * When it is nested or contains "." in general (ex. fieldName.nestedName) the source is nestedName -> type
+         */
+        Map<String, Object> fieldMapping;
+        if (fieldPath.length < 2) {
+            fieldMapping = (Map<String, Object>) source.get(fieldName);
+        } else {
+            fieldMapping = (Map<String, Object>) source.get(fieldPath[1]);
+        }
+
+        for (int i = 2; i < fieldPath.length; i++) {
+            fieldMapping = (Map<String, Object>) fieldMapping.get(fieldPath[i]);
+        }
+
+        return (String) fieldMapping.get("type");
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/PrettyFormatRestExecutor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/PrettyFormatRestExecutor.java
@@ -17,16 +17,20 @@ package com.amazon.opendistroforelasticsearch.sql.executor.format;
 
 import com.amazon.opendistroforelasticsearch.sql.executor.QueryActionElasticExecutor;
 import com.amazon.opendistroforelasticsearch.sql.executor.RestExecutor;
+import com.amazon.opendistroforelasticsearch.sql.query.QueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.join.BackOffRetryStrategy;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestStatus;
-import com.amazon.opendistroforelasticsearch.sql.query.QueryAction;
 
 import java.util.Map;
 
 public class PrettyFormatRestExecutor implements RestExecutor {
+
+    private static final Logger LOG = LogManager.getLogger();
 
     private final String format;
 
@@ -64,9 +68,7 @@ public class PrettyFormatRestExecutor implements RestExecutor {
             Object queryResult = QueryActionElasticExecutor.executeAnyAction(client, queryAction);
             protocol = new Protocol(client, queryAction.getQueryStatement(), queryResult, format);
         } catch (Exception e) {
-            // TODO Might require some refactoring, Exceptions that happen in RestSqAction code before invoking execution
-            // TODO are being caught in RestController (line 242) and being sent as a bytesRestResponse
-            // ex. "SELECT * FROM WHERE balance > 30000", results in ParserException and ErrorMessage is never made
+            LOG.error("Error happened in pretty formatter", e);
             protocol = new Protocol(e);
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -94,10 +94,8 @@ public class SelectResultSet extends ResultSet {
         String typeName = fetchTypeName(query);
         String[] fieldNames = fetchFieldsAsArray(query);
 
-        if (isSimpleQuerySelectAll(query) || isJoinQuerySelectAll(query, fieldNames))
-            selectAll = true;
-        else
-            selectAll = false; // Reset boolean in the case of JOIN query where multiple calls to loadFromEsState() are made
+        // Reset boolean in the case of JOIN query where multiple calls to loadFromEsState() are made
+        selectAll = isSimpleQuerySelectAll(query) || isJoinQuerySelectAll(query, fieldNames);
 
         GetFieldMappingsRequest request = new GetFieldMappingsRequest()
                 .indices(indexName)

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -408,16 +408,16 @@ public class SelectResultSet extends ResultSet {
      * The only exception here is * picks all non-regular (nested) fields as JSON without flatten.
      */
     private void populateAllNestedFields(List<Schema.Column> columns, List<String> fields) {
-        Set<String> nestedFieldNames = fields.stream().
-                                       map(FieldMapping::new).
-                                       filter(FieldMapping::isPropertyField).
-                                       filter(f -> !f.isMultiField()).
-                                       map(FieldMapping::path).
-                                       collect(toSet());
+        Set<String> nestedFieldPaths = fields.stream().
+                                              map(FieldMapping::new).
+                                              filter(FieldMapping::isPropertyField).
+                                              filter(f -> !f.isMultiField()).
+                                              map(FieldMapping::path).
+                                              collect(toSet());
 
-        for (String fieldName : nestedFieldNames) {
+        for (String nestedFieldPath : nestedFieldPaths) {
             columns.add(
-                new Schema.Column(fieldName, "", Schema.Type.TEXT)
+                new Schema.Column(nestedFieldPath, "", Schema.Type.TEXT)
             );
         }
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -392,11 +392,11 @@ public class SelectResultSet extends ResultSet {
 
     /**
      *  Verify if field is property field (object or nested ) and matched by wildcard pattern given in SELECT
-     *  A special case is text field with nested keyword. Ignore it in the case of SELECT * ?
+     *  A special case is text field with nested keyword. Ignore it because it's a "hidden" field.
      */
     private boolean isFieldPropertyAndMatchWildcard(Map<String, Field> fieldMap, String fieldName) {
         int lastDot = fieldName.lastIndexOf(".");
-        if (lastDot > -1) {
+        if (lastDot != -1) {
             String path = fieldName.substring(0, lastDot);
             return !fieldName.endsWith(".keyword") && fieldMap.containsKey(path + ".*");
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -446,9 +446,10 @@ public class SelectResultSet extends ResultSet {
         if (queryResult instanceof SearchHits) {
             SearchHits searchHits = (SearchHits) queryResult;
 
-            this.size = searchHits.getHits().length;
-            this.totalHits = Optional.ofNullable(searchHits.getTotalHits()).map(th -> th.value).orElse(0L);
             this.rows = populateRows(searchHits);
+            this.size = rows.size();
+            this.totalHits = Math.max(size,
+                                      Optional.ofNullable(searchHits.getTotalHits()).map(th -> th.value).orElse(0L));
 
         } else if (queryResult instanceof Aggregations) {
             Aggregations aggregations = (Aggregations) queryResult;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -345,7 +345,7 @@ public class SelectResultSet extends ResultSet {
 
             /*
              * Unnecessary fields (ex. _index, _parent) are ignored.
-             * Fields like fieldName.keyword will be ignored when isSelectAll is true but will be returned if
+             * Fields like field.keyword will be ignored when isSelectAll is true but will be returned if
              * explicitly selected.
              */
             FieldMapping field = new FieldMapping(fieldName, typeMappings, fieldMap);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -392,13 +392,13 @@ public class SelectResultSet extends ResultSet {
 
     /**
      *  Verify if field is property field (object or nested ) and matched by wildcard pattern given in SELECT
-     *  A special case is text field with nested keyword. Ignore it because it's a "hidden" field.
+     *  A special case is multi-field, typically text field with nested keyword. Ignore it because it's a "hidden" field.
      */
     private boolean isFieldPropertyAndMatchWildcard(Map<String, Field> fieldMap, String fieldName) {
         int lastDot = fieldName.lastIndexOf(".");
         if (lastDot != -1) {
             String path = fieldName.substring(0, lastDot);
-            return !fieldName.endsWith(".keyword") && fieldMap.containsKey(path + ".*");
+            return !isInMultiField(fieldName) && fieldMap.containsKey(path + ".*");
         }
         return true;
     }
@@ -417,7 +417,7 @@ public class SelectResultSet extends ResultSet {
      */
     private void populateAllNestedFields(List<Schema.Column> columns, List<String> fields) {
         Set<String> nestedFieldNames = fields.stream().
-                                       filter(f -> f.contains(".") && !f.endsWith(".keyword")).
+                                       filter(f -> f.contains(".") && !isInMultiField(f)).
                                        map(f -> f.substring(0, f.lastIndexOf("."))).
                                        collect(Collectors.toSet());
 
@@ -427,6 +427,14 @@ public class SelectResultSet extends ResultSet {
             );
         }
     }
+
+    /**
+     * Does field belong to a multi-field, for example, field "a.keyword" in field "a"
+     */
+    private boolean isInMultiField(String fieldName) {
+        return fieldName.endsWith(".keyword");
+    }
+
 
     /**
      * Since this helper method is called within a check to see if the field exists in type mapping, it's

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -303,23 +303,23 @@ public class SelectResultSet extends ResultSet {
      * will be used.
      */
     private List<Schema.Column> populateColumns(Query query, String[] fieldNames, Map<String, FieldMappingMetaData> typeMappings) {
-        List<String> fields;
+        List<String> fieldNameList;
 
         if (isSelectAll() || containsWildcard(query)) {
-            fields = new ArrayList<>(typeMappings.keySet());
+            fieldNameList = new ArrayList<>(typeMappings.keySet());
         } else {
-            fields = Arrays.asList(fieldNames);
+            fieldNameList = Arrays.asList(fieldNames);
         }
 
         /*
-         * The reason the 'fieldMap' mapping is needed on top of 'fields' is because the map would be empty in cases
-         * like 'SELECT *' but List<String> fields will always be set in either case. That way, 'fields' is used to
+         * The reason the 'fieldMap' mapping is needed on top of 'fieldNameList' is because the map would be empty in cases
+         * like 'SELECT *' but List<String> fieldNameList will always be set in either case. That way, 'fieldNameList' is used to
          * access field names in order that they were selected, if given, and then 'fieldMap' is used to access the
          * respective Field object to check for aliases.
          */
         Map<String, Field> fieldMap = fetchFieldMap(query);
         List<Schema.Column> columns = new ArrayList<>();
-        for (String fieldName : fields) {
+        for (String fieldName : fieldNameList) {
             // _score is a special case since it is not included in typeMappings, so it is checked for here
             if (fieldName.equals("_score")) {
                 columns.add(new Schema.Column(fieldName, fetchAlias(fieldName, fieldMap), Schema.Type.FLOAT));
@@ -377,7 +377,7 @@ public class SelectResultSet extends ResultSet {
         }
 
         if (isSelectAllOnly(query)) {
-            populateAllNestedFields(columns, fields);
+            populateAllNestedFields(columns, fieldNameList);
         }
         return columns;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -47,6 +47,8 @@ import static org.elasticsearch.action.admin.indices.mapping.get.GetFieldMapping
 
 public class SelectResultSet extends ResultSet {
 
+    public static final String SCORE = "_score";
+
     private Query query;
     private Object queryResult;
 
@@ -321,7 +323,7 @@ public class SelectResultSet extends ResultSet {
         List<Schema.Column> columns = new ArrayList<>();
         for (String fieldName : fieldNameList) {
             // _score is a special case since it is not included in typeMappings, so it is checked for here
-            if (fieldName.equals("_score")) {
+            if (fieldName.equals(SCORE)) {
                 columns.add(new Schema.Column(fieldName, fetchAlias(fieldName, fieldMap), Schema.Type.FLOAT));
             }
             /*
@@ -462,7 +464,7 @@ public class SelectResultSet extends ResultSet {
 
             if (!isJoinQuery()) { // Row already flatten in source in join. And join doesn't support nested fields for now.
                 rowSource = flatRow(head, rowSource);
-                rowSource.put("_score", hit.getScore());
+                rowSource.put(SCORE, hit.getScore());
                 result = flatNestedField(newKeys, rowSource, hit.getInnerHits());
             }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -403,10 +403,18 @@ public class SelectResultSet extends ResultSet {
         return true;
     }
 
+    /**
+     * SELECT * only without other columns or wildcard pattern specified.
+     */
     private boolean isSelectAllOnly(Query query) {
         return isSelectAll() && fetchFields(query).isEmpty();
     }
 
+    /**
+     * Special case which trades off consistency of SELECT * meaning for more intuition from customer perspective.
+     * In other cases, * means all regular fields on the level.
+     * The only exception here is * picks all non-regular (nested) fields as JSON without flatten.
+     */
     private void populateAllNestedFields(List<Schema.Column> columns, List<String> fields) {
         Set<String> nestedFieldNames = fields.stream().
                                        filter(f -> f.contains(".") && !f.endsWith("keyword")).

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -417,7 +417,7 @@ public class SelectResultSet extends ResultSet {
      */
     private void populateAllNestedFields(List<Schema.Column> columns, List<String> fields) {
         Set<String> nestedFieldNames = fields.stream().
-                                       filter(f -> f.contains(".") && !f.endsWith("keyword")).
+                                       filter(f -> f.contains(".") && !f.endsWith(".keyword")).
                                        map(f -> f.substring(0, f.lastIndexOf("."))).
                                        collect(Collectors.toSet());
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -168,7 +168,7 @@ public class SelectResultSet extends ResultSet {
     }
 
     /**
-     * Is a join query with SELECT * on either one of the table
+     * Is a join query with SELECT * on either one of the tables  some fields specified
      */
     private boolean isJoinQuerySelectAll(Query query, String[] fieldNames) {
         return fieldNames.length == 0 && !fieldsSelectedOnAnotherTable(query);
@@ -449,7 +449,7 @@ public class SelectResultSet extends ResultSet {
 
             this.rows = populateRows(searchHits);
             this.size = rows.size();
-            this.totalHits = Math.max(size, // size may be greater than totalHits after nested rows flatten
+            this.totalHits = Math.max(size, // size may be greater than totalHits after nested rows be flatten
                                       Optional.ofNullable(searchHits.getTotalHits()).map(th -> th.value).orElse(0L));
 
         } else if (queryResult instanceof Aggregations) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
@@ -46,7 +46,7 @@ public class FieldMaker {
             return makeField(makeBinaryMethodField((SQLBinaryOpExpr) expr, alias, true), alias, tableAlias);
 
         } else if (expr instanceof SQLAllColumnExpr) {
-            return new Field("*", "");
+            return Field.STAR;
         } else if (expr instanceof SQLMethodInvokeExpr) {
             SQLMethodInvokeExpr mExpr = (SQLMethodInvokeExpr) expr;
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
@@ -46,6 +46,7 @@ public class FieldMaker {
             return makeField(makeBinaryMethodField((SQLBinaryOpExpr) expr, alias, true), alias, tableAlias);
 
         } else if (expr instanceof SQLAllColumnExpr) {
+            return new Field("*", "");
         } else if (expr instanceof SQLMethodInvokeExpr) {
             SQLMethodInvokeExpr mExpr = (SQLMethodInvokeExpr) expr;
 
@@ -92,7 +93,6 @@ public class FieldMaker {
         } else {
             throw new SqlParseException("unknown field name : " + expr);
         }
-        return null;
     }
 
     private static Object getScriptValue(SQLExpr expr) throws SqlParseException {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
@@ -149,7 +149,7 @@ public class ESActionFactory {
     }
 
     private static QueryAction handleSelect(Client client, Select select) {
-        if (select.isAgg) {
+        if (select.isAggregate) {
             return new AggregationQueryAction(client, select);
         } else {
             return new DefaultQueryAction(client, select);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/StringUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/StringUtils.java
@@ -15,8 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.sql.utils;
 
-import com.google.common.base.CharMatcher;
-
 import java.util.Locale;
 
 /**
@@ -90,7 +88,9 @@ public class StringUtils {
      * @return       number of occurrences
      */
     public static int countMatches(CharSequence input, char match) {
-        return CharMatcher.is(match).countIn(input);
+        return Math.toIntExact(input.chars().
+                                     filter(c -> c == match).
+                                     count());
     }
 
     private StringUtils() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/StringUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/StringUtils.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistroforelasticsearch.sql.utils;
 
+import com.google.common.base.CharMatcher;
+
 import java.util.Locale;
 
 /**
@@ -78,6 +80,17 @@ public class StringUtils {
      */
     public static String toUpper(final String input) {
         return input.toUpperCase(Locale.ROOT);
+    }
+
+    /**
+     * Count how many occurrences of character in this input {@code Sequence}.
+     *
+     * @param input  the input string
+     * @param match  char to be matched
+     * @return       number of occurrences
+     */
+    public static int countMatches(CharSequence input, char match) {
+        return CharMatcher.is(match).countIn(input);
     }
 
     private StringUtils() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMappingTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMappingTest.java
@@ -1,0 +1,110 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.esdomain.mapping;
+
+import com.amazon.opendistroforelasticsearch.sql.domain.Field;
+import com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils;
+import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetaData;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit test for {@code FieldMapping}. Ignore trivial methods such as isSpecified, isMetaField etc.
+ */
+public class FieldMappingTest {
+
+    @Test
+    public void testFieldMatchesWildcardPatternSpecifiedInQuery() {
+        assertThat(
+            new FieldMapping("employee.first", map(), fieldsSpecifiedInQuery("employee.*")),
+            isWildcardSpecified(true)
+        );
+    }
+
+    @Test
+    public void testFieldMismatchesWildcardPatternSpecifiedInQuery() {
+        assertThat(
+            new FieldMapping("employee.first", map(), fieldsSpecifiedInQuery("manager.*")),
+            isWildcardSpecified(false)
+        );
+    }
+
+    @Test
+    public void testFieldIsProperty() {
+        assertThat(
+            new FieldMapping("employee.first"),
+            isPropertyField(true)
+        );
+
+        assertThat(
+            new FieldMapping("employee.first.keyword"),
+            isPropertyField(true)
+        );
+    }
+
+    @Test
+    public void testFieldIsNotProperty() {
+        assertThat(
+            new FieldMapping("employee"),
+            isPropertyField(false)
+        );
+
+        assertThat(
+            new FieldMapping("employee.keyword"),
+            isPropertyField(false)
+        );
+    }
+
+    private Matcher<FieldMapping> isWildcardSpecified(boolean isMatched) {
+        return MatcherUtils.featureValueOf("is field match wildcard specified in query",
+                                           is(isMatched),
+                                           FieldMapping::isWildcardSpecified);
+    }
+
+    private Matcher<FieldMapping> isPropertyField(boolean isProperty) {
+        return MatcherUtils.featureValueOf("isPropertyField",
+                                           is(isProperty),
+                                           FieldMapping::isPropertyField);
+    }
+
+    private Map<String, Field> fieldsSpecifiedInQuery(String...fieldNames) {
+        return Arrays.stream(fieldNames).
+                      collect(Collectors.toMap(name -> name,
+                                               name -> new Field(name, "")));
+    }
+
+    private Map<String, FieldMappingMetaData> typeMappings() {
+        return null;
+    }
+
+    private <K, V> Map<K, V> map(K key, V value) {
+        return singletonMap(key, value);
+    }
+
+    private <K, V> Map<K, V> map() {
+        return emptyMap();
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMappingTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMappingTest.java
@@ -17,7 +17,6 @@ package com.amazon.opendistroforelasticsearch.sql.esdomain.mapping;
 
 import com.amazon.opendistroforelasticsearch.sql.domain.Field;
 import com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils;
-import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse.FieldMappingMetaData;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 
@@ -37,7 +36,7 @@ public class FieldMappingTest {
     @Test
     public void testFieldMatchesWildcardPatternSpecifiedInQuery() {
         assertThat(
-            new FieldMapping("employee.first", typeMappings(), fieldsSpecifiedInQuery("employee.*")),
+            new FieldMapping("employee.first", emptyMap(), fieldsSpecifiedInQuery("employee.*")),
             isWildcardSpecified(true)
         );
     }
@@ -45,7 +44,7 @@ public class FieldMappingTest {
     @Test
     public void testFieldMismatchesWildcardPatternSpecifiedInQuery() {
         assertThat(
-            new FieldMapping("employee.first", typeMappings(), fieldsSpecifiedInQuery("manager.*")),
+            new FieldMapping("employee.first", emptyMap(), fieldsSpecifiedInQuery("manager.*")),
             isWildcardSpecified(false)
         );
     }
@@ -56,7 +55,10 @@ public class FieldMappingTest {
             new FieldMapping("employee.first"),
             isPropertyField(true)
         );
+    }
 
+    @Test
+    public void testNestedMultiFieldIsProperty() {
         assertThat(
             new FieldMapping("employee.first.keyword"),
             isPropertyField(true)
@@ -69,7 +71,10 @@ public class FieldMappingTest {
             new FieldMapping("employee"),
             isPropertyField(false)
         );
+    }
 
+    @Test
+    public void testMultiFieldIsNotProperty() {
         assertThat(
             new FieldMapping("employee.keyword"),
             isPropertyField(false)
@@ -92,10 +97,6 @@ public class FieldMappingTest {
         return Arrays.stream(fieldNames).
                       collect(Collectors.toMap(name -> name,
                                                name -> new Field(name, "")));
-    }
-
-    private Map<String, FieldMappingMetaData> typeMappings() {
-        return emptyMap();
     }
 
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMappingTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esdomain/mapping/FieldMappingTest.java
@@ -26,19 +26,18 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 /**
- * Unit test for {@code FieldMapping}. Ignore trivial methods such as isSpecified, isMetaField etc.
+ * Unit test for {@code FieldMapping} with trivial methods ignored such as isSpecified, isMetaField etc.
  */
 public class FieldMappingTest {
 
     @Test
     public void testFieldMatchesWildcardPatternSpecifiedInQuery() {
         assertThat(
-            new FieldMapping("employee.first", map(), fieldsSpecifiedInQuery("employee.*")),
+            new FieldMapping("employee.first", typeMappings(), fieldsSpecifiedInQuery("employee.*")),
             isWildcardSpecified(true)
         );
     }
@@ -46,7 +45,7 @@ public class FieldMappingTest {
     @Test
     public void testFieldMismatchesWildcardPatternSpecifiedInQuery() {
         assertThat(
-            new FieldMapping("employee.first", map(), fieldsSpecifiedInQuery("manager.*")),
+            new FieldMapping("employee.first", typeMappings(), fieldsSpecifiedInQuery("manager.*")),
             isWildcardSpecified(false)
         );
     }
@@ -96,14 +95,6 @@ public class FieldMappingTest {
     }
 
     private Map<String, FieldMappingMetaData> typeMappings() {
-        return null;
-    }
-
-    private <K, V> Map<K, V> map(K key, V value) {
-        return singletonMap(key, value);
-    }
-
-    private <K, V> Map<K, V> map() {
         return emptyMap();
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
@@ -164,17 +164,20 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void selectAllFromNestedWithoutFieldInFrom() throws IOException {
-        assertNestedFieldQueryResultContainsColumnsAndData("SELECT * FROM %s", regularFields, fields("message", "comment"));
+        assertNestedFieldQueryResultContainsColumnsAndData("SELECT * FROM %s",
+                                                           regularFields, fields("message", "comment"));
     }
 
     @Test
     public void selectAllFromNestedWithFieldInFrom() throws IOException {
-        assertNestedFieldQueryResultContainsColumnsAndData("SELECT * FROM %s e, e.message m", regularFields, messageFields);
+        assertNestedFieldQueryResultContainsColumnsAndData("SELECT * FROM %s e, e.message m",
+                                                           regularFields, messageFields);
     }
 
     @Test
     public void selectAllFromNestedWithMultipleFieldsInFrom() throws IOException {
-        assertNestedFieldQueryResultContainsColumnsAndData("SELECT * FROM %s e, e.message m, e.comment c", regularFields, messageFields, commentFields);
+        assertNestedFieldQueryResultContainsColumnsAndData("SELECT * FROM %s e, e.message m, e.comment c",
+                                                           regularFields, messageFields, commentFields);
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -163,7 +164,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void selectAllFromNestedWithoutFieldInFrom() throws IOException {
-        assertNestedFieldQueryResultContainsColumnsAndData("SELECT * FROM %s", regularFields);
+        assertNestedFieldQueryResultContainsColumnsAndData("SELECT * FROM %s", regularFields, fields("message", "comment"));
     }
 
     @Test
@@ -184,7 +185,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void selectSpecificRegularFieldAndAllFromNestedWithFieldInFrom() throws IOException {
         assertNestedFieldQueryResultContainsColumnsAndData("SELECT e.someField, m.* FROM %s e, e.message m",
-                                                           Collections.singleton("someField"), messageFields);
+                                                           fields("someField"), messageFields);
     }
 
     /**
@@ -200,6 +201,10 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
         assertContainsColumnsInAnyOrder(getSchema(response), allExpectedFieldNames);
         assertContainsData(getDataRows(response), allExpectedFieldNames);
+    }
+
+    private Set<String> fields(String... fieldNames) {
+        return Sets.newHashSet(fieldNames);
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -241,6 +241,15 @@ public class TestUtils {
                 "              },\n" +
                 "              \"author\": {\n" +
                 "                \"type\": \"keyword\",\n" +
+            /*
+                "                \"type\": \"keyword\",\n" +
+                "                \"fields\": {\n" +
+                "                  \"keyword\": {\n" +
+                "                    \"type\": \"keyword\",\n" +
+                "                    \"ignore_above\" : 256\n" +
+                "                  }\n" +
+                "                },\n" +
+             */
                 "                \"index\": \"true\"\n" +
                 "              },\n" +
                 "              \"dayOfWeek\": {\n" +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -241,15 +241,12 @@ public class TestUtils {
                 "              },\n" +
                 "              \"author\": {\n" +
                 "                \"type\": \"keyword\",\n" +
-            /*
-                "                \"type\": \"keyword\",\n" +
                 "                \"fields\": {\n" +
                 "                  \"keyword\": {\n" +
                 "                    \"type\": \"keyword\",\n" +
                 "                    \"ignore_above\" : 256\n" +
                 "                  }\n" +
                 "                },\n" +
-             */
                 "                \"index\": \"true\"\n" +
                 "              },\n" +
                 "              \"dayOfWeek\": {\n" +


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/95

*Description of changes:* The meaning of SELECT * in nested field query was not clear. To fix issue, we need to clarify its semantics.

For examples, in `SELECT * FROM A a, a.B b` and `SELECT * FROM A a, a.B b, a.C c` (suppose B and C are nested fields in A), regulars fields of A and nested fields in B should be returned for the first query. In addition, nested fields in C should be returned for the second query. **Basically, * just means regular fields. FROM clause decides if any nested fields should be flatten and present in result**. 

One exception is `SELECT * FROM A`. All fields are returned including nested fields in this case. Because we'd like to trade off consistency of SELECT * notation for more intuition from customer perspective.

Please find more details in my integration test.

A proposal is to switch current metadata query to mappings in `LocalClusterState`. Because mappings are being flatten and hierarchy is missing in the response of current query. Ideally, we should build domain object layer on top and avoid code like `fieldName.contains(".")`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
