### PR TITLE
Fix generated script for ORDER BY for ORDER BY date_format case

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
@@ -24,11 +24,17 @@ public class Order {
 	private String nestedPath;
 	private String name;
 	private String type;
+	private boolean isScriptField;
 
-	public Order(String nestedPath, String name, String type) {
+	public boolean isScriptField() {
+		return isScriptField;
+	}
+
+	public Order(String nestedPath, String name, String type, boolean isScriptField) {
         this.nestedPath = nestedPath;
 		this.name = name;
 		this.type = type;
+		this.isScriptField = isScriptField;
 	}
 
     public String getNestedPath() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
@@ -26,15 +26,15 @@ public class Order {
 	private String type;
 	private boolean isScriptField;
 
-	public boolean isScriptField() {
-		return isScriptField;
-	}
+    public boolean isScriptField() {
+        return isScriptField;
+    }
 
 	public Order(String nestedPath, String name, String type, boolean isScriptField) {
         this.nestedPath = nestedPath;
 		this.name = name;
 		this.type = type;
-		this.isScriptField = isScriptField;
+        this.isScriptField = isScriptField;
 	}
 
     public String getNestedPath() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
@@ -24,17 +24,17 @@ public class Order {
 	private String nestedPath;
 	private String name;
 	private String type;
-    private boolean isScriptField;
+    private boolean isScript;
 
-    public boolean isScriptField() {
-        return isScriptField;
+    public boolean isScript() {
+        return isScript;
     }
 
-	public Order(String nestedPath, String name, String type, boolean isScriptField) {
+	public Order(String nestedPath, String name, String type, boolean isScript) {
         this.nestedPath = nestedPath;
 		this.name = name;
 		this.type = type;
-        this.isScriptField = isScriptField;
+        this.isScript = isScript;
 	}
 
     public String getNestedPath() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
@@ -24,7 +24,7 @@ public class Order {
 	private String nestedPath;
 	private String name;
 	private String type;
-	private boolean isScriptField;
+    private boolean isScriptField;
 
     public boolean isScriptField() {
         return isScriptField;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
@@ -95,11 +95,11 @@ public class Select extends Query {
 		return rowCount;
 	}
 
-	public void addOrderBy(String nestedPath, String name, String type) {
+	public void addOrderBy(String nestedPath, String name, String type, boolean isScriptField) {
 		if ("_score".equals(name)) {
 			isQuery = true;
 		}
-		this.orderBys.add(new Order(nestedPath, name, type));
+		this.orderBys.add(new Order(nestedPath, name, type, isScriptField));
 	}
 
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SqlParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SqlParser.java
@@ -218,7 +218,7 @@ public class SqlParser {
             Field field = FieldMaker.makeField(expr, null, null);
 
             String orderByName;
-            if (field instanceof MethodField && field.getName().equals("script")) {
+            if (isScriptField(field)) {
                 // TODO The consumer of ordering doesn't know the type of the expression, and elasticsearch needs to
                 // specify it for the script field ordering. Explore opportinities to supply that information to
                 // client code. One of the options is to have metadata store about functions that will supply
@@ -236,9 +236,13 @@ public class SqlParser {
 
             orderByName = orderByName.replace("`", "");
             if (alias != null) orderByName = orderByName.replaceFirst(alias + "\\.", "");
-            select.addOrderBy(field.getNestedPath(), orderByName, type, field instanceof MethodField);
+            select.addOrderBy(field.getNestedPath(), orderByName, type, isScriptField(field));
 
         }
+    }
+
+    private boolean isScriptField(Field field) {
+        return field instanceof MethodField && field.getName().equals("script");
     }
 
     private void findLimit(MySqlSelectQueryBlock.Limit limit, Select select) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
@@ -38,6 +38,7 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.NestedSortBuilder;
+import org.elasticsearch.search.sort.ScriptSortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 
@@ -208,9 +209,22 @@ public class DefaultQueryAction extends QueryAction {
     private void setSorts(List<Order> orderBys) {
         for (Order order : orderBys) {
             if (order.getNestedPath() != null) {
-                request.addSort(SortBuilders.fieldSort(order.getName()).order(SortOrder.valueOf(order.getType())).setNestedSort(new NestedSortBuilder(order.getNestedPath())));
+                request.addSort(
+                        SortBuilders.fieldSort(order.getName())
+                                .order(SortOrder.valueOf(order.getType()))
+                                .setNestedSort(new NestedSortBuilder(order.getNestedPath())));
             } else {
-                request.addSort(order.getName(), SortOrder.valueOf(order.getType()));
+                if (order.isScriptField()) {
+                    // TODO(galk) Investigate how to find the sort type
+
+                    ScriptSortBuilder.ScriptSortType string = ScriptSortBuilder.ScriptSortType.STRING;
+                    request.addSort(
+                            SortBuilders
+                                    .scriptSort(new Script(order.getName()), string)
+                                    .order(SortOrder.valueOf(order.getType())));
+                } else {
+                    request.addSort(order.getName(), SortOrder.valueOf(order.getType()));
+                }
             }
         }
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
@@ -214,7 +214,7 @@ public class DefaultQueryAction extends QueryAction {
                                 .order(SortOrder.valueOf(order.getType()))
                                 .setNestedSort(new NestedSortBuilder(order.getNestedPath())));
             } else {
-                if (order.isScriptField()) {
+                if (order.isScript()) {
                     // TODO: Investigate how to find the type of expression (string or number)
                     // As of now this shouldn't be a problem, because the support is for date_format function
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
@@ -215,7 +215,8 @@ public class DefaultQueryAction extends QueryAction {
                                 .setNestedSort(new NestedSortBuilder(order.getNestedPath())));
             } else {
                 if (order.isScriptField()) {
-                    // TODO(galk) Investigate how to find the sort type
+                    // TODO: Investigate how to find the type of expression (string or number)
+                    // As of now this shouldn't be a problem, because the support is for date_format function
 
                     ScriptSortBuilder.ScriptSortType string = ScriptSortBuilder.ScriptSortType.STRING;
                     request.addSort(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
@@ -38,7 +38,7 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.NestedSortBuilder;
-import org.elasticsearch.search.sort.ScriptSortBuilder;
+import org.elasticsearch.search.sort.ScriptSortBuilder.ScriptSortType;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 
@@ -218,10 +218,9 @@ public class DefaultQueryAction extends QueryAction {
                     // TODO: Investigate how to find the type of expression (string or number)
                     // As of now this shouldn't be a problem, because the support is for date_format function
 
-                    ScriptSortBuilder.ScriptSortType string = ScriptSortBuilder.ScriptSortType.STRING;
                     request.addSort(
                             SortBuilders
-                                    .scriptSort(new Script(order.getName()), string)
+                                    .scriptSort(new Script(order.getName()), ScriptSortType.STRING)
                                     .order(SortOrder.valueOf(order.getType())));
                 } else {
                     request.addSort(order.getName(), SortOrder.valueOf(order.getType()));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFormatIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFormatIT.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 
 public class DateFormatIT extends SQLIntegTestCase {
 
@@ -116,6 +117,22 @@ public class DateFormatIT extends SQLIntegTestCase {
                       "LIMIT 1000"),
             contains("2014-08-17", "2014-08-24")
         );
+    }
+
+
+    @Test
+    public void sortByDateFormat() throws IOException {
+        // Sort by expression in descending order, but sort inside in ascending order, so we increase our confidence
+        // that successful test isn't just random chance.
+
+        JSONArray hits =
+                getHits(executeQuery("SELECT all_client, insert_time " +
+                        "FROM " + TestsConstants.TEST_INDEX_ONLINE + "/online " +
+                        "ORDER BY date_format(insert_time, 'dd-MM-YYYY') DESC, insert_time " +
+                        "LIMIT 10"));
+
+        assertThat(new DateTime(getSource(hits.getJSONObject(0)).get("insert_time"), DateTimeZone.UTC),
+                is(new DateTime("2014-08-24T07:00:55.481Z", DateTimeZone.UTC)));
     }
 
     private Set<Object> dateQuery(String sql) throws SqlParseException {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFormatIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFormatIT.java
@@ -35,7 +35,7 @@ public class DateFormatIT extends SQLIntegTestCase {
 
     private static final String SELECT_FROM =
             "SELECT insert_time " +
-            "FROM " + TestsConstants.TEST_INDEX_ONLINE + "/online ";
+            "FROM " + TestsConstants.TEST_INDEX_ONLINE + " ";
 
     @Override
     protected void init() throws Exception {
@@ -127,9 +127,9 @@ public class DateFormatIT extends SQLIntegTestCase {
 
         JSONArray hits =
                 getHits(executeQuery("SELECT all_client, insert_time " +
-                        "FROM " + TestsConstants.TEST_INDEX_ONLINE + "/online " +
-                        "ORDER BY date_format(insert_time, 'dd-MM-YYYY') DESC, insert_time " +
-                        "LIMIT 10"));
+                        " FROM " + TestsConstants.TEST_INDEX_ONLINE +
+                        " ORDER BY date_format(insert_time, 'dd-MM-YYYY') DESC, insert_time " +
+                        " LIMIT 10"));
 
         assertThat(new DateTime(getSource(hits.getJSONObject(0)).get("insert_time"), DateTimeZone.UTC),
                 is(new DateTime("2014-08-24T07:00:55.481Z", DateTimeZone.UTC)));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
@@ -87,16 +87,6 @@ public class DateFormatTest {
         assertThat(ip.getType(), is("ASC"));
     }
 
-    public Select getSelect(String query) {
-        ElasticSqlExprParser parser = new ElasticSqlExprParser(query);
-        SQLQueryExpr expr = (SQLQueryExpr) parser.expr();
-        try {
-            return new SqlParser().parseSelect(expr);
-        } catch (SqlParseException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @Test
     @Ignore("06/27/2019: During implementing of ORDER BY date_format found that this fails as well. " +
             "Will investigate after order by fix submitted, to scope amount of fixes.")
@@ -165,6 +155,14 @@ public class DateFormatTest {
             throw new ParserException("Illegal sql: " + sql);
         }
         return (SQLQueryExpr) expr;
+    }
+
+    private Select getSelect(String query) {
+        try {
+            return new SqlParser().parseSelect(parseSql(query));
+        } catch (SqlParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private <T, U> Matcher<Iterable<? super T>> hasQueryWithValue(String name, Matcher<? super U> matcher) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
@@ -76,13 +76,13 @@ public class DateFormatTest {
 
         Order formula = orderBys.get(0);
 
-        assertThat(formula.isScriptField(), is(true));
+        assertThat(formula.isScript(), is(true));
         assertThat(formula.getType(), is("DESC"));
         assertThat(formula.getName(), containsString("DateTimeFormatter.ofPattern"));
 
         Order ip = orderBys.get(1);
 
-        assertThat(ip.isScriptField(), is(false));
+        assertThat(ip.isScript(), is(false));
         assertThat(ip.getName(), is("ip"));
         assertThat(ip.getType(), is("ASC"));
     }


### PR DESCRIPTION
*Issue #, if available: [103](https://github.com/opendistro-for-elasticsearch/sql/issues/103)

*Description of changes:Performing analysis of sorted field, and if it's "script" field then generate "script" order by

Testing: unit test, integration test, manual testing via Kibana on local elasticsearch instance


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
