### PR TITLE
Locale root

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/StringUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/StringUtils.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.utils;
+
+import java.util.Locale;
+
+public class StringUtils {
+
+    public static String format(final String format, Object... args) {
+
+        return String.format(Locale.ROOT, format, args);
+    }
+
+    public static String toLower(final String input) {
+
+        return input.toLowerCase(Locale.ROOT);
+    }
+
+    public static String toUpper(final String input) {
+
+        return input.toUpperCase(Locale.ROOT);
+    }
+
+    private StringUtils() {
+
+        throw new AssertionError(getClass().getCanonicalName() + " is a utility class and must not be initialized");
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/StringUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/StringUtils.java
@@ -17,25 +17,70 @@ package com.amazon.opendistroforelasticsearch.sql.utils;
 
 import java.util.Locale;
 
+/**
+ * Helper class for wrapping locale-dependent methods
+ * of {@link String} class in equivalent locale-independent
+ * methods which always use {@link Locale#ROOT|.
+ */
 public class StringUtils {
 
+    /**
+     * Returns a formatted string using the specified format string and
+     * arguments, as well as the {@link Locale#ROOT} locale.
+     *
+     * @param  format
+     *         format string
+     *
+     * @param  args
+     *         arguments referenced by the format specifiers in the format string
+     *
+     * @throws  java.util.IllegalFormatException
+     *          If a format string contains an illegal syntax, a format
+     *          specifier that is incompatible with the given arguments,
+     *          insufficient arguments given the format string, or other
+     *          illegal conditions.
+     *
+     * @return  A formatted string
+     *
+     * @see java.lang.String#format(Locale, String, Object...)
+     */
     public static String format(final String format, Object... args) {
-
         return String.format(Locale.ROOT, format, args);
     }
 
+    /**
+     * Converts all of the characters in this {@code String} to lower
+     * case using the rules of the {@link Locale#ROOT} locale. This is equivalent to calling
+     * {@link String#toLowerCase(Locale)} with {@link Locale#ROOT}.
+     *
+     * @param input
+     *        the input String
+     *
+     * @return  the {@code String}, converted to lowercase
+     *
+     * @see     java.lang.String#toLowerCase(Locale)
+     */
     public static String toLower(final String input) {
-
         return input.toLowerCase(Locale.ROOT);
     }
 
+    /**
+     * Converts all of the characters in this {@code String} to upper
+     * case using the rules of the {@link Locale#ROOT} locale. This is equivalent to calling
+     * {@link String#toUpperCase(Locale)} with {@link Locale#ROOT}.
+     *
+     * @param input
+     *        the input String
+     *
+     * @return  the {@code String}, converted to uppercase
+     *
+     * @see     java.lang.String#toUpperCase(Locale)
+     */
     public static String toUpper(final String input) {
-
         return input.toUpperCase(Locale.ROOT);
     }
 
     private StringUtils() {
-
         throw new AssertionError(getClass().getCanonicalName() + " is a utility class and must not be initialized");
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/AggregationIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/AggregationIT.java
@@ -56,8 +56,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void countTest() throws IOException {
-
+    public void countTest() throws Exception {
         JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getIntAggregationValue(result, "COUNT(*)", "value"), equalTo(1000));
@@ -65,7 +64,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void countWithDocsHintTest() throws Exception {
-
         JSONObject result = executeQuery(format("SELECT /*! DOCS_WITH_AGGREGATION(10) */ count(*) from %s/account",
                 TEST_INDEX_ACCOUNT));
         JSONArray hits = (JSONArray)result.query("/hits/hits");
@@ -73,40 +71,35 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void sumTest() throws IOException {
-
+    public void sumTest() throws Exception {
         JSONObject result = executeQuery(format("SELECT SUM(balance) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getDoubleAggregationValue(result, "SUM(balance)", "value"), equalTo(25714837.0));
     }
 
     @Test
-    public void minTest() throws IOException {
-
+    public void minTest() throws Exception {
         JSONObject result = executeQuery(format("SELECT MIN(age) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getDoubleAggregationValue(result, "MIN(age)", "value"), equalTo(20.0));
     }
 
     @Test
-    public void maxTest() throws IOException {
-
+    public void maxTest() throws Exception {
         JSONObject result = executeQuery(format("SELECT MAX(age) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getDoubleAggregationValue(result, "MAX(age)", "value"), equalTo(40.0));
     }
 
     @Test
-    public void avgTest() throws IOException {
-
+    public void avgTest() throws Exception {
         JSONObject result = executeQuery(format("SELECT AVG(age) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getDoubleAggregationValue(result, "AVG(age)", "value"), equalTo(30.171));
     }
 
     @Test
-    public void statsTest() throws IOException {
-
+    public void statsTest() throws Exception {
         JSONObject result = executeQuery(format("SELECT STATS(age) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getIntAggregationValue(result, "STATS(age)", "count"), equalTo(1000));
@@ -117,8 +110,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void extendedStatsTest() throws IOException {
-
+    public void extendedStatsTest() throws Exception {
         JSONObject result = executeQuery(format("SELECT EXTENDED_STATS(age) FROM %s/account",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
@@ -135,8 +127,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void percentileTest() throws IOException {
-
+    public void percentileTest() throws Exception {
         JSONObject result = executeQuery(format("SELECT PERCENTILES(age) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertEquals(20.0, getDoubleAggregationValue(result, "PERCENTILES(age)", "values", "1.0"), 0.001);
@@ -150,8 +141,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void percentileTestSpecific() throws IOException {
-
+    public void percentileTestSpecific() throws Exception {
         JSONObject result = executeQuery(format("SELECT PERCENTILES(age,25.0,75.0) FROM %s/account",
                 TEST_INDEX_ACCOUNT));
 
@@ -163,8 +153,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void aliasTest() throws IOException {
-
+    public void aliasTest() throws Exception {
         JSONObject result = executeQuery(format("SELECT COUNT(*) AS mycount FROM %s/account",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
@@ -173,7 +162,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void groupByTest() throws Exception {
-
         JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY gender",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
@@ -195,7 +183,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void postFilterTest() throws Exception {
-
         JSONObject result = executeQuery(format("SELECT /*! POST_FILTER({\\\"term\\\":" +
                         "{\\\"gender\\\":\\\"m\\\"}}) */ COUNT(*) FROM %s/account GROUP BY gender",
                 TEST_INDEX_ACCOUNT));
@@ -218,7 +205,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void multipleGroupByTest() throws Exception {
-
         JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY gender," +
                         " terms('field'='age','size'=200,'alias'='age')",
                 TEST_INDEX_ACCOUNT));
@@ -252,7 +238,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void multipleGroupBysWithSize() throws Exception {
-
         JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY gender," +
                         " terms('alias'='ageAgg','field'='age','size'=3)",
                 TEST_INDEX_ACCOUNT));
@@ -269,7 +254,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void termsWithSize() throws Exception {
-
         JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY terms" +
                         "('alias'='ageAgg','field'='age','size'=3)",
                 TEST_INDEX_ACCOUNT));
@@ -280,7 +264,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void termsWithMissing() throws Exception {
-
         JSONObject result = executeQuery(format("SELECT count(*) FROM %s/gotCharacters GROUP BY terms" +
                         "('alias'='nick','field'='nickname','missing'='no_nickname')",
                 TEST_INDEX_GAME_OF_THRONES));
@@ -300,7 +283,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void termsWithOrder() throws Exception {
-
         final String dog1 = "snoopy";
         final String dog2 = "rex";
 
@@ -326,8 +308,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void orderByAscTest() throws IOException {
-
+    public void orderByAscTest() throws Exception {
         JSONObject result = executeQuery(format(
                 "SELECT COUNT(*) FROM %s/account GROUP BY age ORDER BY COUNT(*)",
                 TEST_INDEX_ACCOUNT));
@@ -350,8 +331,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void orderByDescTest() throws IOException {
-
+    public void orderByDescTest() throws Exception {
         JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY age" +
                 " ORDER BY COUNT(*) DESC", TEST_INDEX_ACCOUNT));
         JSONObject ageAgg = getAggregation(result, "age");
@@ -373,8 +353,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void limitTest() throws IOException {
-
+    public void limitTest() throws Exception {
         JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY age" +
                 " ORDER BY COUNT(*) LIMIT 5", TEST_INDEX_ACCOUNT));
         JSONObject ageAgg = getAggregation(result, "age");
@@ -383,8 +362,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void countGroupByRange() throws IOException {
-
+    public void countGroupByRange() throws Exception {
         JSONObject result = executeQuery(format("SELECT COUNT(age) FROM %s/account" +
                 " GROUP BY range(age, 20,25,30,35,40)", TEST_INDEX_ACCOUNT));
         JSONObject ageAgg = getAggregation(result, "range(age,20,25,30,35,40)");
@@ -394,7 +372,6 @@ public class AggregationIT extends SQLIntegTestCase {
         final int[] expectedResults = new int[] {225, 226, 259, 245};
 
         for (int i = 0; i < expectedResults.length; ++i) {
-
             Assert.assertThat(buckets.query(format("/%d/COUNT(age)/value", i)),
                     equalTo(expectedResults[i]));
         }
@@ -404,8 +381,7 @@ public class AggregationIT extends SQLIntegTestCase {
      * <a>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html</a>
      */
     @Test
-    public void countGroupByDateTest() throws IOException {
-
+    public void countGroupByDateTest() throws Exception {
         String result = explainQuery(format("select insert_time from %s group by date_histogram" +
                 "(field='insert_time','interval'='1.5h','format'='yyyy-MM','min_doc_count'=5) ", TEST_INDEX_ONLINE));
         Assert.assertThat(result.replaceAll("\\s+", ""),
@@ -435,8 +411,7 @@ public class AggregationIT extends SQLIntegTestCase {
 //    }
 
     @Test
-    public void topHitTest() throws IOException {
-
+    public void topHitTest() throws Exception {
         String query = format("select topHits('size'=3,age='desc') from %s group by gender",
                 TEST_INDEX_ACCOUNT);
         JSONObject result = executeQuery(query);
@@ -466,8 +441,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void topHitTest_WithInclude() throws IOException {
-
+    public void topHitTest_WithInclude() throws Exception {
         String query = format("select topHits('size'=3,age='desc',include=age) from %s/account group by gender",
                 TEST_INDEX_ACCOUNT);
         JSONObject result = executeQuery(query);
@@ -512,8 +486,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void topHitTest_WithIncludeTwoFields() throws IOException {
-
+    public void topHitTest_WithIncludeTwoFields() throws Exception {
         String query = format("select topHits('size'=3,'include'='age,firstname',age='desc') from %s/account " +
                         "group by gender", TEST_INDEX_ACCOUNT);
         JSONObject result = executeQuery(query);
@@ -535,8 +508,7 @@ public class AggregationIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void topHitTest_WithExclude() throws IOException {
-
+    public void topHitTest_WithExclude() throws Exception {
         String query = format("select topHits('size'=3,'exclude'='lastname',age='desc') from " +
                 "%s/account group by gender", TEST_INDEX_ACCOUNT);
         JSONObject result = executeQuery(query);
@@ -857,7 +829,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void groupByOnNestedFieldWithFilterTest() throws Exception {
-
         String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
                 "filter('myFilter',message.info = 'a')", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
@@ -874,7 +845,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void minOnNestedField() throws Exception {
-
         String query = format("SELECT min(nested(message.dayOfWeek)) as minDays FROM %s/nestedType",
                                         TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
@@ -884,7 +854,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void sumOnNestedField() throws Exception {
-
         String query = format("SELECT sum(nested(message.dayOfWeek)) as sumDays FROM %s/nestedType",
                                         TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
@@ -894,7 +863,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void histogramOnNestedField() throws Exception {
-
         String query = format("select count(*) from %s/nestedType group by histogram" +
                 "('field'='message.dayOfWeek','nested'='message','interval'='2' , 'alias' = 'someAlias' )",
                 TEST_INDEX_NESTED_TYPE);
@@ -921,7 +889,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void reverseToRootGroupByOnNestedFieldWithFilterTestWithReverseNestedAndEmptyPath() throws Exception {
-
         String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
                 "filter('myFilter',message.info = 'a'),reverse_nested(someField,'')", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
@@ -940,7 +907,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void reverseToRootGroupByOnNestedFieldWithFilterTestWithReverseNestedNoPath() throws Exception {
-
         String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info),filter" +
                 "('myFilter',message.info = 'a'),reverse_nested(someField)", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
@@ -959,7 +925,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void reverseToRootGroupByOnNestedFieldWithFilterTestWithReverseNestedOnHistogram() throws Exception {
-
         String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
                 "filter('myFilter',message.info = 'a'),histogram('field'='myNum','reverse_nested'='','interval'='2', " +
                 "'alias' = 'someAlias' )", TEST_INDEX_NESTED_TYPE);
@@ -990,7 +955,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void reverseToRootGroupByOnNestedFieldWithFilterAndSumOnReverseNestedField() throws Exception {
-
         String query = format("SELECT sum(reverse_nested(myNum)) bla FROM %s/nestedType GROUP BY " +
                 "nested(message.info),filter('myFilter',message.info = 'a')", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
@@ -1007,7 +971,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void reverseAnotherNestedGroupByOnNestedFieldWithFilterTestWithReverseNestedNoPath() throws Exception {
-
         String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
                 "filter('myFilter',message.info = 'a'),reverse_nested(comment.data,'~comment')",
                 TEST_INDEX_NESTED_TYPE);
@@ -1028,7 +991,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void reverseAnotherNestedGroupByOnNestedFieldWithFilterTestWithReverseNestedOnHistogram() throws Exception {
-
         String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info),filter" +
                 "('myFilter',message.info = 'a'),histogram('field'='comment.likes','reverse_nested'='~comment'," +
                 "'interval'='2' , 'alias' = 'someAlias' )", TEST_INDEX_NESTED_TYPE);
@@ -1059,7 +1021,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void reverseAnotherNestedGroupByOnNestedFieldWithFilterAndSumOnReverseNestedField() throws Exception {
-
         String query = format("SELECT sum(reverse_nested(comment.likes,'~comment')) bla FROM %s/nestedType " +
                 "GROUP BY  nested(message.info),filter('myFilter',message.info = 'a')", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
@@ -1134,7 +1095,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     private int getIntAggregationValue(final JSONObject queryResult, final String aggregationName,
                                        final String fieldName) {
-
         final JSONObject targetAggregation = getAggregation(queryResult, aggregationName);
         Assert.assertTrue(targetAggregation.has(fieldName));
         return targetAggregation.getInt(fieldName);
@@ -1142,7 +1102,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     private double getDoubleAggregationValue(final JSONObject queryResult, final String aggregationName,
                                              final String fieldName) {
-
         final JSONObject targetAggregation = getAggregation(queryResult, aggregationName);
         Assert.assertTrue(targetAggregation.has(fieldName));
         return targetAggregation.getDouble(fieldName);
@@ -1150,7 +1109,6 @@ public class AggregationIT extends SQLIntegTestCase {
 
     private double getDoubleAggregationValue(final JSONObject queryResult, final String aggregationName,
                                              final String fieldName, final String subFieldName) {
-
         final JSONObject targetAggregation = getAggregation(queryResult, aggregationName);
         Assert.assertTrue(targetAggregation.has(fieldName));
         final JSONObject targetField = targetAggregation.getJSONObject(fieldName);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/AggregationIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/AggregationIT.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -37,6 +36,7 @@ import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstant
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_GAME_OF_THRONES;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_NESTED_TYPE;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ONLINE;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -58,7 +58,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void countTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT COUNT(*) FROM %s/account", TEST_INDEX_ACCOUNT));
+        JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getIntAggregationValue(result, "COUNT(*)", "value"), equalTo(1000));
     }
@@ -66,7 +66,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void countWithDocsHintTest() throws Exception {
 
-        JSONObject result = executeQuery(String.format("SELECT /*! DOCS_WITH_AGGREGATION(10) */ count(*) from %s/account",
+        JSONObject result = executeQuery(format("SELECT /*! DOCS_WITH_AGGREGATION(10) */ count(*) from %s/account",
                 TEST_INDEX_ACCOUNT));
         JSONArray hits = (JSONArray)result.query("/hits/hits");
         Assert.assertThat(hits.length(), equalTo(10));
@@ -75,7 +75,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void sumTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT SUM(balance) FROM %s/account", TEST_INDEX_ACCOUNT));
+        JSONObject result = executeQuery(format("SELECT SUM(balance) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getDoubleAggregationValue(result, "SUM(balance)", "value"), equalTo(25714837.0));
     }
@@ -83,7 +83,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void minTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT MIN(age) FROM %s/account", TEST_INDEX_ACCOUNT));
+        JSONObject result = executeQuery(format("SELECT MIN(age) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getDoubleAggregationValue(result, "MIN(age)", "value"), equalTo(20.0));
     }
@@ -91,7 +91,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void maxTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT MAX(age) FROM %s/account", TEST_INDEX_ACCOUNT));
+        JSONObject result = executeQuery(format("SELECT MAX(age) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getDoubleAggregationValue(result, "MAX(age)", "value"), equalTo(40.0));
     }
@@ -99,7 +99,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void avgTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT AVG(age) FROM %s/account", TEST_INDEX_ACCOUNT));
+        JSONObject result = executeQuery(format("SELECT AVG(age) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getDoubleAggregationValue(result, "AVG(age)", "value"), equalTo(30.171));
     }
@@ -107,7 +107,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void statsTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT STATS(age) FROM %s/account", TEST_INDEX_ACCOUNT));
+        JSONObject result = executeQuery(format("SELECT STATS(age) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getIntAggregationValue(result, "STATS(age)", "count"), equalTo(1000));
         Assert.assertThat(getDoubleAggregationValue(result, "STATS(age)", "min"), equalTo(20.0));
@@ -119,22 +119,25 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void extendedStatsTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT EXTENDED_STATS(age) FROM %s/account",
+        JSONObject result = executeQuery(format("SELECT EXTENDED_STATS(age) FROM %s/account",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getDoubleAggregationValue(result, "EXTENDED_STATS(age)", "min"), equalTo(20.0));
         Assert.assertThat(getDoubleAggregationValue(result, "EXTENDED_STATS(age)", "max"), equalTo(40.0));
         Assert.assertThat(getDoubleAggregationValue(result, "EXTENDED_STATS(age)", "avg"), equalTo(30.171));
         Assert.assertThat(getDoubleAggregationValue(result, "EXTENDED_STATS(age)", "sum"), equalTo(30171.0));
-        Assert.assertThat(getDoubleAggregationValue(result, "EXTENDED_STATS(age)", "sum_of_squares"), equalTo(946393.0));
-        Assert.assertEquals(6.008640362012022, getDoubleAggregationValue(result, "EXTENDED_STATS(age)", "std_deviation"), 0.0001);
-        Assert.assertEquals(36.10375899999996, getDoubleAggregationValue(result, "EXTENDED_STATS(age)", "variance"), 0.0001);
+        Assert.assertThat(getDoubleAggregationValue(result, "EXTENDED_STATS(age)", "sum_of_squares"),
+                equalTo(946393.0));
+        Assert.assertEquals(6.008640362012022,
+                getDoubleAggregationValue(result, "EXTENDED_STATS(age)", "std_deviation"), 0.0001);
+        Assert.assertEquals(36.10375899999996, getDoubleAggregationValue(result, "EXTENDED_STATS(age)", "variance"),
+                0.0001);
     }
 
     @Test
     public void percentileTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT PERCENTILES(age) FROM %s/account", TEST_INDEX_ACCOUNT));
+        JSONObject result = executeQuery(format("SELECT PERCENTILES(age) FROM %s/account", TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertEquals(20.0, getDoubleAggregationValue(result, "PERCENTILES(age)", "values", "1.0"), 0.001);
         Assert.assertEquals(21.0, getDoubleAggregationValue(result, "PERCENTILES(age)", "values", "5.0"), 0.001);
@@ -149,18 +152,20 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void percentileTestSpecific() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT PERCENTILES(age,25.0,75.0) FROM %s/account",
+        JSONObject result = executeQuery(format("SELECT PERCENTILES(age,25.0,75.0) FROM %s/account",
                 TEST_INDEX_ACCOUNT));
 
         Assert.assertThat(getTotalHits(result), equalTo(1000));
-        Assert.assertEquals(25.0, getDoubleAggregationValue(result, "PERCENTILES(age,25.0,75.0)", "values", "25.0"), 0.001);
-        Assert.assertEquals(35.0, getDoubleAggregationValue(result, "PERCENTILES(age,25.0,75.0)", "values", "75.0"), 0.001);
+        Assert.assertEquals(25.0, getDoubleAggregationValue(result, "PERCENTILES(age,25.0,75.0)", "values", "25.0"),
+                0.001);
+        Assert.assertEquals(35.0, getDoubleAggregationValue(result, "PERCENTILES(age,25.0,75.0)", "values", "75.0"),
+                0.001);
     }
 
     @Test
     public void aliasTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT COUNT(*) AS mycount FROM %s/account",
+        JSONObject result = executeQuery(format("SELECT COUNT(*) AS mycount FROM %s/account",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         Assert.assertThat(getIntAggregationValue(result, "mycount", "value"), equalTo(1000));
@@ -169,7 +174,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void groupByTest() throws Exception {
 
-        JSONObject result = executeQuery(String.format("SELECT COUNT(*) FROM %s/account GROUP BY gender",
+        JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY gender",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
         JSONObject gender = getAggregation(result, "gender");
@@ -179,8 +184,8 @@ public class AggregationIT extends SQLIntegTestCase {
         final int maleBucketId = isMaleFirst ? 0 : 1;
         final int femaleBucketId = isMaleFirst ? 1 : 0;
 
-        final String maleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", maleBucketId);
-        final String femaleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", femaleBucketId);
+        final String maleBucketPrefix = format("/buckets/%d", maleBucketId);
+        final String femaleBucketPrefix = format("/buckets/%d", femaleBucketId);
 
         Assert.assertThat(gender.query(maleBucketPrefix + "/key"), equalTo("m"));
         Assert.assertThat(gender.query(maleBucketPrefix + "/COUNT(*)/value"), equalTo(507));
@@ -191,7 +196,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void postFilterTest() throws Exception {
 
-        JSONObject result = executeQuery(String.format("SELECT /*! POST_FILTER({\\\"term\\\":" +
+        JSONObject result = executeQuery(format("SELECT /*! POST_FILTER({\\\"term\\\":" +
                         "{\\\"gender\\\":\\\"m\\\"}}) */ COUNT(*) FROM %s/account GROUP BY gender",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(507));
@@ -202,8 +207,8 @@ public class AggregationIT extends SQLIntegTestCase {
         final int maleBucketId = isMaleFirst ? 0 : 1;
         final int femaleBucketId = isMaleFirst ? 1 : 0;
 
-        final String maleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", maleBucketId);
-        final String femaleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", femaleBucketId);
+        final String maleBucketPrefix = format("/buckets/%d", maleBucketId);
+        final String femaleBucketPrefix = format("/buckets/%d", femaleBucketId);
 
         Assert.assertThat(gender.query(maleBucketPrefix + "/key"), equalTo("m"));
         Assert.assertThat(gender.query(maleBucketPrefix + "/COUNT(*)/value"), equalTo(507));
@@ -214,7 +219,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void multipleGroupByTest() throws Exception {
 
-        JSONObject result = executeQuery(String.format("SELECT COUNT(*) FROM %s/account GROUP BY gender," +
+        JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY gender," +
                         " terms('field'='age','size'=200,'alias'='age')",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
@@ -225,13 +230,14 @@ public class AggregationIT extends SQLIntegTestCase {
         final int maleBucketId = isMaleFirst ? 0 : 1;
         final int femaleBucketId = isMaleFirst ? 1 : 0;
 
-        final String maleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", maleBucketId);
-        final String femaleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", femaleBucketId);
+        final String maleBucketPrefix = format("/buckets/%d", maleBucketId);
+        final String femaleBucketPrefix = format("/buckets/%d", femaleBucketId);
 
         final JSONArray mAgeBuckets = (JSONArray)(gender.optQuery(maleBucketPrefix + "/age/buckets"));
         final JSONArray fAgeBuckets = (JSONArray)(gender.optQuery(femaleBucketPrefix + "/age/buckets"));
 
-        final Set<Integer> expectedAges = IntStream.range(20, 41).boxed().collect(Collectors.toCollection(HashSet::new));
+        final Set<Integer> expectedAges = IntStream.range(20, 41).boxed()
+                .collect(Collectors.toCollection(HashSet::new));
         Assert.assertThat(mAgeBuckets.length(), equalTo(expectedAges.size()));
         Assert.assertThat(fAgeBuckets.length(), equalTo(expectedAges.size()));
 
@@ -247,7 +253,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void multipleGroupBysWithSize() throws Exception {
 
-        JSONObject result = executeQuery(String.format("SELECT COUNT(*) FROM %s/account GROUP BY gender," +
+        JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY gender," +
                         " terms('alias'='ageAgg','field'='age','size'=3)",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
@@ -264,7 +270,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void termsWithSize() throws Exception {
 
-        JSONObject result = executeQuery(String.format("SELECT COUNT(*) FROM %s/account GROUP BY terms" +
+        JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY terms" +
                         "('alias'='ageAgg','field'='age','size'=3)",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(getTotalHits(result), equalTo(1000));
@@ -275,7 +281,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void termsWithMissing() throws Exception {
 
-        JSONObject result = executeQuery(String.format("SELECT count(*) FROM %s/gotCharacters GROUP BY terms" +
+        JSONObject result = executeQuery(format("SELECT count(*) FROM %s/gotCharacters GROUP BY terms" +
                         "('alias'='nick','field'='nickname','missing'='no_nickname')",
                 TEST_INDEX_GAME_OF_THRONES));
         JSONObject nick = getAggregation(result, "nick");
@@ -298,7 +304,7 @@ public class AggregationIT extends SQLIntegTestCase {
         final String dog1 = "snoopy";
         final String dog2 = "rex";
 
-        JSONObject result = executeQuery(String.format("SELECT count(*) FROM %s/dog GROUP BY terms" +
+        JSONObject result = executeQuery(format("SELECT count(*) FROM %s/dog GROUP BY terms" +
                         "('field'='dog_name', 'alias'='dog_name', order='desc')",
                 TEST_INDEX_DOG));
         JSONObject dogName = getAggregation(result, "dog_name");
@@ -308,7 +314,7 @@ public class AggregationIT extends SQLIntegTestCase {
         Assert.assertThat(firstDog, equalTo(dog1));
         Assert.assertThat(secondDog, equalTo(dog2));
 
-        result = executeQuery(String.format("SELECT count(*) FROM %s/dog GROUP BY terms" +
+        result = executeQuery(format("SELECT count(*) FROM %s/dog GROUP BY terms" +
                 "('field'='dog_name', 'alias'='dog_name', order='asc')", TEST_INDEX_DOG));
 
         dogName = getAggregation(result, "dog_name");
@@ -322,7 +328,8 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void orderByAscTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT COUNT(*) FROM %s/account GROUP BY age ORDER BY COUNT(*)",
+        JSONObject result = executeQuery(format(
+                "SELECT COUNT(*) FROM %s/account GROUP BY age ORDER BY COUNT(*)",
                 TEST_INDEX_ACCOUNT));
         JSONObject ageAgg = getAggregation(result, "age");
         JSONArray buckets = ageAgg.getJSONArray("buckets");
@@ -330,7 +337,7 @@ public class AggregationIT extends SQLIntegTestCase {
         int previousBucketCount = 0;
         int currentBucketCount;
         for (int i = 0; i < buckets.length(); ++i) {
-            currentBucketCount = (int) buckets.query(String.format(Locale.ROOT, "/%d/COUNT(*)/value", i));
+            currentBucketCount = (int) buckets.query(format("/%d/COUNT(*)/value", i));
 
             if (0 == i) {
                 previousBucketCount = currentBucketCount;
@@ -345,7 +352,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void orderByDescTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT COUNT(*) FROM %s/account GROUP BY age" +
+        JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY age" +
                 " ORDER BY COUNT(*) DESC", TEST_INDEX_ACCOUNT));
         JSONObject ageAgg = getAggregation(result, "age");
         JSONArray buckets = ageAgg.getJSONArray("buckets");
@@ -353,7 +360,7 @@ public class AggregationIT extends SQLIntegTestCase {
         int previousBucketCount = 0;
         int currentBucketCount;
         for (int i = 0; i < buckets.length(); ++i) {
-            currentBucketCount = (int) buckets.query(String.format(Locale.ROOT, "/%d/COUNT(*)/value", i));
+            currentBucketCount = (int) buckets.query(format("/%d/COUNT(*)/value", i));
 
             if (0 == i) {
                 previousBucketCount = currentBucketCount;
@@ -368,7 +375,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void limitTest() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT COUNT(*) FROM %s/account GROUP BY age" +
+        JSONObject result = executeQuery(format("SELECT COUNT(*) FROM %s/account GROUP BY age" +
                 " ORDER BY COUNT(*) LIMIT 5", TEST_INDEX_ACCOUNT));
         JSONObject ageAgg = getAggregation(result, "age");
         JSONArray buckets = ageAgg.getJSONArray("buckets");
@@ -378,7 +385,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void countGroupByRange() throws IOException {
 
-        JSONObject result = executeQuery(String.format("SELECT COUNT(age) FROM %s/account" +
+        JSONObject result = executeQuery(format("SELECT COUNT(age) FROM %s/account" +
                 " GROUP BY range(age, 20,25,30,35,40)", TEST_INDEX_ACCOUNT));
         JSONObject ageAgg = getAggregation(result, "range(age,20,25,30,35,40)");
         JSONArray buckets = ageAgg.getJSONArray("buckets");
@@ -388,7 +395,7 @@ public class AggregationIT extends SQLIntegTestCase {
 
         for (int i = 0; i < expectedResults.length; ++i) {
 
-            Assert.assertThat(buckets.query(String.format(Locale.ROOT, "/%d/COUNT(age)/value", i)),
+            Assert.assertThat(buckets.query(format("/%d/COUNT(age)/value", i)),
                     equalTo(expectedResults[i]));
         }
     }
@@ -399,7 +406,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void countGroupByDateTest() throws IOException {
 
-        String result = explainQuery(String.format("select insert_time from %s group by date_histogram" +
+        String result = explainQuery(format("select insert_time from %s group by date_histogram" +
                 "(field='insert_time','interval'='1.5h','format'='yyyy-MM','min_doc_count'=5) ", TEST_INDEX_ONLINE));
         Assert.assertThat(result.replaceAll("\\s+", ""),
                 containsString("{\"date_histogram\":{\"field\":\"insert_time\",\"format\":\"yyyy-MM\"," +
@@ -409,7 +416,7 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void countGroupByDateTestWithAlias() throws IOException {
-        String result = explainQuery(String.format("select insert_time from %s group by date_histogram" +
+        String result = explainQuery(format("select insert_time from %s group by date_histogram" +
                 "(field='insert_time','interval'='1.5h','format'='yyyy-MM','alias'='myAlias')", TEST_INDEX_ONLINE));
         Assert.assertThat(result.replaceAll("\\s+",""),
                 containsString("myAlias\":{\"date_histogram\":{\"field\":\"insert_time\"," +
@@ -421,43 +428,16 @@ public class AggregationIT extends SQLIntegTestCase {
 //     */
 //    @Test
 //    public void countDateRangeTest() throws IOException, SqlParseException, SQLFeatureNotSupportedException {
-//        String result = explainQuery(String.format("select online from %s group by date_range(field='insert_time'," +
-//                "'format'='yyyy-MM-dd' ,'2014-08-18','2014-08-17','now-8d','now-7d','now-6d','now')",
-//                TEST_INDEX_ONLINE));
+//        String result = explainQuery(format("select online from %s group by " +
+//                "date_range(field='insert_time','format'='yyyy-MM-dd' ,'2014-08-18','2014-08-17'," +
+//                "'now-8d','now-7d','now-6d','now')", TEST_INDEX_ONLINE));
 //        // TODO: fix the query or fix the code for the query to work
 //    }
 
     @Test
     public void topHitTest() throws IOException {
 
-        String query = String.format("select topHits('size'=3,age='desc') from %s group by gender", TEST_INDEX_ACCOUNT);
-        JSONObject result = executeQuery(query);
-        JSONObject gender = getAggregation(result, "gender");
-        Assert.assertThat(gender.getJSONArray("buckets").length(), equalTo(2));
-
-        final boolean isMaleFirst = gender.optQuery("/buckets/0/key").equals("m");
-        final int maleBucketId = isMaleFirst ? 0 : 1;
-        final int femaleBucketId = isMaleFirst ? 1 : 0;
-
-        final String maleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", maleBucketId);
-        final String femaleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", femaleBucketId);
-
-        Assert.assertThat(gender.query(maleBucketPrefix + "/key"), equalTo("m"));
-        Assert.assertThat(gender.query(maleBucketPrefix + "/topHits(size=3,age=desc)/hits/total/value"),equalTo(507));
-        Assert.assertThat(gender.query(maleBucketPrefix + "/topHits(size=3,age=desc)/hits/total/relation"),equalTo("eq"));
-        Assert.assertThat(((JSONArray)gender.query(maleBucketPrefix + "/topHits(size=3,age=desc)/hits/hits")).length(),
-                equalTo(3));
-        Assert.assertThat(gender.query(femaleBucketPrefix + "/key"), equalTo("f"));
-        Assert.assertThat(gender.query(femaleBucketPrefix + "/topHits(size=3,age=desc)/hits/total/value"), equalTo(493));
-        Assert.assertThat(gender.query(femaleBucketPrefix + "/topHits(size=3,age=desc)/hits/total/relation"), equalTo("eq"));
-        Assert.assertThat(((JSONArray)gender.query(femaleBucketPrefix + "/topHits(size=3,age=desc)/hits/hits")).length(),
-                equalTo(3));
-    }
-
-    @Test
-    public void topHitTest_WithInclude() throws IOException {
-
-        String query = String.format("select topHits('size'=3,age='desc',include=age) from %s/account group by gender",
+        String query = format("select topHits('size'=3,age='desc') from %s group by gender",
                 TEST_INDEX_ACCOUNT);
         JSONObject result = executeQuery(query);
         JSONObject gender = getAggregation(result, "gender");
@@ -467,8 +447,39 @@ public class AggregationIT extends SQLIntegTestCase {
         final int maleBucketId = isMaleFirst ? 0 : 1;
         final int femaleBucketId = isMaleFirst ? 1 : 0;
 
-        final String maleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", maleBucketId);
-        final String femaleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", femaleBucketId);
+        final String maleBucketPrefix = format("/buckets/%d", maleBucketId);
+        final String femaleBucketPrefix = format("/buckets/%d", femaleBucketId);
+
+        Assert.assertThat(gender.query(maleBucketPrefix + "/key"), equalTo("m"));
+        Assert.assertThat(gender.query(maleBucketPrefix + "/topHits(size=3,age=desc)/hits/total/value"), equalTo(507));
+        Assert.assertThat(gender.query(maleBucketPrefix + "/topHits(size=3,age=desc)/hits/total/relation"),
+                equalTo("eq"));
+        Assert.assertThat(((JSONArray)gender.query(maleBucketPrefix + "/topHits(size=3,age=desc)/hits/hits")).length(),
+                equalTo(3));
+        Assert.assertThat(gender.query(femaleBucketPrefix + "/key"), equalTo("f"));
+        Assert.assertThat(gender.query(femaleBucketPrefix + "/topHits(size=3,age=desc)/hits/total/value"),
+                equalTo(493));
+        Assert.assertThat(gender.query(femaleBucketPrefix + "/topHits(size=3,age=desc)/hits/total/relation"),
+                equalTo("eq"));
+        final Object hits = gender.query(femaleBucketPrefix + "/topHits(size=3,age=desc)/hits/hits");
+        Assert.assertThat(((JSONArray)hits).length(), equalTo(3));
+    }
+
+    @Test
+    public void topHitTest_WithInclude() throws IOException {
+
+        String query = format("select topHits('size'=3,age='desc',include=age) from %s/account group by gender",
+                TEST_INDEX_ACCOUNT);
+        JSONObject result = executeQuery(query);
+        JSONObject gender = getAggregation(result, "gender");
+        Assert.assertThat(gender.getJSONArray("buckets").length(), equalTo(2));
+
+        final boolean isMaleFirst = gender.optQuery("/buckets/0/key").equals("m");
+        final int maleBucketId = isMaleFirst ? 0 : 1;
+        final int femaleBucketId = isMaleFirst ? 1 : 0;
+
+        final String maleBucketPrefix = format("/buckets/%d", maleBucketId);
+        final String femaleBucketPrefix = format("/buckets/%d", femaleBucketId);
 
         Assert.assertThat(gender.query(maleBucketPrefix + "/key"), equalTo("m"));
         Assert.assertThat(gender.query(maleBucketPrefix + "/topHits(size=3,age=desc,include=age)/hits/total/value"),
@@ -482,7 +493,8 @@ public class AggregationIT extends SQLIntegTestCase {
         Assert.assertThat(gender.query(femaleBucketPrefix + "/key"), equalTo("f"));
         Assert.assertThat(gender.query(femaleBucketPrefix + "/topHits(size=3,age=desc,include=age)/hits/total/value"),
                 equalTo(493));
-        Assert.assertThat(gender.query(femaleBucketPrefix + "/topHits(size=3,age=desc,include=age)/hits/total/relation"),
+        Assert.assertThat(gender.query(femaleBucketPrefix +
+                        "/topHits(size=3,age=desc,include=age)/hits/total/relation"),
                 equalTo("eq"));
         Assert.assertThat(((JSONArray)gender.query(
                 femaleBucketPrefix + "/topHits(size=3,age=desc,include=age)/hits/hits")).length(),
@@ -490,7 +502,7 @@ public class AggregationIT extends SQLIntegTestCase {
 
         for (int i = 0; i < 2; ++i) {
             for (int j = 0; j < 3; ++j) {
-                JSONObject source = (JSONObject)gender.query(String.format(Locale.ROOT,
+                JSONObject source = (JSONObject)gender.query(format(
                         "/buckets/%d/topHits(size=3,age=desc,include=age)/hits/hits/%d/_source", i, j));
                 Assert.assertThat(source.length(), equalTo(1));
                 Assert.assertTrue(source.has("age"));
@@ -502,7 +514,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void topHitTest_WithIncludeTwoFields() throws IOException {
 
-        String query = String.format("select topHits('size'=3,'include'='age,firstname',age='desc') from %s/account " +
+        String query = format("select topHits('size'=3,'include'='age,firstname',age='desc') from %s/account " +
                         "group by gender", TEST_INDEX_ACCOUNT);
         JSONObject result = executeQuery(query);
         JSONObject gender = getAggregation(result, "gender");
@@ -510,7 +522,7 @@ public class AggregationIT extends SQLIntegTestCase {
 
         for (int i = 0; i < 2; ++i) {
             for (int j = 0; j < 3; ++j) {
-                JSONObject source = (JSONObject)gender.query(String.format(Locale.ROOT,
+                JSONObject source = (JSONObject)gender.query(format(
                         "/buckets/%d/topHits(size=3,include=age,firstname,age=desc)/hits/hits/%d/_source", i, j));
                 Assert.assertThat(source.length(), equalTo(2));
                 Assert.assertTrue(source.has("age"));
@@ -525,7 +537,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void topHitTest_WithExclude() throws IOException {
 
-        String query = String.format("select topHits('size'=3,'exclude'='lastname',age='desc') from " +
+        String query = format("select topHits('size'=3,'exclude'='lastname',age='desc') from " +
                 "%s/account group by gender", TEST_INDEX_ACCOUNT);
         JSONObject result = executeQuery(query);
         JSONObject gender = getAggregation(result, "gender");
@@ -535,22 +547,26 @@ public class AggregationIT extends SQLIntegTestCase {
         final int maleBucketId = isMaleFirst ? 0 : 1;
         final int femaleBucketId = isMaleFirst ? 1 : 0;
 
-        final String maleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", maleBucketId);
-        final String femaleBucketPrefix = String.format(Locale.ROOT, "/buckets/%d", femaleBucketId);
+        final String maleBucketPrefix = format("/buckets/%d", maleBucketId);
+        final String femaleBucketPrefix = format("/buckets/%d", femaleBucketId);
 
         Assert.assertThat(gender.query(maleBucketPrefix + "/key"), equalTo("m"));
-        Assert.assertThat(gender.query(maleBucketPrefix + "/topHits(size=3,exclude=lastname,age=desc)/hits/total/value"),
+        Assert.assertThat(gender.query(maleBucketPrefix +
+                        "/topHits(size=3,exclude=lastname,age=desc)/hits/total/value"),
                 equalTo(507));
-        Assert.assertThat(gender.query(maleBucketPrefix + "/topHits(size=3,exclude=lastname,age=desc)/hits/total/relation"),
+        Assert.assertThat(gender.query(maleBucketPrefix +
+                        "/topHits(size=3,exclude=lastname,age=desc)/hits/total/relation"),
                 equalTo("eq"));
         Assert.assertThat(((JSONArray)gender.query(
                 maleBucketPrefix + "/topHits(size=3,exclude=lastname,age=desc)/hits/hits")).length(),
                 equalTo(3));
 
         Assert.assertThat(gender.query(femaleBucketPrefix + "/key"), equalTo("f"));
-        Assert.assertThat(gender.query(femaleBucketPrefix + "/topHits(size=3,exclude=lastname,age=desc)/hits/total/value"),
+        Assert.assertThat(gender.query(femaleBucketPrefix +
+                        "/topHits(size=3,exclude=lastname,age=desc)/hits/total/value"),
                 equalTo(493));
-        Assert.assertThat(gender.query(femaleBucketPrefix + "/topHits(size=3,exclude=lastname,age=desc)/hits/total/relation"),
+        Assert.assertThat(gender.query(femaleBucketPrefix +
+                        "/topHits(size=3,exclude=lastname,age=desc)/hits/total/relation"),
                 equalTo("eq"));
         Assert.assertThat(((JSONArray)gender.query(
                 femaleBucketPrefix + "/topHits(size=3,exclude=lastname,age=desc)/hits/hits")).length(),
@@ -571,7 +587,7 @@ public class AggregationIT extends SQLIntegTestCase {
 
         for (int i = 0; i < 2; ++i) {
             for (int j = 0; j < 3; ++j) {
-                JSONObject source = (JSONObject)gender.query(String.format(Locale.ROOT,
+                JSONObject source = (JSONObject)gender.query(format(
                         "/buckets/%d/topHits(size=3,exclude=lastname,age=desc)/hits/hits/%d/_source", i, j));
                 Assert.assertThat(source.length(), equalTo(expectedFields.size()));
                 Assert.assertFalse(source.has("lastname"));
@@ -585,36 +601,40 @@ public class AggregationIT extends SQLIntegTestCase {
     // script on metric aggregation tests. uncomment if your elastic has scripts enable (disabled by default)
 //    @Test
 //    public void sumWithScriptTest() throws IOException, SqlParseException, SQLFeatureNotSupportedException {
-//        Aggregations result = query(String.format("SELECT SUM(script('','doc[\\'balance\\'].value + doc[\\'balance\\'].value')) as doubleSum FROM %s/account", TEST_INDEX));
+//        Aggregations result = query(format("SELECT SUM(script('','doc[\\'balance\\'].value + " +
+//                              "doc[\\'balance\\'].value')) as doubleSum FROM %s/account", TEST_INDEX));
 //        Sum sum = result.get("doubleSum");
 //        assertThat(sum.getValue(), equalTo(25714837.0*2));
 //    }
 //
 //    @Test
 //    public void sumWithImplicitScriptTest() throws IOException, SqlParseException, SQLFeatureNotSupportedException {
-//        Aggregations result = query(String.format("SELECT SUM(balance + balance) as doubleSum FROM %s/account", TEST_INDEX));
+//        Aggregations result = query(format("SELECT SUM(balance + balance) as doubleSum FROM %s/account", TEST_INDEX));
 //        Sum sum = result.get("doubleSum");
 //        assertThat(sum.getValue(), equalTo(25714837.0*2));
 //    }
 //
 //    @Test
 //    public void sumWithScriptTestNoAlias() throws IOException, SqlParseException, SQLFeatureNotSupportedException {
-//        Aggregations result = query(String.format("SELECT SUM(balance + balance) FROM %s/account", TEST_INDEX));
+//        Aggregations result = query(format("SELECT SUM(balance + balance) FROM %s/account", TEST_INDEX));
 //        Sum sum = result.get("SUM(script=script(balance + balance,doc('balance').value + doc('balance').value))");
 //        assertThat(sum.getValue(), equalTo(25714837.0*2));
 //    }
 //
 //    @Test
 //    public void scriptedMetricAggregation() throws SQLFeatureNotSupportedException, SqlParseException {
-//        Aggregations result = query ("select scripted_metric('map_script'='if(doc[\\'balance\\'].value > 49670){ if(!_agg.containsKey(\\'ages\\')) { _agg.put(\\'ages\\',doc[\\'age\\'].value); } " +
+//        Aggregations result = query("select scripted_metric('map_script'='if(doc[\\'balance\\'].value > 49670)" +
+//                "{ if(!_agg.containsKey(\\'ages\\')) { _agg.put(\\'ages\\',doc[\\'age\\'].value); } " +
 //                "else { _agg.put(\\'ages\\',_agg.get(\\'ages\\')+doc[\\'age\\'].value); }}'," +
-//                "'reduce_script'='sumThem = 0; for (a in _aggs) { if(a.containsKey(\\'ages\\')){ sumThem += a.get(\\'ages\\');} }; return sumThem;') as wierdSum from " + TEST_INDEX + "/account");
+//                "'reduce_script'='sumThem = 0; for (a in _aggs) { if(a.containsKey(\\'ages\\'))" +
+//                "{ sumThem += a.get(\\'ages\\');} }; return sumThem;') as wierdSum from " + TEST_INDEX + "/account");
 //        ScriptedMetric metric = result.get("wierdSum");
 //        Assert.assertEquals(136L,metric.aggregation());
 //    }
 //
 //    @Test
-//    public void scriptedMetricConcatWithStringParamAndReduceParamAggregation() throws SQLFeatureNotSupportedException, SqlParseException {
+//    public void scriptedMetricConcatWithStringParamAndReduceParamAggregation()
+//                                      throws SQLFeatureNotSupportedException, SqlParseException {
 //        String query = "select scripted_metric(\n" +
 //                "  'init_script' = '_agg[\"concat\"]=[] ',\n" +
 //                "  'map_script'='_agg.concat.add(doc[field].value)' ,\n" +
@@ -635,10 +655,13 @@ public class AggregationIT extends SQLIntegTestCase {
 //    }
 //
 //    @Test
-//    public void scriptedMetricAggregationWithNumberParams() throws SQLFeatureNotSupportedException, SqlParseException {
-//        Aggregations result = query ("select scripted_metric('map_script'='if(doc[\\'balance\\'].value > 49670){ if(!_agg.containsKey(\\'ages\\')) { _agg.put(\\'ages\\',doc[\\'age\\'].value+x); } " +
+//    public void scriptedMetricAggregationWithNumberParams()
+//                              throws SQLFeatureNotSupportedException, SqlParseException {
+//        Aggregations result = query("select scripted_metric('map_script'='if(doc[\\'balance\\'].value > 49670)" +
+//                          "{ if(!_agg.containsKey(\\'ages\\')) { _agg.put(\\'ages\\',doc[\\'age\\'].value+x); } " +
 //                "else { _agg.put(\\'ages\\',_agg.get(\\'ages\\')+doc[\\'age\\'].value+x); }}'," +
-//                "'reduce_script'='sumThem = 0; for (a in _aggs) { if(a.containsKey(\\'ages\\')){ sumThem += a.get(\\'ages\\');} }; return sumThem;'" +
+//                "'reduce_script'='sumThem = 0; for (a in _aggs) { if(a.containsKey(\\'ages\\'))" +
+//                "{ sumThem += a.get(\\'ages\\');} }; return sumThem;'" +
 //                ",'@x'=3) as wierdSum from " + TEST_INDEX + "/account");
 //        ScriptedMetric metric = result.get("wierdSum");
 //        Assert.assertEquals(148L,metric.aggregation());
@@ -646,8 +669,10 @@ public class AggregationIT extends SQLIntegTestCase {
 //
 
 //    @Test
-//    public void topHitTest_WithIncludeAndExclude() throws IOException, SqlParseException, SQLFeatureNotSupportedException {
-//        Aggregations result = query(String.format("select topHits('size'=3,'exclude'='lastname','include'='firstname,lastname',age='desc') from %s/account group by gender ", TEST_INDEX_ACCOUNT));
+//    public void topHitTest_WithIncludeAndExclude()
+//                      throws IOException, SqlParseException, SQLFeatureNotSupportedException {
+//        Aggregations result = query(format("select topHits('size'=3,'exclude'='lastname'," +
+//        "'include'='firstname,lastname',age='desc') from %s/account group by gender ", TEST_INDEX_ACCOUNT));
 //        List<? extends Terms.Bucket> buckets = ((Terms) (result.asList().get(0))).getBuckets();
 //        for (Terms.Bucket bucket : buckets) {
 //            SearchHits hits = ((InternalTopHits) bucket.getAggregations().asList().get(0)).getHits();
@@ -664,14 +689,15 @@ public class AggregationIT extends SQLIntegTestCase {
 //        return ((SearchResponse)select.get()).getAggregations();
 //    }
 //
-//    private SqlElasticSearchRequestBuilder getSearchRequestBuilder(String query) throws SqlParseException, SQLFeatureNotSupportedException {
+//    private SqlElasticSearchRequestBuilder getSearchRequestBuilder(String query)
+//                                      throws SqlParseException, SQLFeatureNotSupportedException {
 //        SearchDao searchDao = MainTestSuite.getSearchDao();
 //        return (SqlElasticSearchRequestBuilder) searchDao.explain(query).explain();
 //    }
 //
 //    @Test
 //    public void testFromSizeWithAggregations() throws Exception {
-//        final String query1 = String.format("SELECT /*! DOCS_WITH_AGGREGATION(0,1) */" +
+//        final String query1 = format("SELECT /*! DOCS_WITH_AGGREGATION(0,1) */" +
 //                " account_number FROM %s/account GROUP BY gender", TEST_INDEX_ACCOUNT);
 //        SearchResponse response1 = (SearchResponse) getSearchRequestBuilder(query1).get();
 //
@@ -680,7 +706,7 @@ public class AggregationIT extends SQLIntegTestCase {
 //        Assert.assertEquals(2, gender1.getBuckets().size());
 //        Object account1 = response1.getHits().getHits()[0].getSourceAsMap().get("account_number");
 //
-//        final String query2 = String.format("SELECT /*! DOCS_WITH_AGGREGATION(1,1) */" +
+//        final String query2 = format("SELECT /*! DOCS_WITH_AGGREGATION(1,1) */" +
 //                " account_number FROM %s/account GROUP BY gender", TEST_INDEX_ACCOUNT);
 //        SearchResponse response2 = (SearchResponse) getSearchRequestBuilder(query2).get();
 //
@@ -696,8 +722,9 @@ public class AggregationIT extends SQLIntegTestCase {
 //    @Test
 //    public void testSubAggregations() throws  Exception {
 //        Set expectedAges = new HashSet<>(ContiguousSet.create(Range.closed(20, 40), DiscreteDomain.integers()));
-//        final String query = String.format("SELECT /*! DOCS_WITH_AGGREGATION(10) */" +
-//                " * FROM %s/account GROUP BY (gender, terms('field'='age','size'=200,'alias'='age')), (state) LIMIT 200,200", TEST_INDEX_ACCOUNT);
+//        final String query = format("SELECT /*! DOCS_WITH_AGGREGATION(10) */" +
+//                " * FROM %s/account GROUP BY (gender, terms('field'='age','size'=200,'alias'='age'))," +
+//                " (state) LIMIT 200,200", TEST_INDEX_ACCOUNT);
 //
 //        Map<String, Set<Integer>> buckets = new HashMap<>();
 //
@@ -732,7 +759,8 @@ public class AggregationIT extends SQLIntegTestCase {
 //
 //    @Test
 //    public void testSimpleSubAggregations() throws  Exception {
-//        final String query = String.format("SELECT /*! DOCS_WITH_AGGREGATION(10) */ * FROM %s/account GROUP BY (gender), (state) ", TEST_INDEX_ACCOUNT);
+//        final String query = format("SELECT /*! DOCS_WITH_AGGREGATION(10) */ * FROM %s/account " +
+//                                              "GROUP BY (gender), (state) ", TEST_INDEX_ACCOUNT);
 //
 //        SqlElasticSearchRequestBuilder select = getSearchRequestBuilder(query);
 //        SearchResponse response = (SearchResponse) select.get();
@@ -759,7 +787,8 @@ public class AggregationIT extends SQLIntegTestCase {
 //
 //    @Test
 //    public void geoHashGrid() throws SQLFeatureNotSupportedException, SqlParseException {
-//        Aggregations result = query(String.format("SELECT COUNT(*) FROM %s/location GROUP BY geohash_grid(field='center',precision=5) ", TEST_INDEX_LOCATION));
+//        Aggregations result = query(format("SELECT COUNT(*) FROM %s/location " +
+//                          "GROUP BY geohash_grid(field='center',precision=5) ", TEST_INDEX_LOCATION));
 //        InternalGeoHashGrid grid = result.get("geohash_grid(field=center,precision=5)");
 //        Collection<? extends InternalMultiBucketAggregation.InternalBucket> buckets = grid.getBuckets();
 //        for (InternalMultiBucketAggregation.InternalBucket bucket : buckets) {
@@ -770,7 +799,8 @@ public class AggregationIT extends SQLIntegTestCase {
 //
 //    @Test
 //    public void geoBounds() throws SQLFeatureNotSupportedException, SqlParseException {
-//        Aggregations result = query(String.format("SELECT * FROM %s/location GROUP BY geo_bounds(field='center',alias='bounds') ", TEST_INDEX_LOCATION));
+//        Aggregations result = query(format("SELECT * FROM %s/location " +
+//                          "GROUP BY geo_bounds(field='center',alias='bounds') ", TEST_INDEX_LOCATION));
 //        InternalGeoBounds bounds = result.get("bounds");
 //        Assert.assertEquals(0.5,bounds.bottomRight().getLat(),0.001);
 //        Assert.assertEquals(105.0,bounds.bottomRight().getLon(),0.001);
@@ -780,7 +810,8 @@ public class AggregationIT extends SQLIntegTestCase {
 //
 //    @Test
 //    public void groupByOnNestedFieldTest() throws Exception {
-//        Aggregations result = query(String.format("SELECT COUNT(*) FROM %s/nestedType GROUP BY nested(message.info)", TEST_INDEX_NESTED_TYPE));
+//        Aggregations result = query(format("SELECT COUNT(*) FROM %s/nestedType " +
+//                          "GROUP BY nested(message.info)", TEST_INDEX_NESTED_TYPE));
 //        InternalNested nested = result.get("message.info@NESTED");
 //        Terms infos = nested.getAggregations().get("message.info");
 //        Assert.assertEquals(3,infos.getBuckets().size());
@@ -797,14 +828,15 @@ public class AggregationIT extends SQLIntegTestCase {
 //                Assert.assertEquals(1, count);
 //            }
 //            else {
-//                throw new Exception(String.format("Unexpected key. expected: a OR b OR c . found: %s", key));
+//                throw new Exception(format("Unexpected key. expected: a OR b OR c . found: %s", key));
 //            }
 //        }
 //    }
 //
 //    @Test
 //    public void groupByTestWithFilter() throws Exception {
-//        Aggregations result = query(String.format("SELECT COUNT(*) FROM %s/account GROUP BY filter(gender='m'),gender", TEST_INDEX_ACCOUNT));
+//        Aggregations result = query(format("SELECT COUNT(*) FROM %s/account " +
+//                          "GROUP BY filter(gender='m'),gender", TEST_INDEX_ACCOUNT));
 //        InternalFilter filter = result.get("filter(gender = 'm')@FILTER");
 //        Terms gender = filter.getAggregations().get("gender");
 //
@@ -815,7 +847,7 @@ public class AggregationIT extends SQLIntegTestCase {
 //                Assert.assertEquals(507, count);
 //            }
 //            else {
-//                throw new Exception(String.format("Unexpected key. expected: only m. found: %s", key));
+//                throw new Exception(format("Unexpected key. expected: only m. found: %s", key));
 //            }
 //        }
 //    }
@@ -826,7 +858,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void groupByOnNestedFieldWithFilterTest() throws Exception {
 
-        String query = String.format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
+        String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
                 "filter('myFilter',message.info = 'a')", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
 
@@ -843,7 +875,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void minOnNestedField() throws Exception {
 
-        String query = String.format("SELECT min(nested(message.dayOfWeek)) as minDays FROM %s/nestedType",
+        String query = format("SELECT min(nested(message.dayOfWeek)) as minDays FROM %s/nestedType",
                                         TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
         JSONObject aggregation = getAggregation(result, "message.dayOfWeek@NESTED");
@@ -853,7 +885,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void sumOnNestedField() throws Exception {
 
-        String query = String.format("SELECT sum(nested(message.dayOfWeek)) as sumDays FROM %s/nestedType",
+        String query = format("SELECT sum(nested(message.dayOfWeek)) as sumDays FROM %s/nestedType",
                                         TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
         JSONObject aggregation = getAggregation(result, "message.dayOfWeek@NESTED");
@@ -863,7 +895,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void histogramOnNestedField() throws Exception {
 
-        String query = String.format("select count(*) from %s/nestedType group by histogram" +
+        String query = format("select count(*) from %s/nestedType group by histogram" +
                 "('field'='message.dayOfWeek','nested'='message','interval'='2' , 'alias' = 'someAlias' )",
                 TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
@@ -890,7 +922,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void reverseToRootGroupByOnNestedFieldWithFilterTestWithReverseNestedAndEmptyPath() throws Exception {
 
-        String query = String.format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
+        String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
                 "filter('myFilter',message.info = 'a'),reverse_nested(someField,'')", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
         JSONObject aggregation = getAggregation(result, "message.info@NESTED");
@@ -909,7 +941,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void reverseToRootGroupByOnNestedFieldWithFilterTestWithReverseNestedNoPath() throws Exception {
 
-        String query = String.format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info),filter" +
+        String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info),filter" +
                 "('myFilter',message.info = 'a'),reverse_nested(someField)", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
         JSONObject aggregation = getAggregation(result, "message.info@NESTED");
@@ -928,7 +960,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void reverseToRootGroupByOnNestedFieldWithFilterTestWithReverseNestedOnHistogram() throws Exception {
 
-        String query = String.format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
+        String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
                 "filter('myFilter',message.info = 'a'),histogram('field'='myNum','reverse_nested'='','interval'='2', " +
                 "'alias' = 'someAlias' )", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
@@ -959,7 +991,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void reverseToRootGroupByOnNestedFieldWithFilterAndSumOnReverseNestedField() throws Exception {
 
-        String query = String.format("SELECT sum(reverse_nested(myNum)) bla FROM %s/nestedType GROUP BY " +
+        String query = format("SELECT sum(reverse_nested(myNum)) bla FROM %s/nestedType GROUP BY " +
                 "nested(message.info),filter('myFilter',message.info = 'a')", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
         JSONObject aggregation = getAggregation(result, "message.info@NESTED");
@@ -976,7 +1008,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void reverseAnotherNestedGroupByOnNestedFieldWithFilterTestWithReverseNestedNoPath() throws Exception {
 
-        String query = String.format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
+        String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info)," +
                 "filter('myFilter',message.info = 'a'),reverse_nested(comment.data,'~comment')",
                 TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
@@ -997,7 +1029,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void reverseAnotherNestedGroupByOnNestedFieldWithFilterTestWithReverseNestedOnHistogram() throws Exception {
 
-        String query = String.format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info),filter" +
+        String query = format("SELECT COUNT(*) FROM %s/nestedType GROUP BY  nested(message.info),filter" +
                 "('myFilter',message.info = 'a'),histogram('field'='comment.likes','reverse_nested'='~comment'," +
                 "'interval'='2' , 'alias' = 'someAlias' )", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
@@ -1028,7 +1060,7 @@ public class AggregationIT extends SQLIntegTestCase {
     @Test
     public void reverseAnotherNestedGroupByOnNestedFieldWithFilterAndSumOnReverseNestedField() throws Exception {
 
-        String query = String.format("SELECT sum(reverse_nested(comment.likes,'~comment')) bla FROM %s/nestedType " +
+        String query = format("SELECT sum(reverse_nested(comment.likes,'~comment')) bla FROM %s/nestedType " +
                 "GROUP BY  nested(message.info),filter('myFilter',message.info = 'a')", TEST_INDEX_NESTED_TYPE);
         JSONObject result = executeQuery(query);
         JSONObject aggregation = getAggregation(result, "message.info@NESTED");
@@ -1045,14 +1077,14 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void docsReturnedTestWithoutDocsHint() throws Exception {
-        String query = String.format("SELECT count(*) from %s/account", TEST_INDEX_ACCOUNT);
+        String query = format("SELECT count(*) from %s/account", TEST_INDEX_ACCOUNT);
         JSONObject result = executeQuery(query);
         Assert.assertThat(getHits(result).length(), equalTo(0));
     }
 
     @Test
     public void docsReturnedTestWithDocsHint() throws Exception {
-        String query = String.format("SELECT /*! DOCS_WITH_AGGREGATION(10) */ count(*) from %s/account",
+        String query = format("SELECT /*! DOCS_WITH_AGGREGATION(10) */ count(*) from %s/account",
                 TEST_INDEX_ACCOUNT);
         JSONObject result = executeQuery(query);
         Assert.assertThat(getHits(result).length(), equalTo(10));
@@ -1060,7 +1092,7 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void termsWithScript() throws Exception {
-        String query = String.format("select count(*), avg(number) from %s group by terms('alias'='asdf'," +
+        String query = format("select count(*), avg(number) from %s group by terms('alias'='asdf'," +
                 " substring(field, 0, 1)), date_histogram('alias'='time', 'field'='timestamp', " +
                 "'interval'='20d ', 'format'='yyyy-MM-dd') limit 1000", TEST_INDEX_ONLINE);
         String result = explainQuery(query);
@@ -1071,7 +1103,7 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void groupByScriptedDateHistogram() throws Exception {
-        String query = String.format("select count(*), avg(number) from %s group by date_histogram('alias'='time'," +
+        String query = format("select count(*), avg(number) from %s group by date_histogram('alias'='time'," +
                 " ceil(timestamp), 'interval'='20d ', 'format'='yyyy-MM-dd') limit 1000" , TEST_INDEX_ONLINE);
         String result = explainQuery(query);
 
@@ -1081,7 +1113,7 @@ public class AggregationIT extends SQLIntegTestCase {
 
     @Test
     public void groupByScriptedHistogram() throws Exception {
-        String query = String.format("select count(*) from %s group by histogram('alias'='field', pow(field,1))",
+        String query = format("select count(*) from %s group by histogram('alias'='field', pow(field,1))",
                 TEST_INDEX_ONLINE);
         String result = explainQuery(query);
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/CsvFormatResponseIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/CsvFormatResponseIT.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Collectors;
 
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
@@ -41,6 +40,7 @@ import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstant
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_GAME_OF_THRONES;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_NESTED_TYPE;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ONLINE;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -77,7 +77,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void allPercentilesByDefault() throws IOException {
 
-        final String query = String.format(Locale.ROOT, "SELECT PERCENTILES(age) FROM %s", TEST_INDEX_ACCOUNT);
+        final String query = format("SELECT PERCENTILES(age) FROM %s", TEST_INDEX_ACCOUNT);
         final String result = executeQueryWithStringOutput(query);
 
         final String expectedHeaders = "PERCENTILES(age).1.0,PERCENTILES(age).5.0,PERCENTILES(age).25.0," +
@@ -88,7 +88,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void specificPercentilesIntAndDouble() throws IOException {
 
-        final String query = String.format(Locale.ROOT, "SELECT PERCENTILES(age,10,49.0) FROM %s",
+        final String query = format("SELECT PERCENTILES(age,10,49.0) FROM %s",
                 TEST_INDEX_ACCOUNT);
         final String result = executeQueryWithStringOutput(query);
 
@@ -103,7 +103,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void nestedObjectsAndArraysAreQuoted() throws IOException {
 
-        final String query = String.format(Locale.ROOT, "SELECT * FROM %s WHERE _id = 5",
+        final String query = format("SELECT * FROM %s WHERE _id = 5",
                 TEST_INDEX_NESTED_TYPE);
         final String result = executeQueryWithStringOutput(query);
 
@@ -121,7 +121,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
         setFlatOption(true);
 
-        final String query = String.format(Locale.ROOT, "SELECT * FROM %s WHERE _id = 5",
+        final String query = format("SELECT * FROM %s WHERE _id = 5",
                 TEST_INDEX_NESTED_TYPE);
         final String result = executeQueryWithStringOutput(query);
 
@@ -157,7 +157,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     public void fieldOrderWithScriptFields() throws IOException {
 
         final String[] expectedFields = {"email", "script1", "script2", "gender", "address"};
-        final String query = String.format(Locale.ROOT, "SELECT email, " +
+        final String query = format("SELECT email, " +
                 "script(script1, \"doc['balance'].value * 2\"), " +
                 "script(script2, painless, \"doc['balance'].value + 10\"), gender, address " +
                 "FROM %s WHERE email='amberduke@pyrami.com'", TEST_INDEX_ACCOUNT);
@@ -169,7 +169,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void simpleSearchResultNotNestedNotFlatNoAggs() throws Exception {
-        String query = String.format(Locale.ROOT, "select dog_name,age from %s/dog order by age", TEST_INDEX_DOG);
+        String query = format("select dog_name,age from %s/dog order by age", TEST_INDEX_DOG);
         final CSVResult csvResult = executeCsvRequest(query, false);
 
         List<String> headers = csvResult.getHeaders();
@@ -185,7 +185,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void simpleSearchResultWithNestedNotFlatNoAggs() throws Exception {
-        String query = String.format(Locale.ROOT, "select name,house from %s/gotCharacters",
+        String query = format("select name,house from %s/gotCharacters",
                 TEST_INDEX_GAME_OF_THRONES);
         CSVResult csvResult = executeCsvRequest(query, false);
 
@@ -210,7 +210,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     @Ignore("headers incorrect in case of nested fields")
     @Test
     public void simpleSearchResultWithNestedOneFieldNotFlatNoAggs() throws Exception {
-        String query = String.format(Locale.ROOT, "select name.firstname,house from %s/gotCharacters",
+        String query = format("select name.firstname,house from %s/gotCharacters",
                 TEST_INDEX_GAME_OF_THRONES);
         CSVResult csvResult = executeCsvRequest(query, false);
 
@@ -231,7 +231,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     @Ignore("headers incorrect in case of nested fields")
     @Test
     public void simpleSearchResultWithNestedTwoFieldsFromSameNestedNotFlatNoAggs() throws Exception {
-        String query = String.format(Locale.ROOT, "select name.firstname,name.lastname,house from %s/gotCharacters",
+        String query = format("select name.firstname,name.lastname,house from %s/gotCharacters",
                 TEST_INDEX_GAME_OF_THRONES);
         CSVResult csvResult = executeCsvRequest(query, false);
 
@@ -255,7 +255,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void simpleSearchResultWithNestedWithFlatNoAggs() throws Exception {
-        String query = String.format(Locale.ROOT, "select name.firstname,house from %s/gotCharacters",
+        String query = format("select name.firstname,house from %s/gotCharacters",
                 TEST_INDEX_GAME_OF_THRONES);
         CSVResult csvResult = executeCsvRequest(query, true);
 
@@ -274,7 +274,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void joinSearchResultNotNestedNotFlatNoAggs() throws Exception {
-        String query = String.format(Locale.ROOT, "select c.gender , h.hname,h.words from %s/gotCharacters c " +
+        String query = format("select c.gender , h.hname,h.words from %s/gotCharacters c " +
                 "JOIN %s/gotCharacters h " +
                 "on h.hname = c.house ", TEST_INDEX_GAME_OF_THRONES, TEST_INDEX_GAME_OF_THRONES);
         CSVResult csvResult = executeCsvRequest(query, false);
@@ -293,7 +293,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void simpleNumericValueAgg() throws Exception {
-        String query = String.format(Locale.ROOT, "select count(*) from %s/dog ", TEST_INDEX_DOG);
+        String query = format("select count(*) from %s/dog ", TEST_INDEX_DOG);
         CSVResult csvResult = executeCsvRequest(query, false);
 
         List<String> headers = csvResult.getHeaders();
@@ -309,7 +309,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void simpleNumericValueAggWithAlias() throws Exception {
-        String query = String.format(Locale.ROOT, "select avg(age) as myAlias from %s/dog ", TEST_INDEX_DOG);
+        String query = format("select avg(age) as myAlias from %s/dog ", TEST_INDEX_DOG);
         CSVResult csvResult = executeCsvRequest(query, false);
 
         List<String> headers = csvResult.getHeaders();
@@ -325,7 +325,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void twoNumericAggWithAlias() throws Exception {
-        String query = String.format(Locale.ROOT, "select count(*) as count, avg(age) as myAlias from %s/dog ",
+        String query = format("select count(*) as count, avg(age) as myAlias from %s/dog ",
                 TEST_INDEX_DOG);
         CSVResult csvResult = executeCsvRequest(query, false);
 
@@ -348,7 +348,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void aggAfterTermsGroupBy() throws Exception {
-        String query = String.format(Locale.ROOT, "SELECT COUNT(*) FROM %s/account GROUP BY gender",
+        String query = format("SELECT COUNT(*) FROM %s/account GROUP BY gender",
                 TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false);
         List<String> headers = csvResult.getHeaders();
@@ -365,7 +365,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void aggAfterTwoTermsGroupBy() throws Exception {
-        String query = String.format(Locale.ROOT,
+        String query = format(
                 "SELECT COUNT(*) FROM %s/account where age in (35,36) GROUP BY gender,age",
                 TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false);
@@ -386,7 +386,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void multipleAggAfterTwoTermsGroupBy() throws Exception {
-        String query = String.format(Locale.ROOT,
+        String query = format(
                 "SELECT COUNT(*) , sum(balance) FROM %s/account where age in (35,36) GROUP BY gender,age",
                 TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false);
@@ -412,7 +412,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void dateHistogramTest() throws Exception {
-        String query = String.format(Locale.ROOT, "select count(*) from %s/online" +
+        String query = format("select count(*) from %s/online" +
                 " group by date_histogram('field'='insert_time','interval'='4d','alias'='days')", TEST_INDEX_ONLINE);
         CSVResult csvResult = executeCsvRequest(query, false);
         List<String> headers = csvResult.getHeaders();
@@ -428,7 +428,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void statsAggregationTest() throws Exception {
-        String query = String.format(Locale.ROOT, "SELECT STATS(age) FROM %s/account", TEST_INDEX_ACCOUNT);
+        String query = format("SELECT STATS(age) FROM %s/account", TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false);
         List<String> headers = csvResult.getHeaders();
         Assert.assertEquals(5, headers.size());
@@ -445,7 +445,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void extendedStatsAggregationTest() throws Exception {
-        String query = String.format(Locale.ROOT, "SELECT EXTENDED_STATS(age) FROM %s/account", TEST_INDEX_ACCOUNT);
+        String query = format("SELECT EXTENDED_STATS(age) FROM %s/account", TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false);
         List<String> headers = csvResult.getHeaders();
 
@@ -466,7 +466,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void percentileAggregationTest() throws Exception {
-        String query = String.format(Locale.ROOT, "select percentiles(age) as per from %s/account where age > 31",
+        String query = format("select percentiles(age) as per from %s/account where age > 31",
                 TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false);
         List<String> headers = csvResult.getHeaders();
@@ -487,7 +487,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void includeTypeAndNotScore() throws Exception {
-        String query = String.format(Locale.ROOT, "select age , firstname from %s/account where age > 31 limit 2",
+        String query = format("select age , firstname from %s/account where age > 31 limit 2",
                 TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false, false, true, false);
         List<String> headers = csvResult.getHeaders();
@@ -502,7 +502,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void includeScoreAndNotType() throws Exception {
-        String query = String.format(Locale.ROOT,
+        String query = format(
                 "select age , firstname from %s/account where age > 31 order by _score desc limit 2 ",
                 TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false, true, false, false);
@@ -518,7 +518,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void includeScoreAndType() throws Exception {
-        String query = String.format(Locale.ROOT,
+        String query = format(
                 "select age , firstname from %s/account where age > 31 order by _score desc limit 2 ",
                 TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false, true, true, false);
@@ -542,7 +542,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void scriptedField() throws Exception {
-        String query = String.format(Locale.ROOT,
+        String query = format(
                 "select age+1 as agePlusOne ,age , firstname from %s/account where age =  31 limit 1",
                 TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false);
@@ -559,7 +559,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     @Ignore("separator not exposed")
     @Test
     public void twoCharsSeperator() throws Exception {
-        String query = String.format(Locale.ROOT, "select dog_name,age from %s/dog order by age", TEST_INDEX_DOG);
+        String query = format("select dog_name,age from %s/dog order by age", TEST_INDEX_DOG);
         CSVResult csvResult = executeCsvRequest(query, false);
 
         List<String> headers = csvResult.getHeaders();
@@ -576,7 +576,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void includeIdAndNotTypeOrScore() throws Exception {
-        String query = String.format(Locale.ROOT,
+        String query = format(
                 "select age , firstname from %s/account where lastname = 'Marquez' ", TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false, false, false, true);
         List<String> headers = csvResult.getHeaders();
@@ -590,7 +590,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void includeIdAndTypeButNoScore() throws Exception {
-        String query = String.format(Locale.ROOT,
+        String query = format(
                 "select age , firstname from %s/account where lastname = 'Marquez' ", TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false, false, true, true);
         List<String> headers = csvResult.getHeaders();
@@ -607,7 +607,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     private void verifyFieldOrder(final String[] expectedFields) throws IOException {
 
         final String fields = String.join(", ", expectedFields);
-        final String query = String.format(Locale.ROOT, "SELECT %s FROM %s " +
+        final String query = format("SELECT %s FROM %s " +
                 "WHERE email='amberduke@pyrami.com'", fields, TEST_INDEX_ACCOUNT);
 
         verifyFieldOrder(expectedFields, query);
@@ -635,7 +635,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
                                         boolean includeType, boolean includeId) throws IOException {
 
         final String requestBody = super.makeRequest(query);
-        final String endpoint = String.format(Locale.ROOT,
+        final String endpoint = format(
                 "/_opendistro/_sql?format=csv&flat=%b&_id=%b&_score=%b&_type=%b",
                 flat, includeId, includeScore, includeType);
         final Request sqlRequest = new Request("POST", endpoint);
@@ -656,7 +656,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
         final List<String> rows = new ArrayList<>();
 
-        final String newLine = String.format(Locale.ROOT, "%n");
+        final String newLine = format("%n");
         int newLineIndex = response.indexOf(newLine);
 
         final String headerLine;
@@ -685,7 +685,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
             final String delimiter = areItemsNested ? ", " : ",";
             final String objectField = String.join(delimiter, permutation);
-            final String row = String.format(Locale.ROOT, "%s%s%s%s%s",
+            final String row = format("%s%s%s%s%s",
                     printablePrefix(prefix), areItemsNested ? "\"{" : "",
                     objectField, areItemsNested ? "}\"" : "", printableSuffix(suffix));
             return hasItem(row);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/CsvFormatResponseIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/CsvFormatResponseIT.java
@@ -67,7 +67,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Override
     protected Request getSqlRequest(String request, boolean explain) {
-
         Request sqlRequest = super.getSqlRequest(request, explain);
         sqlRequest.addParameter("format", "csv");
         sqlRequest.addParameter("flat", flatOption ? "true" : "false");
@@ -76,7 +75,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void allPercentilesByDefault() throws IOException {
-
         final String query = format("SELECT PERCENTILES(age) FROM %s", TEST_INDEX_ACCOUNT);
         final String result = executeQueryWithStringOutput(query);
 
@@ -87,7 +85,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void specificPercentilesIntAndDouble() throws IOException {
-
         final String query = format("SELECT PERCENTILES(age,10,49.0) FROM %s",
                 TEST_INDEX_ACCOUNT);
         final String result = executeQueryWithStringOutput(query);
@@ -102,7 +99,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void nestedObjectsAndArraysAreQuoted() throws IOException {
-
         final String query = format("SELECT * FROM %s WHERE _id = 5",
                 TEST_INDEX_NESTED_TYPE);
         final String result = executeQueryWithStringOutput(query);
@@ -118,7 +114,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void arraysAreQuotedInFlatMode() throws IOException {
-
         setFlatOption(true);
 
         final String query = format("SELECT * FROM %s WHERE _id = 5",
@@ -138,7 +133,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void fieldOrder() throws IOException {
-
         final String[] expectedFields = {"age", "firstname", "address", "gender", "email"};
 
         verifyFieldOrder(expectedFields);
@@ -146,7 +140,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void fieldOrderOther() throws IOException {
-
         final String[] expectedFields = {"email", "firstname", "age", "gender", "address"};
 
         verifyFieldOrder(expectedFields);
@@ -155,7 +148,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     @Ignore("Getting parser error")
     @Test
     public void fieldOrderWithScriptFields() throws IOException {
-
         final String[] expectedFields = {"email", "script1", "script2", "gender", "address"};
         final String query = format("SELECT email, " +
                 "script(script1, \"doc['balance'].value * 2\"), " +
@@ -605,7 +597,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     //endregion Tests migrated from CSVResultsExtractorTests
 
     private void verifyFieldOrder(final String[] expectedFields) throws IOException {
-
         final String fields = String.join(", ", expectedFields);
         final String query = format("SELECT %s FROM %s " +
                 "WHERE email='amberduke@pyrami.com'", fields, TEST_INDEX_ACCOUNT);
@@ -614,7 +605,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     }
 
     private void verifyFieldOrder(final String[] expectedFields, final String query) throws IOException {
-
         final String result = executeQueryWithStringOutput(query);
 
         final String expectedHeader = String.join(",", expectedFields);
@@ -622,18 +612,15 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     }
 
     private void setFlatOption(boolean flat) {
-
         this.flatOption = flat;
     }
 
     private CSVResult executeCsvRequest(final String query, boolean flat) throws IOException {
-
         return executeCsvRequest(query, flat, false, false, false);
     }
 
     private CSVResult executeCsvRequest(final String query, boolean flat, boolean includeScore,
                                         boolean includeType, boolean includeId) throws IOException {
-
         final String requestBody = super.makeRequest(query);
         final String endpoint = format(
                 "/_opendistro/_sql?format=csv&flat=%b&_id=%b&_score=%b&_type=%b",
@@ -653,7 +640,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     }
 
     private CSVResult csvResultFromStringResponse(final String response) {
-
         final List<String> rows = new ArrayList<>();
 
         final String newLine = format("%n");
@@ -678,11 +664,9 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
 
     private static AnyOf<List<String>> hasRow(final String prefix, final String suffix, final List<String> items,
                                               final boolean areItemsNested) {
-
         final Collection<List<String>> permutations = TestUtils.getPermutations(items);
 
         final List<Matcher<? super List<String>>> matchers = permutations.stream().map(permutation -> {
-
             final String delimiter = areItemsNested ? ", " : ",";
             final String objectField = String.join(delimiter, permutation);
             final String row = format("%s%s%s%s%s",
@@ -696,7 +680,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     }
 
     private static String printablePrefix(final String prefix) {
-
         if (prefix == null || prefix.trim().isEmpty()) {
             return "";
         }
@@ -705,7 +688,6 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
     }
 
     private static String printableSuffix(final String suffix) {
-
         if (suffix == null || suffix.trim().isEmpty()) {
             return "";
         }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFormatIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFormatIT.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.contains;
 
 public class DateFormatIT extends SQLIntegTestCase {
@@ -123,7 +124,7 @@ public class DateFormatIT extends SQLIntegTestCase {
             JSONObject response = executeQuery(sql);
             return getResult(response, "insert_time");
         } catch (IOException e) {
-            throw new SqlParseException(String.format("Unable to process query '%s'", sql));
+            throw new SqlParseException(format("Unable to process query '%s'", sql));
         }
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DeleteIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DeleteIT.java
@@ -19,8 +19,8 @@ import org.json.JSONObject;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Locale;
 
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class DeleteIT extends SQLIntegTestCase {
@@ -33,16 +33,14 @@ public class DeleteIT extends SQLIntegTestCase {
 
     @Test
     public void deleteAllTest() throws IOException, InterruptedException {
-        String selectQuery = String.format(
-            Locale.ROOT,
+        String selectQuery = format(
             "SELECT * FROM %s/account",
             TestsConstants.TEST_INDEX_ACCOUNT
         );
         JSONObject response = executeRequest(makeRequest(selectQuery));
         int totalHits = getTotalHits(response);
 
-        String deleteQuery = String.format(
-            Locale.ROOT,
+        String deleteQuery = format(
             "DELETE FROM %s/account",
             TestsConstants.TEST_INDEX_ACCOUNT);
         response = executeRequest(makeRequest(deleteQuery));
@@ -58,16 +56,14 @@ public class DeleteIT extends SQLIntegTestCase {
 
     @Test
     public void deleteWithConditionTest() throws IOException, InterruptedException {
-        String selectQuery = String.format(
-            Locale.ROOT,
+        String selectQuery = format(
             "SELECT * FROM %s/phrase WHERE match_phrase(phrase, 'quick fox here')",
             TestsConstants.TEST_INDEX_PHRASE
         );
         JSONObject response = executeRequest(makeRequest(selectQuery));
         int totalHits = getTotalHits(response);
 
-        String deleteQuery = String.format(
-            Locale.ROOT,
+        String deleteQuery = format(
             "DELETE FROM %s/phrase WHERE match_phrase(phrase, 'quick fox here')",
             TestsConstants.TEST_INDEX_PHRASE
         );
@@ -77,8 +73,7 @@ public class DeleteIT extends SQLIntegTestCase {
         // To prevent flakiness, the minimum value of 2000 msec works fine.
         Thread.sleep(2000);
 
-        selectQuery = String.format(
-            Locale.ROOT,
+        selectQuery = format(
             "SELECT * FROM %s/phrase",
             TestsConstants.TEST_INDEX_PHRASE
         );

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ExplainIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ExplainIT.java
@@ -29,6 +29,7 @@ import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstant
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_NESTED_TYPE;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_PEOPLE;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_PHRASE;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -52,7 +53,7 @@ public class ExplainIT extends SQLIntegTestCase {
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
                 .replaceAll("\r","");
 
-        String result = explainQuery(String.format("SELECT * FROM %s WHERE firstname LIKE 'A%%' AND age > 20 " +
+        String result = explainQuery(format("SELECT * FROM %s WHERE firstname LIKE 'A%%' AND age > 20 " +
                 "GROUP BY gender order by _score", TEST_INDEX_ACCOUNT));
         Assert.assertThat(result.replaceAll("\\s+",""), equalTo(expectedOutput.replaceAll("\\s+","")));
     }
@@ -65,7 +66,7 @@ public class ExplainIT extends SQLIntegTestCase {
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
                 .replaceAll("\r","");
 
-        String result = explainQuery(String.format("SELECT a, CASE WHEN gender='0' then 'aaa' else 'bbb'end a2345," +
+        String result = explainQuery(format("SELECT a, CASE WHEN gender='0' then 'aaa' else 'bbb'end a2345," +
                         "count(c) FROM %s GROUP BY terms('field'='a','execution_hint'='global_ordinals'),a2345",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(result.replaceAll("\\s+",""), equalTo(expectedOutput.replaceAll("\\s+","")));
@@ -79,7 +80,7 @@ public class ExplainIT extends SQLIntegTestCase {
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
                 .replaceAll("\r","");
 
-        String result = explainQuery(String.format("SELECT case when gender is null then 'aaa' " +
+        String result = explainQuery(format("SELECT case when gender is null then 'aaa' " +
                 "else gender  end  test , cust_code FROM %s", TEST_INDEX_ACCOUNT));
         Assert.assertThat(result.replaceAll("\\s+",""), equalTo(expectedOutput.replaceAll("\\s+","")));
     }
@@ -92,7 +93,7 @@ public class ExplainIT extends SQLIntegTestCase {
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
                 .replaceAll("\r","");
 
-        String result = explainQuery(String.format("SELECT  case when value between 100 and 200 then 'aaa' " +
+        String result = explainQuery(format("SELECT  case when value between 100 and 200 then 'aaa' " +
                 "else value  end  test, cust_code FROM %s", TEST_INDEX_ACCOUNT));
         Assert.assertThat(result.replaceAll("\\s+",""), equalTo(expectedOutput.replaceAll("\\s+","")));
     }
@@ -105,7 +106,7 @@ public class ExplainIT extends SQLIntegTestCase {
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
                 .replaceAll("\r","");
 
-        String result = explainQuery(String.format("SELECT * FROM %s WHERE firstname LIKE 'A%%' " +
+        String result = explainQuery(format("SELECT * FROM %s WHERE firstname LIKE 'A%%' " +
                 "AND age > 20 GROUP BY gender", TEST_INDEX_ACCOUNT));
         Assert.assertThat(result.replaceAll("\\s+",""), equalTo(expectedOutput.replaceAll("\\s+","")));
     }
@@ -118,7 +119,7 @@ public class ExplainIT extends SQLIntegTestCase {
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
                 .replaceAll("\r","");;
 
-        String result = explainQuery(String.format("DELETE FROM %s WHERE firstname LIKE 'A%%' AND age > 20",
+        String result = explainQuery(format("DELETE FROM %s WHERE firstname LIKE 'A%%' AND age > 20",
                 TEST_INDEX_ACCOUNT));
         Assert.assertThat(result.replaceAll("\\s+",""), equalTo(expectedOutput.replaceAll("\\s+","")));
     }
@@ -131,7 +132,7 @@ public class ExplainIT extends SQLIntegTestCase {
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
                 .replaceAll("\r","");;
 
-        String result = explainQuery(String.format("SELECT * FROM %s WHERE GEO_INTERSECTS" +
+        String result = explainQuery(format("SELECT * FROM %s WHERE GEO_INTERSECTS" +
                 "(place,'POLYGON ((102 2, 103 2, 103 3, 102 3, 102 2))')", TEST_INDEX_LOCATION));
         Assert.assertThat(result.replaceAll("\\s+",""), equalTo(expectedOutput.replaceAll("\\s+","")));
     }
@@ -139,7 +140,7 @@ public class ExplainIT extends SQLIntegTestCase {
     @Test
     public void orderByOnNestedFieldTest() throws Exception {
 
-        String result = explainQuery(String.format("SELECT * FROM %s ORDER BY NESTED('message.info','message')",
+        String result = explainQuery(format("SELECT * FROM %s ORDER BY NESTED('message.info','message')",
                 TEST_INDEX_NESTED_TYPE));
         Assert.assertThat(result.replaceAll("\\s+", ""),
                 equalTo("{\"from\":0,\"size\":200,\"sort\":[{\"message.info\":" +
@@ -154,7 +155,7 @@ public class ExplainIT extends SQLIntegTestCase {
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
                 .replaceAll("\r", "");
 
-        String result = explainQuery(String.format("SELECT * FROM %s WHERE q=multimatch(query='this is a test'," +
+        String result = explainQuery(format("SELECT * FROM %s WHERE q=multimatch(query='this is a test'," +
                 "fields='subject^3,message',analyzer='standard',type='best_fields',boost=1.0," +
                 "slop=0,tie_breaker=0.3,operator='and')", TEST_INDEX_ACCOUNT));
         Assert.assertThat(result.replaceAll("\\s+", ""), equalTo(expectedOutput.replaceAll("\\s+", "")));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ExplainIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ExplainIT.java
@@ -60,7 +60,6 @@ public class ExplainIT extends SQLIntegTestCase {
 
     @Test
     public void aggregationQuery() throws IOException {
-
         String expectedOutputFilePath = TestUtils.getResourceFilePath(
                 "src/test/resources/expectedOutput/aggregation_query_explain.json");
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
@@ -74,7 +73,6 @@ public class ExplainIT extends SQLIntegTestCase {
 
     @Test
     public void explainScriptValue() throws IOException {
-
         String expectedOutputFilePath = TestUtils.getResourceFilePath(
                 "src/test/resources/expectedOutput/script_value.json");
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
@@ -87,7 +85,6 @@ public class ExplainIT extends SQLIntegTestCase {
 
     @Test
     public void betweenScriptValue() throws IOException {
-
         String expectedOutputFilePath = TestUtils.getResourceFilePath(
                 "src/test/resources/expectedOutput/between_query.json");
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
@@ -100,7 +97,6 @@ public class ExplainIT extends SQLIntegTestCase {
 
     @Test
     public void searchSanityFilter() throws IOException {
-
         String expectedOutputFilePath = TestUtils.getResourceFilePath(
                 "src/test/resources/expectedOutput/search_explain_filter.json");
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
@@ -113,7 +109,6 @@ public class ExplainIT extends SQLIntegTestCase {
 
     @Test
     public void deleteSanity() throws IOException {
-
         String expectedOutputFilePath = TestUtils.getResourceFilePath(
                 "src/test/resources/expectedOutput/delete_explain.json");
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
@@ -126,7 +121,6 @@ public class ExplainIT extends SQLIntegTestCase {
 
     @Test
     public void spatialFilterExplainTest() throws IOException {
-
         String expectedOutputFilePath = TestUtils.getResourceFilePath(
                 "src/test/resources/expectedOutput/search_spatial_explain.json");
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
@@ -139,7 +133,6 @@ public class ExplainIT extends SQLIntegTestCase {
 
     @Test
     public void orderByOnNestedFieldTest() throws Exception {
-
         String result = explainQuery(format("SELECT * FROM %s ORDER BY NESTED('message.info','message')",
                 TEST_INDEX_NESTED_TYPE));
         Assert.assertThat(result.replaceAll("\\s+", ""),
@@ -149,7 +142,6 @@ public class ExplainIT extends SQLIntegTestCase {
 
     @Test
     public void multiMatchQuery() throws IOException {
-
         String expectedOutputFilePath = TestUtils.getResourceFilePath(
                 "src/test/resources/expectedOutput/multi_match_query.json");
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)
@@ -163,7 +155,6 @@ public class ExplainIT extends SQLIntegTestCase {
 
     @Test
     public void termsIncludeExcludeExplainTest() throws IOException {
-
         final String queryPrefix = "SELECT * FROM " + TEST_INDEX_PHRASE + " GROUP BY ";
         final String expected1 = "\"include\":\".*sport.*\",\"exclude\":\"water_.*\"";
         final String expected2 = "\"include\":[\"honda\",\"mazda\"],\"exclude\":[\"jensen\",\"rover\"]";
@@ -185,7 +176,6 @@ public class ExplainIT extends SQLIntegTestCase {
 
     @Test
     public void explainNLJoin() throws IOException {
-
         String expectedOutputFilePath = TestUtils.getResourceFilePath(
                 "src/test/resources/expectedOutput/nested_loop_join_explain.json");
         String expectedOutput = Files.toString(new File(expectedOutputFilePath), StandardCharsets.UTF_8)

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/GetEndpointQueryIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/GetEndpointQueryIT.java
@@ -38,7 +38,6 @@ public class GetEndpointQueryIT extends SQLIntegTestCase {
 
     @Test
     public void unicodeTermInQuery() throws IOException  {
-
         // NOTE: There are unicode characters in name, not just whitespace.
         final String name = "盛虹";
         final String query = format("SELECT id, firstname FROM %s " +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/GetEndpointQueryIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/GetEndpointQueryIT.java
@@ -21,9 +21,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Locale;
 
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -41,7 +41,7 @@ public class GetEndpointQueryIT extends SQLIntegTestCase {
 
         // NOTE: There are unicode characters in name, not just whitespace.
         final String name = "盛虹";
-        final String query = String.format(Locale.ROOT, "SELECT id, firstname FROM %s " +
+        final String query = format("SELECT id, firstname FROM %s " +
                 "WHERE firstname=matchQuery('%s') LIMIT 2", TEST_INDEX_ACCOUNT, name);
 
         final JSONObject result = executeQueryWithGetRequest(query);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/HashJoinIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/HashJoinIT.java
@@ -68,13 +68,11 @@ public class HashJoinIT extends SQLIntegTestCase {
 
     @Test
     public void innerJoin() throws IOException {
-
         testJoin("INNER JOIN");
     }
 
     @Test
     public void leftJoin() throws IOException {
-
         testJoin("LEFT JOIN");
     }
 
@@ -119,7 +117,6 @@ public class HashJoinIT extends SQLIntegTestCase {
     }
 
     private void testJoin(final String join) throws IOException {
-
         final String queryPrefix = "SELECT";
 
         // TODO: reduce the balance threshold to 10000 when the memory circuit breaker issue
@@ -135,7 +132,6 @@ public class HashJoinIT extends SQLIntegTestCase {
     }
 
     private void testJoinWithObjectField(final String join, final String hint) throws IOException {
-
         final String queryPrefix = "SELECT";
 
         // TODO: reduce the balance threshold to 10000 when the memory circuit breaker issue
@@ -153,7 +149,6 @@ public class HashJoinIT extends SQLIntegTestCase {
     }
 
     private void executeAndCompareOldAndNewJoins(final String oldQuery, final String newQuery) throws IOException {
-
         final JSONObject responseOld = executeQuery(oldQuery);
         final JSONObject responseNew = executeQuery(newQuery);
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/HashJoinIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/HashJoinIT.java
@@ -22,11 +22,11 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Set;
 
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_GAME_OF_THRONES;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -126,7 +126,7 @@ public class HashJoinIT extends SQLIntegTestCase {
         //  (https://github.com/opendistro-for-elasticsearch/sql/issues/73) is fixed.
         final String querySuffixTemplate = "a.firstname, a.lastname, b.city, b.state FROM %1$s a %2$s %1$s b " +
                 "ON b.age = a.age WHERE a.balance > 45000 AND b.age > 25 LIMIT 1000000";
-        final String querySuffix = String.format(Locale.ROOT, querySuffixTemplate, TEST_INDEX_ACCOUNT, join);
+        final String querySuffix = format(querySuffixTemplate, TEST_INDEX_ACCOUNT, join);
 
         final String oldQuery = String.join(" ", queryPrefix, USE_OLD_JOIN_ALGORITHM, querySuffix);
         final String newQuery = String.join(" ", queryPrefix, BYPASS_CIRCUIT_BREAK, querySuffix);
@@ -144,7 +144,7 @@ public class HashJoinIT extends SQLIntegTestCase {
                 "FROM %1$s c %2$s %1$s f ON f.gender.keyword = c.gender.keyword " +
                 "AND f.house.keyword = c.house.keyword " +
                 "WHERE c.gender = 'M' LIMIT 1000000";
-        final String querySuffix = String.format(Locale.ROOT, querySuffixTemplate, TEST_INDEX_GAME_OF_THRONES, join);
+        final String querySuffix = format(querySuffixTemplate, TEST_INDEX_GAME_OF_THRONES, join);
 
         final String oldQuery = String.join(" ", queryPrefix, USE_OLD_JOIN_ALGORITHM, querySuffix);
         final String newQuery = String.join(" ", queryPrefix, hint, BYPASS_CIRCUIT_BREAK, querySuffix);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/HavingIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/HavingIT.java
@@ -175,7 +175,6 @@ public class HavingIT extends SQLIntegTestCase {
     }
 
     private Set<Object[]> getResult(JSONObject response, String aggName, String aggFunc) {
-
         String bucketsPath = format("/aggregations/%s/buckets", aggName);
         JSONArray buckets = (JSONArray) response.query(bucketsPath);
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/HavingIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/HavingIT.java
@@ -25,10 +25,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
@@ -176,7 +176,7 @@ public class HavingIT extends SQLIntegTestCase {
 
     private Set<Object[]> getResult(JSONObject response, String aggName, String aggFunc) {
 
-        String bucketsPath = String.format(Locale.ROOT, "/aggregations/%s/buckets", aggName);
+        String bucketsPath = format("/aggregations/%s/buckets", aggName);
         JSONArray buckets = (JSONArray) response.query(bucketsPath);
 
         Set<Object[]> result = new HashSet<>();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JSONRequestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JSONRequestIT.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Map;
 
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -45,7 +46,7 @@ public class JSONRequestIT extends SQLIntegTestCase {
     @Test
     public void search() throws IOException {
         int ageToCompare = 25;
-        SearchHits response = query(String.format("{\"query\":\"" +
+        SearchHits response = query(format("{\"query\":\"" +
                 "SELECT * " +
                 "FROM %s/account " +
                 "WHERE age > %s " +
@@ -73,10 +74,11 @@ public class JSONRequestIT extends SQLIntegTestCase {
          * }
          */
         int ageToCompare = 25;
-        SearchHits response = query(String.format("{\"query\":\"" +
+        SearchHits response = query(format("{\"query\":\"" +
                 "SELECT * " +
                 "FROM %s/account " +
-                "LIMIT 1000\",\"filter\":{\"range\":{\"age\":{\"gt\":%s}}}}", TestsConstants.TEST_INDEX_ACCOUNT, ageToCompare));
+                "LIMIT 1000\",\"filter\":{\"range\":{\"age\":{\"gt\":%s}}}}",
+                TestsConstants.TEST_INDEX_ACCOUNT, ageToCompare));
         SearchHit[] hits = response.getHits();
         for (SearchHit hit : hits) {
             int age = (int) hit.getSourceAsMap().get("age");
@@ -101,7 +103,7 @@ public class JSONRequestIT extends SQLIntegTestCase {
          */
         int ageToCompare = 25;
         int balanceToCompare = 35000;
-        SearchHits response = query(String.format("{\"query\":\"" +
+        SearchHits response = query(format("{\"query\":\"" +
                 "SELECT * " +
                 "FROM %s/account " +
                 "WHERE age > %s " +
@@ -135,7 +137,7 @@ public class JSONRequestIT extends SQLIntegTestCase {
          */
         int likesToCompare = 3;
         String fieldToCompare = "a";
-        SearchHits response = query(String.format("{\"query\":\"" +
+        SearchHits response = query(format("{\"query\":\"" +
                 "SELECT * " +
                 "FROM %s/nestedType " +
                 "WHERE nested(comment.likes) < %s\"," +
@@ -174,7 +176,7 @@ public class JSONRequestIT extends SQLIntegTestCase {
          */
         int likesToCompare = 1;
         String dataToCompare = "aa";
-        SearchHits response = query(String.format("{\"query\":\"" +
+        SearchHits response = query(format("{\"query\":\"" +
                 "SELECT * " +
                 "FROM %s/nestedType " +
                 "WHERE nested(comment.likes) > %s\"," +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JoinIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JoinIT.java
@@ -48,7 +48,6 @@ public class JoinIT extends SQLIntegTestCase {
 
     @Override
     protected void init() throws Exception {
-
         loadIndex(Index.DOG);
         loadIndex(Index.DOGS2);
         loadIndex(Index.PEOPLE);
@@ -71,7 +70,6 @@ public class JoinIT extends SQLIntegTestCase {
 
     @Test
     public void joinParseWithHintsCheckSelectedFieldsSplitHASH() throws IOException {
-
         String query = format("SELECT /*! HASH_WITH_TERMS_FILTER*/ " +
                 "a.firstname ,a.lastname, a.gender ,d.dog_name FROM %s/people a JOIN %s/dog d " +
                 "ON d.holdersName = a.firstname WHERE (a.age > 10 OR a.balance > 2000) AND d.age > 1",
@@ -92,19 +90,16 @@ public class JoinIT extends SQLIntegTestCase {
 
     @Test
     public void joinWithNoWhereButWithConditionHash() throws IOException {
-
         joinWithNoWhereButWithCondition(false);
     }
 
     @Test
     public void joinWithNoWhereButWithConditionNL() throws IOException {
-
         joinWithNoWhereButWithCondition(true);
     }
 
     @Test
     public void joinWithStarHASH() throws IOException {
-
         String query = format("SELECT * FROM %1$s/gotCharacters c " +
                 "JOIN %1$s/gotCharacters h ON h.hname = c.house ", TEST_INDEX_GAME_OF_THRONES);
 
@@ -120,162 +115,135 @@ public class JoinIT extends SQLIntegTestCase {
 
     @Test
     public void joinNoConditionButWithWhereHASH() throws IOException {
-
         joinNoConditionButWithWhere(false);
     }
 
     @Test
     public void joinNoConditionButWithWhereNL() throws IOException {
-
         joinNoConditionButWithWhere(true);
     }
 
     @Test
     public void joinNoConditionAndNoWhereHASH() throws IOException {
-
         joinNoConditionAndNoWhere(false);
     }
 
     @Test
     public void joinNoConditionAndNoWhereNL() throws IOException {
-
         joinNoConditionAndNoWhere(true);
     }
 
     @Test
     public void joinNoConditionAndNoWhereWithTotalLimitHASH() throws IOException {
-
         joinNoConditionAndNoWhereWithTotalLimit(false);
     }
 
     @Test
     public void joinNoConditionAndNoWhereWithTotalLimitNL() throws IOException {
-
         joinNoConditionAndNoWhereWithTotalLimit(true);
     }
 
     @Test
     public void joinWithNestedFieldsOnReturnHASH() throws IOException {
-
         joinWithNestedFieldsOnReturn(false);
     }
 
     @Test
     public void joinWithNestedFieldsOnReturnNL() throws IOException {
-
         joinWithNestedFieldsOnReturn(true);
     }
 
     @Test
     public void joinWithAllAliasOnReturnHASH() throws IOException {
-
         joinWithAllAliasOnReturn(false);
     }
     @Test
     public void joinWithAllAliasOnReturnNL() throws IOException {
-
         joinWithAllAliasOnReturn(true);
     }
 
     @Test
     public void joinWithSomeAliasOnReturnHASH() throws IOException {
-
         joinWithSomeAliasOnReturn(false);
     }
 
     @Test
     public void joinWithSomeAliasOnReturnNL() throws IOException {
-
         joinWithSomeAliasOnReturn(true);
     }
 
     @Test
     public void joinWithNestedFieldsOnComparisonAndOnReturnHASH() throws IOException {
-
         joinWithNestedFieldsOnComparisonAndOnReturn(false);
     }
 
     @Test
     public void joinWithNestedFieldsOnComparisonAndOnReturnNL() throws IOException {
-
         joinWithNestedFieldsOnComparisonAndOnReturn(true);
     }
 
     @Test
     public void testLeftJoinHASH() throws IOException {
-
         testLeftJoin(false);
     }
 
     @Test
     public void testLeftJoinNL() throws IOException {
-
         testLeftJoin(true);
     }
 
     @Test
     public void hintLimits_firstLimitSecondNullHASH() throws IOException {
-
         hintLimits_firstLimitSecondNull(false);
     }
 
     @Test
     public void hintLimits_firstLimitSecondNullNL() throws IOException {
-
         hintLimits_firstLimitSecondNull(true);
     }
 
     @Test
     public void hintLimits_firstLimitSecondLimitHASH() throws IOException {
-
         hintLimits_firstLimitSecondLimit(false);
     }
 
     @Test
     public void hintLimits_firstLimitSecondLimitNL() throws IOException {
-
         hintLimits_firstLimitSecondLimit(true);
     }
 
     @Test
     public void hintLimits_firstLimitSecondLimitOnlyOneNL() throws IOException {
-
         hintLimits_firstLimitSecondLimitOnlyOne(true);
     }
 
     @Test
     public void hintLimits_firstLimitSecondLimitOnlyOneHASH() throws IOException {
-
         hintLimits_firstLimitSecondLimitOnlyOne(false);
     }
 
     @Test
     public void hintLimits_firstNullSecondLimitHASH() throws IOException {
-
         hintLimits_firstNullSecondLimit(false);
     }
 
     @Test
     public void hintLimits_firstNullSecondLimitNL() throws IOException {
-
         hintLimits_firstNullSecondLimit(true);
     }
 
     @Test
     public void testLeftJoinWithLimitHASH() throws IOException {
-
         testLeftJoinWithLimit(false);
     }
 
     @Test
     public void testLeftJoinWithLimitNL() throws IOException {
-
         testLeftJoinWithLimit(true);
     }
 
     @Test
     public void hintMultiSearchCanRunFewTimesNL() throws IOException {
-
         String query = format("SELECT /*! USE_NL*/ /*! NL_MULTISEARCH_SIZE(2)*/ " +
                 "c.name.firstname,c.parents.father,h.hname,h.words FROM %1$s/gotCharacters c " +
                 "JOIN %1$s/gotCharacters h", TEST_INDEX_GAME_OF_THRONES);
@@ -287,7 +255,6 @@ public class JoinIT extends SQLIntegTestCase {
 
     @Test
     public void joinWithGeoIntersectNL() throws IOException {
-
         String query = format("SELECT p1.description,p2.description " +
                 "FROM %s/location p1 JOIN %s/location2 p2 ON GEO_INTERSECTS(p2.place,p1.place)",
                 TEST_INDEX_LOCATION, TEST_INDEX_LOCATION2);
@@ -305,7 +272,6 @@ public class JoinIT extends SQLIntegTestCase {
     @Ignore
     @Test
     public void joinWithInQuery() throws IOException {
-
         //TODO: Either change the ON condition field to keyword or create a different subquery
         String query = format("SELECT c.gender,c.name.firstname,h.hname,h.words " +
                 "FROM %1$s/gotCharacters c JOIN %1$s/gotCharacters h ON h.hname = c.house " +
@@ -320,20 +286,17 @@ public class JoinIT extends SQLIntegTestCase {
 
     @Test
     public void joinWithOrHASH() throws IOException {
-
         joinWithOr(false);
     }
 
     @Test
     public void joinWithOrNL() throws IOException {
-
         joinWithOr(true);
     }
 
     @Ignore // TODO: explanation does not have the terms section
     @Test
     public void joinWithOrWithTermsFilterOpt() throws IOException {
-
         String query = format("SELECT /*! HASH_WITH_TERMS_FILTER*/ " +
                         "d.dog_name,c.name.firstname FROM %s/gotCharacters c " +
                         "JOIN %s/dog d ON d.holdersName = c.name.firstname OR d.age = c.name.ofHisName",
@@ -352,55 +315,46 @@ public class JoinIT extends SQLIntegTestCase {
 
     @Test
     public void joinWithOrderbyFirstTableHASH() throws IOException {
-
         joinWithOrderFirstTable(false);
     }
 
     @Test
     public void joinWithOrderbyFirstTableNL() throws IOException {
-
         joinWithOrderFirstTable(true);
     }
 
     @Test
     public void joinWithAllFromSecondTableHASH() throws IOException {
-
         joinWithAllFromSecondTable(false);
     }
 
     @Test
     public void joinWithAllFromSecondTableNL() throws IOException {
-
         joinWithAllFromSecondTable(true);
     }
 
     @Test
     public void joinWithAllFromFirstTableHASH() throws IOException {
-
         joinWithAllFromFirstTable(false);
     }
 
     @Test
     public void joinWithAllFromFirstTableNL() throws IOException {
-
         joinWithAllFromFirstTable(true);
     }
 
     @Test
     public void leftJoinWithAllFromSecondTableHASH() throws IOException {
-
         leftJoinWithAllFromSecondTable(false);
     }
 
     @Test
     public void leftJoinWithAllFromSecondTableNL() throws IOException {
-
         leftJoinWithAllFromSecondTable(true);
     }
 
     @Test
     public void joinParseCheckSelectedFieldsSplitNLConditionOrderEQ() throws IOException {
-
         final String query = format("SELECT /*! USE_NL*/ " +
                 "a.firstname, a.lastname, a.gender, d.dog_name FROM %s/people a JOIN %s/dog d " +
                 "ON a.firstname = d.holdersName WHERE (a.age > 10 OR a.balance > 2000) AND d.age > 1",
@@ -428,7 +382,6 @@ public class JoinIT extends SQLIntegTestCase {
 
     @Test
     public void joinParseCheckSelectedFieldsSplitNLConditionOrderGT() throws IOException {
-
         final String query = format("SELECT /*! USE_NL*/ " +
                 "a.firstname, a.lastname, a.gender, d.firstname, d.age  FROM " +
                 "%s/people a JOIN %s/account d on a.age < d.age " +
@@ -451,7 +404,6 @@ public class JoinIT extends SQLIntegTestCase {
 
     @Test
     public void joinParseCheckSelectedFieldsSplitNLConditionOrderLT() throws IOException {
-
         final String query = format("SELECT /*! USE_NL*/ " +
                 "a.firstname, a.lastname, a.gender, d.firstname, d.age  FROM " +
                 "%s/people a JOIN %s/account d on a.age > d.age " +
@@ -474,54 +426,45 @@ public class JoinIT extends SQLIntegTestCase {
 
     @Test
     public void leftJoinNLWithNullInCondition() throws IOException {
-
         joinWithNullInCondition(true, "LEFT", "OR", "OR", 7);
     }
 
     @Test
     public void leftJoinNLWithNullInCondition1() throws IOException {
-
         joinWithNullInCondition(true, "LEFT", "OR", "AND", 7);
     }
 
     @Test
     public void leftJoinNLWithNullInCondition2() throws IOException {
-
         joinWithNullInCondition(true, "LEFT", "AND", "AND", 7);
     }
 
     @Test
     public void leftJoinNLWithNullInCondition3() throws IOException {
-
         joinWithNullInCondition(true, "LEFT", "AND", "OR", 7);
     }
 
     @Test
     public void innerJoinNLWithNullInCondition() throws IOException {
-
         joinWithNullInCondition(true, "", "OR", "OR", 0 );
     }
 
     @Test
     public void innerJoinNLWithNullInCondition1() throws IOException {
-
         joinWithNullInCondition(true, "", "OR", "AND", 0);
     }
 
     @Test
     public void innerJoinNLWithNullInCondition2() throws IOException {
-
         joinWithNullInCondition(true, "", "AND", "AND", 0);
     }
 
     @Test
     public void innerJoinNLWithNullInCondition3() throws IOException {
-
         joinWithNullInCondition(true, "", "AND", "OR", 0);
     }
 
     private void joinWithAllFromSecondTable(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         final String query = format("SELECT%1$s c.name.firstname, d.* " +
                         "FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters d ON d.hname = c.house",
@@ -539,7 +482,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinWithAllFromFirstTable(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         final String query = format("SELECT%1$s c.name.firstname " +
                         "FROM %2$s/gotCharacters d JOIN %2$s/gotCharacters c ON c.house = d.hname",
@@ -557,7 +499,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void leftJoinWithAllFromSecondTable(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         final String query = format("SELECT%1$s c.name.firstname, d.* " +
                         "FROM %2$s/gotCharacters c LEFT JOIN %2$s/gotCharacters d ON d.hname = c.house",
@@ -577,7 +518,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinParseCheckSelectedFieldsSplit(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s a.firstname ,a.lastname,a.gender,d.dog_name " +
                 "FROM %s/people a JOIN %s/dog d ON d.holdersName = a.firstname " +
@@ -588,7 +528,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinNoConditionButWithWhere(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s c.gender,h.hname,h.words FROM %2$s/gotCharacters c " +
                         "JOIN %2$s/gotCharacters h WHERE match_phrase(c.name.firstname, 'Daenerys')",
@@ -600,7 +539,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinNoConditionAndNoWhere(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s c.name.firstname,c.parents.father,h.hname,h.words " +
                         "FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h",
@@ -612,7 +550,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinWithNoWhereButWithCondition(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s c.gender,h.hname,h.words " +
                         "FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h ON h.hname = c.house",
@@ -636,7 +573,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void verifyJoinParseCheckSelectedFieldsSplitResult(JSONObject result, boolean useNestedLoops) {
-
         Map<String, String> match1 = ImmutableMap.of(
                 "a.firstname", "Daenerys",
                 "a.lastname", "Targaryen",
@@ -662,7 +598,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinNoConditionAndNoWhereWithTotalLimit(boolean useNestedLoops) throws  IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s c.name.firstname,c.parents.father,h.hname,h.words" +
                         " FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h LIMIT 9",
@@ -674,7 +609,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinWithNestedFieldsOnReturn(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s c.name.firstname,c.parents.father,h.hname,h.words " +
                         "FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h ON h.hname = c.house " +
@@ -697,7 +631,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinWithAllAliasOnReturn(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s c.name.firstname name,c.parents.father father," +
                         "h.hname house FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h ON h.hname = c.house " +
@@ -720,7 +653,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinWithSomeAliasOnReturn(boolean useNestedLoops)  throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s c.name.firstname ,c.parents.father father, " +
                         "h.hname house FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h ON h.hname = c.house " +
@@ -744,7 +676,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinWithNestedFieldsOnComparisonAndOnReturn(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s c.name.firstname,c.parents.father, h.hname,h.words " +
                         " FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h ON h.hname = c.name.lastname " +
@@ -768,7 +699,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void testLeftJoin(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s c.name.firstname, f.name.firstname,f.name.lastname " +
                         "FROM %2$s/gotCharacters c LEFT JOIN %2$s/gotCharacters f " +
@@ -800,7 +730,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void hintLimits_firstLimitSecondNull(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s /*! JOIN_TABLES_LIMIT(2,null) */ " +
                         "c.name.firstname,c.parents.father, h.hname,h.words " +
@@ -813,7 +742,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void hintLimits_firstLimitSecondLimit(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s /*! JOIN_TABLES_LIMIT(2,2) */ " +
                 "c.name.firstname,c.parents.father, h.hname,h.words FROM %2$s/gotCharacters c " +
@@ -825,7 +753,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void hintLimits_firstLimitSecondLimitOnlyOne(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s /*! JOIN_TABLES_LIMIT(3,1) */ " +
                         "c.name.firstname,c.parents.father , h.hname,h.words FROM %2$s/gotCharacters h " +
@@ -838,7 +765,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void hintLimits_firstNullSecondLimit(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s /*! JOIN_TABLES_LIMIT(null,2) */ " +
                 "c.name.firstname,c.parents.father , h.hname,h.words FROM %2$s/gotCharacters c " +
@@ -850,7 +776,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void testLeftJoinWithLimit(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s /*! JOIN_TABLES_LIMIT(3,null) */ " +
                         "c.name.firstname, f.name.firstname,f.name.lastname FROM %2$s/gotCharacters c " +
@@ -863,7 +788,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinWithOr(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s d.dog_name,c.name.firstname " +
                         "FROM %s/gotCharacters c JOIN %s/dog d " +
@@ -891,7 +815,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void joinWithOrderFirstTable(boolean useNestedLoops) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s c.name.firstname,d.words " +
                         "FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters d ON d.hname = c.house " +
@@ -904,7 +827,6 @@ public class JoinIT extends SQLIntegTestCase {
         if (useNestedLoops) {
             Assert.assertThat(hits.length(), equalTo(0));
         } else {
-
             Assert.assertThat(hits.length(), equalTo(4));
 
             String[] expectedNames = { "Brandon", "Daenerys", "Eddard", "Jaime" };
@@ -917,7 +839,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private boolean containsTerm(final String explainedQuery, final String termName) {
-
         return Pattern.compile(
                 Pattern.quote("\"terms\":{")
                         + ".*"
@@ -929,7 +850,6 @@ public class JoinIT extends SQLIntegTestCase {
 
     private void joinWithNullInCondition(boolean useNestedLoops, String left,
                                          String oper1, String oper2, int expectedNum) throws IOException {
-
         final String hint = useNestedLoops ? USE_NL_HINT : "";
         String query = format("SELECT%s c.name.firstname,c.parents.father,c.hname," +
                         "f.name.firstname,f.house,f.hname FROM %s/gotCharacters c " +
@@ -951,9 +871,7 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private boolean hitsInclude(final JSONArray actualHits, Map<String, ?> expectedSourceValues) {
-
         for (final Object hitObj : actualHits.toList()) {
-
             final Map<String, ?> hit = uncheckedGetMap(hitObj);
             if (hitMatches(hit, expectedSourceValues)) {
                 return true;
@@ -964,7 +882,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private void assertHitMatches(final JSONObject actualHit, final Map<String, ?> expectedSourceValues) {
-
         final JSONObject src = actualHit.getJSONObject("_source");
         Assert.assertThat(src.length(), equalTo(expectedSourceValues.size()));
         src.keySet().forEach(key -> {
@@ -975,7 +892,6 @@ public class JoinIT extends SQLIntegTestCase {
     }
 
     private boolean hitMatches(final Map<String, ?> actualHit, final Map<String, ?> expectedSourceValues) {
-
         final Map<String, ?> src = uncheckedGetMap(actualHit.get("_source"));
 
         if (src.size() != expectedSourceValues.size()) {
@@ -983,7 +899,6 @@ public class JoinIT extends SQLIntegTestCase {
         }
 
         for (final String key: src.keySet()) {
-
             if (!expectedSourceValues.containsKey(key)) {
                 return false;
             }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JoinIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JoinIT.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
@@ -38,6 +37,7 @@ import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstant
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_LOCATION2;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_PEOPLE;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_PEOPLE2;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -72,7 +72,7 @@ public class JoinIT extends SQLIntegTestCase {
     @Test
     public void joinParseWithHintsCheckSelectedFieldsSplitHASH() throws IOException {
 
-        String query = String.format(Locale.ROOT, "SELECT /*! HASH_WITH_TERMS_FILTER*/ " +
+        String query = format("SELECT /*! HASH_WITH_TERMS_FILTER*/ " +
                 "a.firstname ,a.lastname, a.gender ,d.dog_name FROM %s/people a JOIN %s/dog d " +
                 "ON d.holdersName = a.firstname WHERE (a.age > 10 OR a.balance > 2000) AND d.age > 1",
                 TEST_INDEX_PEOPLE, TEST_INDEX_DOG);
@@ -105,7 +105,7 @@ public class JoinIT extends SQLIntegTestCase {
     @Test
     public void joinWithStarHASH() throws IOException {
 
-        String query = String.format(Locale.ROOT, "SELECT * FROM %1$s/gotCharacters c " +
+        String query = format("SELECT * FROM %1$s/gotCharacters c " +
                 "JOIN %1$s/gotCharacters h ON h.hname = c.house ", TEST_INDEX_GAME_OF_THRONES);
 
         JSONObject result = executeQuery(query);
@@ -276,7 +276,7 @@ public class JoinIT extends SQLIntegTestCase {
     @Test
     public void hintMultiSearchCanRunFewTimesNL() throws IOException {
 
-        String query = String.format(Locale.ROOT, "SELECT /*! USE_NL*/ /*! NL_MULTISEARCH_SIZE(2)*/ " +
+        String query = format("SELECT /*! USE_NL*/ /*! NL_MULTISEARCH_SIZE(2)*/ " +
                 "c.name.firstname,c.parents.father,h.hname,h.words FROM %1$s/gotCharacters c " +
                 "JOIN %1$s/gotCharacters h", TEST_INDEX_GAME_OF_THRONES);
 
@@ -288,7 +288,7 @@ public class JoinIT extends SQLIntegTestCase {
     @Test
     public void joinWithGeoIntersectNL() throws IOException {
 
-        String query = String.format(Locale.ROOT, "SELECT p1.description,p2.description " +
+        String query = format("SELECT p1.description,p2.description " +
                 "FROM %s/location p1 JOIN %s/location2 p2 ON GEO_INTERSECTS(p2.place,p1.place)",
                 TEST_INDEX_LOCATION, TEST_INDEX_LOCATION2);
 
@@ -307,7 +307,7 @@ public class JoinIT extends SQLIntegTestCase {
     public void joinWithInQuery() throws IOException {
 
         //TODO: Either change the ON condition field to keyword or create a different subquery
-        String query = String.format(Locale.ROOT, "SELECT c.gender,c.name.firstname,h.hname,h.words " +
+        String query = format("SELECT c.gender,c.name.firstname,h.hname,h.words " +
                 "FROM %1$s/gotCharacters c JOIN %1$s/gotCharacters h ON h.hname = c.house " +
                 "WHERE c.name.firstname IN (SELECT holdersName FROM %2$s/dog)",
                 TEST_INDEX_GAME_OF_THRONES, TEST_INDEX_DOG);
@@ -334,7 +334,7 @@ public class JoinIT extends SQLIntegTestCase {
     @Test
     public void joinWithOrWithTermsFilterOpt() throws IOException {
 
-        String query = String.format(Locale.ROOT, "SELECT /*! HASH_WITH_TERMS_FILTER*/ " +
+        String query = format("SELECT /*! HASH_WITH_TERMS_FILTER*/ " +
                         "d.dog_name,c.name.firstname FROM %s/gotCharacters c " +
                         "JOIN %s/dog d ON d.holdersName = c.name.firstname OR d.age = c.name.ofHisName",
                 TEST_INDEX_GAME_OF_THRONES, TEST_INDEX_DOG);
@@ -401,7 +401,7 @@ public class JoinIT extends SQLIntegTestCase {
     @Test
     public void joinParseCheckSelectedFieldsSplitNLConditionOrderEQ() throws IOException {
 
-        final String query = String.format(Locale.ROOT, "SELECT /*! USE_NL*/ " +
+        final String query = format("SELECT /*! USE_NL*/ " +
                 "a.firstname, a.lastname, a.gender, d.dog_name FROM %s/people a JOIN %s/dog d " +
                 "ON a.firstname = d.holdersName WHERE (a.age > 10 OR a.balance > 2000) AND d.age > 1",
                 TEST_INDEX_PEOPLE2, TEST_INDEX_DOG2);
@@ -429,7 +429,7 @@ public class JoinIT extends SQLIntegTestCase {
     @Test
     public void joinParseCheckSelectedFieldsSplitNLConditionOrderGT() throws IOException {
 
-        final String query = String.format(Locale.ROOT, "SELECT /*! USE_NL*/ " +
+        final String query = format("SELECT /*! USE_NL*/ " +
                 "a.firstname, a.lastname, a.gender, d.firstname, d.age  FROM " +
                 "%s/people a JOIN %s/account d on a.age < d.age " +
                 "WHERE (d.firstname = 'Lynn' OR d.firstname = 'Obrien') AND a.firstname = 'Mcgee'",
@@ -452,7 +452,7 @@ public class JoinIT extends SQLIntegTestCase {
     @Test
     public void joinParseCheckSelectedFieldsSplitNLConditionOrderLT() throws IOException {
 
-        final String query = String.format(Locale.ROOT, "SELECT /*! USE_NL*/ " +
+        final String query = format("SELECT /*! USE_NL*/ " +
                 "a.firstname, a.lastname, a.gender, d.firstname, d.age  FROM " +
                 "%s/people a JOIN %s/account d on a.age > d.age " +
                 "WHERE (d.firstname = 'Sandoval' OR d.firstname = 'Hewitt') AND a.firstname = 'Fulton'",
@@ -523,7 +523,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinWithAllFromSecondTable(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        final String query = String.format(Locale.ROOT, "SELECT%1$s c.name.firstname, d.* " +
+        final String query = format("SELECT%1$s c.name.firstname, d.* " +
                         "FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters d ON d.hname = c.house",
                 hint, TEST_INDEX_GAME_OF_THRONES);
 
@@ -541,7 +541,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinWithAllFromFirstTable(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        final String query = String.format(Locale.ROOT, "SELECT%1$s c.name.firstname " +
+        final String query = format("SELECT%1$s c.name.firstname " +
                         "FROM %2$s/gotCharacters d JOIN %2$s/gotCharacters c ON c.house = d.hname",
                 hint, TEST_INDEX_GAME_OF_THRONES);
 
@@ -559,7 +559,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void leftJoinWithAllFromSecondTable(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        final String query = String.format(Locale.ROOT, "SELECT%1$s c.name.firstname, d.* " +
+        final String query = format("SELECT%1$s c.name.firstname, d.* " +
                         "FROM %2$s/gotCharacters c LEFT JOIN %2$s/gotCharacters d ON d.hname = c.house",
                 hint, TEST_INDEX_GAME_OF_THRONES);
 
@@ -579,7 +579,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinParseCheckSelectedFieldsSplit(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s a.firstname ,a.lastname,a.gender,d.dog_name " +
+        String query = format("SELECT%s a.firstname ,a.lastname,a.gender,d.dog_name " +
                 "FROM %s/people a JOIN %s/dog d ON d.holdersName = a.firstname " +
                 "WHERE (a.age > 10 OR a.balance > 2000) AND d.age > 1", hint, TEST_INDEX_PEOPLE, TEST_INDEX_DOG);
 
@@ -590,7 +590,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinNoConditionButWithWhere(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s c.gender,h.hname,h.words FROM %2$s/gotCharacters c " +
+        String query = format("SELECT%s c.gender,h.hname,h.words FROM %2$s/gotCharacters c " +
                         "JOIN %2$s/gotCharacters h WHERE match_phrase(c.name.firstname, 'Daenerys')",
                 hint, TEST_INDEX_GAME_OF_THRONES);
 
@@ -602,7 +602,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinNoConditionAndNoWhere(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s c.name.firstname,c.parents.father,h.hname,h.words " +
+        String query = format("SELECT%s c.name.firstname,c.parents.father,h.hname,h.words " +
                         "FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h",
                 hint, TEST_INDEX_GAME_OF_THRONES);
 
@@ -614,7 +614,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinWithNoWhereButWithCondition(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s c.gender,h.hname,h.words " +
+        String query = format("SELECT%s c.gender,h.hname,h.words " +
                         "FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h ON h.hname = c.house",
                 hint, TEST_INDEX_GAME_OF_THRONES);
 
@@ -664,7 +664,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinNoConditionAndNoWhereWithTotalLimit(boolean useNestedLoops) throws  IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s c.name.firstname,c.parents.father,h.hname,h.words" +
+        String query = format("SELECT%s c.name.firstname,c.parents.father,h.hname,h.words" +
                         " FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h LIMIT 9",
                 hint, TEST_INDEX_GAME_OF_THRONES);
 
@@ -676,7 +676,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinWithNestedFieldsOnReturn(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s c.name.firstname,c.parents.father,h.hname,h.words " +
+        String query = format("SELECT%s c.name.firstname,c.parents.father,h.hname,h.words " +
                         "FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h ON h.hname = c.house " +
                         "WHERE match_phrase(c.name.firstname, 'Daenerys')",
                 hint, TEST_INDEX_GAME_OF_THRONES);
@@ -699,7 +699,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinWithAllAliasOnReturn(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s c.name.firstname name,c.parents.father father," +
+        String query = format("SELECT%s c.name.firstname name,c.parents.father father," +
                         "h.hname house FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h ON h.hname = c.house " +
                         "WHERE match_phrase(c.name.firstname, 'Daenerys')",
                 hint, TEST_INDEX_GAME_OF_THRONES);
@@ -722,7 +722,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinWithSomeAliasOnReturn(boolean useNestedLoops)  throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s c.name.firstname ,c.parents.father father, " +
+        String query = format("SELECT%s c.name.firstname ,c.parents.father father, " +
                         "h.hname house FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h ON h.hname = c.house " +
                         "WHERE match_phrase(c.name.firstname, 'Daenerys')",
                 hint, TEST_INDEX_GAME_OF_THRONES);
@@ -746,7 +746,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinWithNestedFieldsOnComparisonAndOnReturn(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s c.name.firstname,c.parents.father, h.hname,h.words " +
+        String query = format("SELECT%s c.name.firstname,c.parents.father, h.hname,h.words " +
                         " FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h ON h.hname = c.name.lastname " +
                         "WHERE match_phrase(c.name.firstname, 'Daenerys')",
                 hint, TEST_INDEX_GAME_OF_THRONES);
@@ -770,7 +770,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void testLeftJoin(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format("SELECT%s c.name.firstname, f.name.firstname,f.name.lastname " +
+        String query = format("SELECT%s c.name.firstname, f.name.firstname,f.name.lastname " +
                         "FROM %2$s/gotCharacters c LEFT JOIN %2$s/gotCharacters f " +
                         "ON f.name.firstname = c.parents.father",
                 hint, TEST_INDEX_GAME_OF_THRONES);
@@ -802,7 +802,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void hintLimits_firstLimitSecondNull(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s /*! JOIN_TABLES_LIMIT(2,null) */ " +
+        String query = format("SELECT%s /*! JOIN_TABLES_LIMIT(2,null) */ " +
                         "c.name.firstname,c.parents.father, h.hname,h.words " +
                         "FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters h",
                 hint, TEST_INDEX_GAME_OF_THRONES);
@@ -815,7 +815,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void hintLimits_firstLimitSecondLimit(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s /*! JOIN_TABLES_LIMIT(2,2) */ " +
+        String query = format("SELECT%s /*! JOIN_TABLES_LIMIT(2,2) */ " +
                 "c.name.firstname,c.parents.father, h.hname,h.words FROM %2$s/gotCharacters c " +
                 "JOIN %2$s/gotCharacters h", hint, TEST_INDEX_GAME_OF_THRONES);
 
@@ -827,7 +827,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void hintLimits_firstLimitSecondLimitOnlyOne(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s /*! JOIN_TABLES_LIMIT(3,1) */ " +
+        String query = format("SELECT%s /*! JOIN_TABLES_LIMIT(3,1) */ " +
                         "c.name.firstname,c.parents.father , h.hname,h.words FROM %2$s/gotCharacters h " +
                         "JOIN  %2$s/gotCharacters c  ON c.name.lastname = h.hname",
                 hint, TEST_INDEX_GAME_OF_THRONES);
@@ -840,7 +840,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void hintLimits_firstNullSecondLimit(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s /*! JOIN_TABLES_LIMIT(null,2) */ " +
+        String query = format("SELECT%s /*! JOIN_TABLES_LIMIT(null,2) */ " +
                 "c.name.firstname,c.parents.father , h.hname,h.words FROM %2$s/gotCharacters c " +
                 "JOIN %2$s/gotCharacters h", hint, TEST_INDEX_GAME_OF_THRONES);
 
@@ -852,7 +852,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void testLeftJoinWithLimit(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s /*! JOIN_TABLES_LIMIT(3,null) */ " +
+        String query = format("SELECT%s /*! JOIN_TABLES_LIMIT(3,null) */ " +
                         "c.name.firstname, f.name.firstname,f.name.lastname FROM %2$s/gotCharacters c " +
                         "LEFT JOIN %2$s/gotCharacters f ON f.name.firstname = c.parents.father",
                 hint, TEST_INDEX_GAME_OF_THRONES);
@@ -865,7 +865,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinWithOr(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s d.dog_name,c.name.firstname " +
+        String query = format("SELECT%s d.dog_name,c.name.firstname " +
                         "FROM %s/gotCharacters c JOIN %s/dog d " +
                         "ON d.holdersName = c.name.firstname OR d.age = c.name.ofHisName",
                 hint, TEST_INDEX_GAME_OF_THRONES, TEST_INDEX_DOG);
@@ -893,7 +893,7 @@ public class JoinIT extends SQLIntegTestCase {
     private void joinWithOrderFirstTable(boolean useNestedLoops) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s c.name.firstname,d.words " +
+        String query = format("SELECT%s c.name.firstname,d.words " +
                         "FROM %2$s/gotCharacters c JOIN %2$s/gotCharacters d ON d.hname = c.house " +
                         "ORDER BY c.name.firstname",
                 hint, TEST_INDEX_GAME_OF_THRONES);
@@ -910,7 +910,7 @@ public class JoinIT extends SQLIntegTestCase {
             String[] expectedNames = { "Brandon", "Daenerys", "Eddard", "Jaime" };
 
             IntStream.rangeClosed(0, 3).forEach(i -> {
-                String firstnamePath = String.format(Locale.ROOT, "/%d/_source/c.name.firstname", i);
+                String firstnamePath = format("/%d/_source/c.name.firstname", i);
                 Assert.assertThat(hits.query(firstnamePath), equalTo(expectedNames[i]));
             });
         }
@@ -931,7 +931,7 @@ public class JoinIT extends SQLIntegTestCase {
                                          String oper1, String oper2, int expectedNum) throws IOException {
 
         final String hint = useNestedLoops ? USE_NL_HINT : "";
-        String query = String.format(Locale.ROOT, "SELECT%s c.name.firstname,c.parents.father,c.hname," +
+        String query = format("SELECT%s c.name.firstname,c.parents.father,c.hname," +
                         "f.name.firstname,f.house,f.hname FROM %s/gotCharacters c " +
                         "%s JOIN %s/gotCharacters f ON f.name.firstname = c.parents.father " +
                         "%s f.house = c.hname %s f.house = c.name.firstname",

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MetaDataQueriesIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MetaDataQueriesIT.java
@@ -24,11 +24,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
-
 
 /**
  * The following are tests for SHOW/DESCRIBE query support under Pretty Format Response protocol using JDBC format.
@@ -42,7 +42,8 @@ import static org.hamcrest.Matchers.not;
  * These are the outputs of "schema" for SHOW and DESCRIBE, the position of the value in "datarows" will match the
  * position of the field in "schema":
  *
- * 1) SHOW query (based on the getTables() method listed here https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html)
+ * 1) SHOW query (based on the getTables() method listed here
+ *      https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html)
  *    "schema": [
  *     {
  *       "name": "TABLE_CAT",
@@ -212,7 +213,7 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
 
     @Test
     public void showSingleIndex() throws IOException {
-        JSONObject response = executeQuery(String.format("SHOW TABLES LIKE %s", TestsConstants.TEST_INDEX_ACCOUNT));
+        JSONObject response = executeQuery(format("SHOW TABLES LIKE %s", TestsConstants.TEST_INDEX_ACCOUNT));
 
         String[] fields = {"TABLE_CAT", "TABLE_NAME", "TABLE_TYPE"};
         checkContainsColumns(getSchema(response), fields);
@@ -235,7 +236,7 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
 
     @Test
     public void showCaseSensitivityCheck() throws IOException {
-        JSONObject response = executeQuery(String.format("show tables like %s", TestsConstants.TEST_INDEX_ACCOUNT));
+        JSONObject response = executeQuery(format("show tables like %s", TestsConstants.TEST_INDEX_ACCOUNT));
 
         String[] fields = {"TABLE_CAT", "TABLE_NAME", "TABLE_TYPE"};
         checkContainsColumns(getSchema(response), fields);
@@ -252,9 +253,9 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
 
     @Test
     public void showWildcardIndex() throws IOException {
-        JSONObject response = executeQuery(String.format("SHOW TABLES LIKE %s%%", TestsConstants.TEST_INDEX));
+        JSONObject response = executeQuery(format("SHOW TABLES LIKE %s%%", TestsConstants.TEST_INDEX));
 
-        String pattern = String.format("%s.*", TestsConstants.TEST_INDEX);
+        String pattern = format("%s.*", TestsConstants.TEST_INDEX);
         JSONArray dataRows = getDataRows(response);
         assertThat(dataRows.length(), equalTo(3));
         for (int i = 0; i < dataRows.length(); i++) {
@@ -267,7 +268,7 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
 
     @Test
     public void describeSingleIndex() throws IOException {
-        JSONObject response = executeQuery(String.format("DESCRIBE TABLES LIKE %s", TestsConstants.TEST_INDEX_ACCOUNT));
+        JSONObject response = executeQuery(format("DESCRIBE TABLES LIKE %s", TestsConstants.TEST_INDEX_ACCOUNT));
 
         // Schema for DESCRIBE is filled with a lot of fields that aren't used so only the important
         // ones are checked for here
@@ -292,7 +293,7 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
 
     @Test
     public void describeCaseSensitivityCheck() throws IOException {
-        JSONObject response = executeQuery(String.format("describe tables like %s", TestsConstants.TEST_INDEX_ACCOUNT));
+        JSONObject response = executeQuery(format("describe tables like %s", TestsConstants.TEST_INDEX_ACCOUNT));
 
         String[] fields = {"TABLE_NAME", "COLUMN_NAME", "TYPE_NAME"};
         checkContainsColumns(getSchema(response), fields);
@@ -309,9 +310,9 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
 
     @Test
     public void describeWildcardIndex() throws IOException {
-        JSONObject response = executeQuery(String.format("DESCRIBE TABLES LIKE %s%%", TestsConstants.TEST_INDEX));
+        JSONObject response = executeQuery(format("DESCRIBE TABLES LIKE %s%%", TestsConstants.TEST_INDEX));
 
-        String pattern = String.format("%s.*", TestsConstants.TEST_INDEX);
+        String pattern = format("%s.*", TestsConstants.TEST_INDEX);
         JSONArray dataRows = getDataRows(response);
         assertThat(dataRows.length(), greaterThan(0));
         for (int i = 0; i < dataRows.length(); i++) {
@@ -324,7 +325,7 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
 
     @Test
     public void describeWildcardColumn() throws IOException {
-        JSONObject response = executeQuery(String.format("DESCRIBE TABLES LIKE %s COLUMNS LIKE %%name",
+        JSONObject response = executeQuery(format("DESCRIBE TABLES LIKE %s COLUMNS LIKE %%name",
                                 TestsConstants.TEST_INDEX_ACCOUNT));
 
         String pattern = ".*name";
@@ -340,7 +341,7 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
 
     @Test
     public void describeSingleCharacterWildcard() throws IOException {
-        JSONObject response = executeQuery(String.format("DESCRIBE TABLES LIKE %s COLUMNS LIKE %%na_e",
+        JSONObject response = executeQuery(format("DESCRIBE TABLES LIKE %s COLUMNS LIKE %%na_e",
                                 TestsConstants.TEST_INDEX_ACCOUNT));
 
         String pattern = ".*na.e";

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MethodQueryIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MethodQueryIT.java
@@ -19,8 +19,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Locale;
 
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsString;
 
@@ -44,7 +44,7 @@ public class MethodQueryIT extends SQLIntegTestCase {
      */
     @Test
     public void queryTest() throws IOException {
-        final String result = explainQuery(String.format(Locale.ROOT,
+        final String result = explainQuery(format(
                 "select address from %s where q= query('address:880 Holmes Lane') limit 3",
                 TestsConstants.TEST_INDEX_ACCOUNT));
         Assert.assertThat(result,
@@ -60,7 +60,7 @@ public class MethodQueryIT extends SQLIntegTestCase {
      */
     @Test
     public void matchQueryTest() throws IOException {
-        final String result = explainQuery(String.format(Locale.ROOT,
+        final String result = explainQuery(format(
                 "select address from %s where address= matchQuery('880 Holmes Lane') limit 3",
                 TestsConstants.TEST_INDEX_ACCOUNT));
         Assert.assertThat(result,
@@ -79,7 +79,7 @@ public class MethodQueryIT extends SQLIntegTestCase {
     // todo
     @Test
     public void scoreQueryTest() throws IOException {
-        final String result = explainQuery(String.format(Locale.ROOT,
+        final String result = explainQuery(format(
                 "select address from %s " +
                         "where score(matchQuery(address, 'Lane'),100) " +
                         "or score(matchQuery(address,'Street'),0.5)  order by _score desc limit 3",
@@ -99,7 +99,7 @@ public class MethodQueryIT extends SQLIntegTestCase {
      */
     @Test
     public void wildcardQueryTest() throws IOException {
-        final String result = explainQuery(String.format(Locale.ROOT,
+        final String result = explainQuery(format(
                 "select address from %s where address= wildcardQuery('l*e')  order by _score desc limit 3",
                 TestsConstants.TEST_INDEX_ACCOUNT));
         Assert.assertThat(result,
@@ -117,7 +117,7 @@ public class MethodQueryIT extends SQLIntegTestCase {
      */
     @Test
     public void matchPhraseQueryTest() throws IOException {
-        final String result = explainQuery(String.format(Locale.ROOT,
+        final String result = explainQuery(format(
                 "select address from %s " +
                         "where address= matchPhrase('671 Bristol Street')  order by _score desc limit 3",
                 TestsConstants.TEST_INDEX_ACCOUNT));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MetricsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MetricsIT.java
@@ -32,7 +32,9 @@ import java.io.InputStreamReader;
 import java.util.concurrent.TimeUnit;
 
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_DOG;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.equalTo;
+
 
 @Ignore
 public class MetricsIT extends SQLIntegTestCase {
@@ -53,7 +55,7 @@ public class MetricsIT extends SQLIntegTestCase {
 
     private void multiQueries(int n) throws IOException {
         for (int i=0; i<n; ++i) {
-            executeQuery(String.format("SELECT COUNT(*) FROM %s/dog", TEST_INDEX_DOG));
+            executeQuery(format("SELECT COUNT(*) FROM %s/dog", TEST_INDEX_DOG));
         }
     }
 
@@ -68,12 +70,12 @@ public class MetricsIT extends SQLIntegTestCase {
         RestClient restClient = ESIntegTestCase.getRestClient();
         Response sqlResponse = restClient.performRequest(request);
 
-        Assert.assertTrue(sqlResponse.getStatusLine().getStatusCode() == 200);
+        Assert.assertThat(sqlResponse.getStatusLine().getStatusCode(), equalTo(200));
 
         InputStream is = sqlResponse.getEntity().getContent();
         StringBuilder sb = new StringBuilder();
         try (BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
-            String line = null;
+            String line;
             while((line = br.readLine()) != null) {
                 sb.append(line);
             }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MultiQueryIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MultiQueryIT.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 
@@ -42,7 +43,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
 
     @Test
     public void unionAllSameRequestOnlyOneRecordTwice() throws IOException {
-        String query = String.format("SELECT firstname " +
+        String query = format("SELECT firstname " +
                                      "FROM %s/account " +
                                      "WHERE firstname = 'Amber' " +
                                      "LIMIT 1 " +
@@ -66,7 +67,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
 
     @Test
     public void unionAllOnlyOneRecordEachWithAlias() throws IOException {
-        String query = String.format("SELECT firstname FROM %s/account WHERE firstname = 'Amber' " +
+        String query = format("SELECT firstname FROM %s/account WHERE firstname = 'Amber' " +
                                      "UNION ALL " +
                                      "SELECT dog_name as firstname FROM %s/dog WHERE dog_name = 'rex'",
                 TestsConstants.TEST_INDEX_ACCOUNT, TestsConstants.TEST_INDEX_DOG);
@@ -88,7 +89,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
 
     @Test
     public void unionAllOnlyOneRecordEachWithComplexAlias() throws IOException {
-        String query = String.format("SELECT firstname FROM %s/account WHERE firstname = 'Amber' " +
+        String query = format("SELECT firstname FROM %s/account WHERE firstname = 'Amber' " +
                                      "UNION ALL " +
                                      "SELECT name.firstname as firstname " +
                                      "FROM %s/gotCharacters " +
@@ -152,7 +153,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
 
     @Test
     public void minusCMinusDTwoFieldsAliasOnBothSecondTableFields() throws IOException {
-        String query = String.format("SELECT pk, letter FROM %s/systems WHERE system_name = 'C' " +
+        String query = format("SELECT pk, letter FROM %s/systems WHERE system_name = 'C' " +
                                      "MINUS " +
                                      "SELECT myId as pk, myLetter as letter FROM %s/systems WHERE system_name = 'E'",
                 TestsConstants.TEST_INDEX_SYSTEM, TestsConstants.TEST_INDEX_SYSTEM);
@@ -182,7 +183,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
 
     @Test
     public void minusCMinusCTwoFieldsOneAlias() throws IOException {
-        String query = String.format("SELECT pk as myId, letter FROM %s/systems WHERE system_name = 'C' " +
+        String query = format("SELECT pk as myId, letter FROM %s/systems WHERE system_name = 'C' " +
                                      "MINUS " +
                                      "SELECT pk as myId, letter FROM %s/systems WHERE system_name = 'C'",
                 TestsConstants.TEST_INDEX_SYSTEM, TestsConstants.TEST_INDEX_SYSTEM);
@@ -193,7 +194,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
 
     @Test
     public void minusCMinusTNonExistentFieldTwoFields() throws IOException {
-        String query = String.format("SELECT pk, letter FROM %s/systems WHERE system_name = 'C' " +
+        String query = format("SELECT pk, letter FROM %s/systems WHERE system_name = 'C' " +
                                      "MINUS " +
                                      "SELECT pk, letter FROM %s/systems WHERE system_name = 'T' ",
                 TestsConstants.TEST_INDEX_SYSTEM, TestsConstants.TEST_INDEX_SYSTEM);
@@ -233,7 +234,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
     }
 
     private void innerMinusAMinusANoAlias(String hint) throws IOException {
-        String query = String.format("SELECT %s pk FROM %s/systems WHERE system_name = 'A' " +
+        String query = format("SELECT %s pk FROM %s/systems WHERE system_name = 'A' " +
                                      "MINUS " +
                                      "SELECT pk FROM %s/systems WHERE system_name = 'A'",
                 hint, TestsConstants.TEST_INDEX_SYSTEM, TestsConstants.TEST_INDEX_SYSTEM);
@@ -243,7 +244,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
     }
 
     private void innerMinusAMinusBNoAlias(String hint) throws IOException {
-        String query = String.format("SELECT %s pk FROM %s/systems WHERE system_name = 'A' " +
+        String query = format("SELECT %s pk FROM %s/systems WHERE system_name = 'A' " +
                                      "MINUS " +
                                      "SELECT pk FROM %s/systems WHERE system_name = 'B'",
                 hint, TestsConstants.TEST_INDEX_SYSTEM, TestsConstants.TEST_INDEX_SYSTEM);
@@ -259,7 +260,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
     }
 
     private void innerMinusCMinusDTwoFieldsNoAlias(String hint) throws IOException {
-        String query = String.format("SELECT %s pk, letter FROM %s/systems WHERE system_name = 'C' " +
+        String query = format("SELECT %s pk, letter FROM %s/systems WHERE system_name = 'C' " +
                                      "MINUS " +
                                      "SELECT pk, letter FROM %s/systems WHERE system_name = 'D'",
                 hint, TestsConstants.TEST_INDEX_SYSTEM, TestsConstants.TEST_INDEX_SYSTEM);
@@ -278,7 +279,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
     }
 
     private void innerMinusCMinusDTwoFieldsAliasOnBothTables(String hint) throws IOException  {
-        String query = String.format("SELECT %s pk as myId, letter FROM %s/systems WHERE system_name = 'C' " +
+        String query = format("SELECT %s pk as myId, letter FROM %s/systems WHERE system_name = 'C' " +
                                      "MINUS " +
                                      "SELECT myId, myLetter as letter FROM %s/systems WHERE system_name = 'E'",
                 hint, TestsConstants.TEST_INDEX_SYSTEM, TestsConstants.TEST_INDEX_SYSTEM);
@@ -297,7 +298,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
     }
 
     private void innerMinusCMinusTNonExistentFieldOneField(String hint) throws IOException {
-        String query = String.format("SELECT %s letter FROM %s/systems WHERE system_name = 'C' " +
+        String query = format("SELECT %s letter FROM %s/systems WHERE system_name = 'C' " +
                                      "MINUS " +
                                      "SELECT letter FROM %s/systems WHERE system_name = 'T'",
                 hint, TestsConstants.TEST_INDEX_SYSTEM, TestsConstants.TEST_INDEX_SYSTEM);
@@ -307,7 +308,7 @@ public class MultiQueryIT extends SQLIntegTestCase {
     }
 
     private void innerMinusTMinusCNonExistentFieldFirstQuery(String hint) throws IOException {
-        String query = String.format("SELECT %s letter FROM %s/systems WHERE system_name = 'T' " +
+        String query = format("SELECT %s letter FROM %s/systems WHERE system_name = 'T' " +
                                      "MINUS " +
                                      "SELECT letter FROM %s/systems WHERE system_name = 'C'",
                 hint, TestsConstants.TEST_INDEX_SYSTEM, TestsConstants.TEST_INDEX_SYSTEM);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/NestedFieldQueryIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/NestedFieldQueryIT.java
@@ -370,7 +370,6 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
 
             @Override
             public boolean matches(Object item) {
-
                 if (item instanceof SearchHit) {
                     final SearchHit hit = (SearchHit) item;
                     ArrayList<Integer> actualValues = (ArrayList<Integer>) hit.getSourceAsMap().get("myNum");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/NestedFieldQueryIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/NestedFieldQueryIT.java
@@ -297,9 +297,11 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
         Assert.assertNotNull(msgInfoBuckets);
         Assert.assertThat(msgInfoBuckets.length(), equalTo(2));
         Assert.assertThat(msgInfoBuckets.query("/0/key"), equalTo("a"));
-        Assert.assertThat((Double) msgInfoBuckets.query("/0/message.dayOfWeek@NESTED/sumDay/value"), closeTo(9.0, 0.01));
+        Assert.assertThat((Double) msgInfoBuckets.query("/0/message.dayOfWeek@NESTED/sumDay/value"),
+                closeTo(9.0, 0.01));
         Assert.assertThat(msgInfoBuckets.query("/1/key"), equalTo("b"));
-        Assert.assertThat((Double) msgInfoBuckets.query("/1/message.dayOfWeek@NESTED/sumDay/value"), closeTo(10.0, 0.01));
+        Assert.assertThat((Double) msgInfoBuckets.query("/1/message.dayOfWeek@NESTED/sumDay/value"),
+                closeTo(10.0, 0.01));
     }
 
     // Doesn't support: aggregate function other than COUNT()
@@ -458,5 +460,4 @@ public class NestedFieldQueryIT extends SQLIntegTestCase {
         Assert.assertTrue(aggregations.has(aggregationName));
         return aggregations.getJSONObject(aggregationName);
     }
-
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PluginIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PluginIT.java
@@ -24,10 +24,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Locale;
 
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.equalTo;
+
 
 public class PluginIT extends SQLIntegTestCase {
 
@@ -41,7 +42,7 @@ public class PluginIT extends SQLIntegTestCase {
     @Test
     public void sqlEnableSettingsTest() throws IOException {
         updateClusterSettings(PERSISTENT, "opendistro.sql.enabled", "true");
-        String query = String.format(Locale.ROOT, "SELECT firstname FROM %s/account WHERE account_number=1", TEST_INDEX_ACCOUNT);
+        String query = format("SELECT firstname FROM %s/account WHERE account_number=1", TEST_INDEX_ACCOUNT);
         JSONObject queryResult = executeQuery(query);
         Assert.assertThat(getHits(queryResult).length(), equalTo(1));
 
@@ -57,14 +58,15 @@ public class PluginIT extends SQLIntegTestCase {
         Assert.assertThat(queryResult.getInt("status"), equalTo(400));
         JSONObject error = queryResult.getJSONObject("error");
         Assert.assertThat(error.getString("reason"), equalTo("Invalid SQL query"));
-        Assert.assertThat(error.getString("details"), equalTo("Either opendistro.sql.enabled or rest.action.multi.allow_explicit_index setting is false"));
+        Assert.assertThat(error.getString("details"),
+                equalTo("Either opendistro.sql.enabled or rest.action.multi.allow_explicit_index setting is false"));
         Assert.assertThat(error.getString("type"), equalTo("SQLFeatureDisabledException"));
         resetClusterSettings(PERSISTENT, "opendistro.sql.enabled");
     }
 
     private JSONObject updateClusterSettings(String settingType, String setting , String value) throws IOException {
         Request request = new Request("PUT", "/_cluster/settings?pretty");
-        String persistentSetting = String.format(Locale.ROOT, "{\"%s\": {\"%s\": %s}}", settingType, setting, value);
+        String persistentSetting = format("{\"%s\": {\"%s\": %s}}", settingType, setting, value);
         request.setJsonEntity(persistentSetting);
         RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
         restOptionsBuilder.addHeader("Content-Type", "application/json");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PreparedStatementIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PreparedStatementIT.java
@@ -18,13 +18,15 @@ package com.amazon.opendistroforelasticsearch.sql.esintgtest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.test.ESIntegTestCase;
-
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
+
 
 // Refer to https://www.elastic.co/guide/en/elasticsearch/reference/6.5/integration-tests.html
 // for detailed ESIntegTestCase usages doc.
@@ -45,7 +47,7 @@ public class PreparedStatementIT extends SQLIntegTestCase {
     public void testPreparedStatement() throws IOException {
         int ageToCompare = 35;
 
-        JSONObject response = executeRequest(String.format("{\n" +
+        JSONObject response = executeRequest(format("{\n" +
                 "  \"query\": \"SELECT * FROM %s/account WHERE age > ? AND state in (?, ?) LIMIT ?\",\n" +
                 "  \"parameters\": [\n" +
                 "    {\n" +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
@@ -467,7 +467,6 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void fieldOrder() throws IOException {
-
         final String[] expectedFields = {"age", "firstname", "address", "gender", "email"};
         final Object[] expectedValues = {32, "Amber", "880 Holmes Lane", "M", "amberduke@pyrami.com"};
 
@@ -476,7 +475,6 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void fieldOrderOther() throws IOException {
-
         final String[] expectedFields = {"email", "firstname", "age", "gender", "address"};
         final Object[] expectedValues = {"amberduke@pyrami.com", "Amber", 32, "M", "880 Holmes Lane"};
 
@@ -484,14 +482,12 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     }
 
     private void testFieldOrder(final String[] expectedFields, final Object[] expectedValues) throws IOException {
-
         final String fields = String.join(", ", expectedFields);
         final String query = format("SELECT %s FROM %s " +
                 "WHERE email='amberduke@pyrami.com'", fields, TestsConstants.TEST_INDEX_ACCOUNT);
         final JSONObject result = executeQuery(query);
 
         for (int i = 0; i < expectedFields.length; ++i) {
-
             final String fieldName = (String)result.query(format("/schema/%d/name", i));
             assertThat(fieldName, equalTo(expectedFields[i]));
             final Object fieldValue = result.query(format("/datarows/0/%d", i));
@@ -506,7 +502,6 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     }
 
     private void assertContainsColumnsInAnyOrder(JSONArray schema, Set<String> fields) {
-
         assertThat(schema.length(), equalTo(fields.size()));
 
         for (int i = 0; i < schema.length(); i++) {
@@ -518,7 +513,6 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     }
 
     private void assertContainsColumns(JSONArray schema, List<String> fields) {
-
         assertThat(schema.length(), equalTo(fields.size()));
 
         for (int i = 0; i < schema.length(); i++) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
@@ -27,14 +27,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+
 
 /**
  * PrettyFormatResponseIT will likely be excluding some of the tests written in PrettyFormatResponseTest since
@@ -84,17 +85,17 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     public void wrongIndexType() throws IOException  {
         String type = "wrongType";
         try {
-            executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s/%s",
+            executeQuery(format("SELECT * FROM %s/%s",
                                             TestsConstants.TEST_INDEX_ACCOUNT, type));
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is(String.format(Locale.ROOT, "Index type %s does not exist", type)));
+            assertThat(e.getMessage(), is(format("Index type %s does not exist", type)));
         }
     }
 
     @Test
     public void selectAll() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT * FROM %s/%s",
+                                format("SELECT * FROM %s/%s",
                                         TestsConstants.TEST_INDEX_ACCOUNT, "account"));
 
         // This also tests that .keyword fields are ignored when SELECT * is called
@@ -105,7 +106,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void selectNames() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT firstname, lastname FROM %s/%s",
+                                format("SELECT firstname, lastname FROM %s/%s",
                                         TestsConstants.TEST_INDEX_ACCOUNT, "account"));
 
         assertContainsColumns(getSchema(response), nameFields);
@@ -115,7 +116,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void selectWrongField() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT wrongField FROM %s",
+                                format("SELECT wrongField FROM %s",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         assertThat(getSchema(response).length(), equalTo(0));
@@ -130,7 +131,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void selectKeyword() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT firstname.keyword FROM %s",
+                                format("SELECT firstname.keyword FROM %s",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         List<String> fields = Collections.singletonList("firstname.keyword");
@@ -148,7 +149,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void selectScore() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT _score FROM %s WHERE balance > 30000",
+                                format("SELECT _score FROM %s WHERE balance > 30000",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         List<String> fields = Collections.singletonList("_score");
@@ -158,7 +159,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void selectAllFromNestedWithoutFieldInFrom() throws IOException {
-        JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s",
+        JSONObject response = executeQuery(format("SELECT * FROM %s",
                 TestsConstants.TEST_INDEX_NESTED_TYPE));
 
         assertContainsColumnsInAnyOrder(getSchema(response), regularFields);
@@ -168,7 +169,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void selectAllFromNestedWithFieldInFrom() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT * FROM %s e, e.message m",
+                                format("SELECT * FROM %s e, e.message m",
                                         TestsConstants.TEST_INDEX_NESTED_TYPE));
 
         assertContainsColumnsInAnyOrder(getSchema(response), messageFields);
@@ -178,7 +179,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void selectNestedFields() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT nested(message.info), someField FROM %s",
+                                format("SELECT nested(message.info), someField FROM %s",
                                         TestsConstants.TEST_INDEX_NESTED_TYPE));
 
         List<String> fields = Arrays.asList("message.info", "someField");
@@ -193,7 +194,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void selectNestedFieldWithWildcard() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT nested(message.*) FROM %s",
+                                format("SELECT nested(message.*) FROM %s",
                                         TestsConstants.TEST_INDEX_NESTED_TYPE));
 
         assertContainsColumnsInAnyOrder(getSchema(response), messageFields);
@@ -204,7 +205,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     public void selectWithWhere() throws IOException {
         int balanceToCompare = 30000;
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT balance " +
+                                format("SELECT balance " +
                                               "FROM %s/%s " +
                                               "WHERE balance > %d",
                                         TestsConstants.TEST_INDEX_ACCOUNT, "account", balanceToCompare));
@@ -226,7 +227,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void groupBySingleField() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT * FROM %s GROUP BY age",
+                                format("SELECT * FROM %s GROUP BY age",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         List<String> fields = Collections.singletonList("age");
@@ -237,7 +238,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void groupByMultipleFields() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT * FROM %s GROUP BY age, balance",
+                                format("SELECT * FROM %s GROUP BY age, balance",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         List<String> fields = Arrays.asList("age", "balance");
@@ -248,7 +249,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void testSizeAndTotal() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT * " +
+                                format("SELECT * " +
                                               "FROM %s " +
                                               "WHERE balance > 30000 " +
                                               "LIMIT 5",
@@ -265,7 +266,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void testSizeWithGroupBy() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT * FROM %s GROUP BY age LIMIT 5",
+                                format("SELECT * FROM %s GROUP BY age LIMIT 5",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         assertThat(getDataRows(response).length(), equalTo(5));
@@ -274,7 +275,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void aggregationFunctionInSelect() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT COUNT(*) FROM %s GROUP BY age",
+                                format("SELECT COUNT(*) FROM %s GROUP BY age",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         String count = "COUNT(*)";
@@ -293,7 +294,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void aggregationFunctionInSelectCaseCheck() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT count(*) FROM %s GROUP BY age",
+                                format("SELECT count(*) FROM %s GROUP BY age",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         String count = "COUNT(*)";
@@ -312,7 +313,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void aggregationFunctionInSelectWithAlias() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT COUNT(*) AS total FROM %s GROUP BY age",
+                                format("SELECT COUNT(*) AS total FROM %s GROUP BY age",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         String count = "total";
@@ -331,7 +332,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void aggregationFunctionInSelectGroupByMultipleFields() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT SUM(age) FROM %s GROUP BY age, state.keyword",
+                                format("SELECT SUM(age) FROM %s GROUP BY age, state.keyword",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         List<String> fields = Arrays.asList("age", "state.keyword", "SUM(age)");
@@ -341,7 +342,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void aggregationFunctionInSelectNoGroupBy() throws IOException {
-        JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT SUM(age) FROM %s",
+        JSONObject response = executeQuery(format("SELECT SUM(age) FROM %s",
                 TestsConstants.TEST_INDEX_ACCOUNT));
 
         String ageSum = "SUM(age)";
@@ -359,7 +360,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void multipleAggregationFunctionsInSelect() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT COUNT(*), AVG(age) FROM %s GROUP BY age",
+                                format("SELECT COUNT(*), AVG(age) FROM %s GROUP BY age",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         List<String> fields = Arrays.asList("age", "COUNT(*)", "AVG(age)");
@@ -375,13 +376,13 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
      */
 //    @Test
 //    public void nestedAggregationFunctionInSelect() {
-//        String query = String.format(Locale.ROOT, "SELECT SUM(SQRT(age)) FROM age GROUP BY age", TEST_INDEX_ACCOUNT);
+//        String query = format("SELECT SUM(SQRT(age)) FROM age GROUP BY age", TEST_INDEX_ACCOUNT);
 //    }
 
     @Test
     public void fieldsWithAlias() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT firstname AS first, age AS a FROM %s",
+                                format("SELECT firstname AS first, age AS a FROM %s",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
         Map<String, String> aliases = new HashMap<>();
@@ -394,7 +395,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void indexWithMissingFields() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT phrase, insert_time2 " +
+                                format("SELECT phrase, insert_time2 " +
                                               "FROM %s " +
                                               "WHERE match_phrase(phrase, 'brown fox')",
                                         TestsConstants.TEST_INDEX_PHRASE));
@@ -408,7 +409,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void joinQuery() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT b1.balance, b1.age, b2.firstname " +
+                                format("SELECT b1.balance, b1.age, b2.firstname " +
                                               "FROM %s b1 JOIN %s b2 ON b1.age = b2.age",
                                         TestsConstants.TEST_INDEX_ACCOUNT, TestsConstants.TEST_INDEX_ACCOUNT));
 
@@ -419,7 +420,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
 
     @Test
     public void joinQueryWithAlias() throws IOException {
-        JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT b1.balance AS bal, " +
+        JSONObject response = executeQuery(format("SELECT b1.balance AS bal, " +
                         " b1.age AS age, b2.firstname AS name FROM %s b1 JOIN %s b2 ON b1.age = b2.age",
                 TestsConstants.TEST_INDEX_ACCOUNT, TestsConstants.TEST_INDEX_ACCOUNT));
 
@@ -435,7 +436,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void joinQueryWithObjectFieldInSelect() throws IOException {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT c.name.firstname, d.name.lastname " +
+                                format("SELECT c.name.firstname, d.name.lastname " +
                                               "FROM %s c JOIN %s d ON d.hname = c.house",
                                         TestsConstants.TEST_INDEX_GAME_OF_THRONES,
                                         TestsConstants.TEST_INDEX_GAME_OF_THRONES));
@@ -455,7 +456,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     @Test
     public void joinQuerySelectOnlyOnOneTable() throws Exception {
         JSONObject response = executeQuery(
-                                String.format(Locale.ROOT, "SELECT b1.age " +
+                                format("SELECT b1.age " +
                                               "FROM %s b1 JOIN %s b2 ON b1.firstname = b2.firstname",
                                         TestsConstants.TEST_INDEX_ACCOUNT, TestsConstants.TEST_INDEX_ACCOUNT));
 
@@ -485,15 +486,15 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     private void testFieldOrder(final String[] expectedFields, final Object[] expectedValues) throws IOException {
 
         final String fields = String.join(", ", expectedFields);
-        final String query = String.format(Locale.ROOT, "SELECT %s FROM %s " +
+        final String query = format("SELECT %s FROM %s " +
                 "WHERE email='amberduke@pyrami.com'", fields, TestsConstants.TEST_INDEX_ACCOUNT);
         final JSONObject result = executeQuery(query);
 
         for (int i = 0; i < expectedFields.length; ++i) {
 
-            final String fieldName = (String)result.query(String.format(Locale.ROOT, "/schema/%d/name", i));
+            final String fieldName = (String)result.query(format("/schema/%d/name", i));
             assertThat(fieldName, equalTo(expectedFields[i]));
-            final Object fieldValue = result.query(String.format(Locale.ROOT, "/datarows/0/%d", i));
+            final Object fieldValue = result.query(format("/datarows/0/%d", i));
             assertThat(fieldValue, equalTo(expectedValues[i]));
         }
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
@@ -223,7 +223,6 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
      * @param fields A list of fields to match
      */
     private Matcher<SearchHit> hasValueForFields(String value, String... fields) {
-
         return anyOf(
                 Arrays.stream(fields)
                 .map(field -> kv(field, is(value)))
@@ -243,12 +242,10 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
         return new BaseMatcher<SearchHit>() {
             @Override
             public void describeTo(Description description) {
-
             }
 
             @Override
             public boolean matches(Object item) {
-
                 SearchHit hit = (SearchHit)item;
                 List<Object> elements = uncheckedGetList(((HashMap) hit.getSourceAsMap().get(path)).get(field));
                 return elements.contains(value);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryIT.java
@@ -31,13 +31,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Set;
 
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_GAME_OF_THRONES;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_NESTED_TYPE;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ONLINE;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
@@ -85,7 +85,7 @@ public class QueryIT extends SQLIntegTestCase {
 
     @Test
     public void searchTypeTest() throws IOException {
-        JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s/phrase LIMIT 1000",
+        JSONObject response = executeQuery(format("SELECT * FROM %s/phrase LIMIT 1000",
                 TestsConstants.TEST_INDEX_PHRASE));
         Assert.assertTrue(response.has("hits"));
         Assert.assertEquals(6, getTotalHits(response));
@@ -93,7 +93,7 @@ public class QueryIT extends SQLIntegTestCase {
 
     @Test
     public void multipleFromTest() throws IOException {
-        JSONObject response = executeQuery(String.format(Locale.ROOT,
+        JSONObject response = executeQuery(format(
                 "SELECT * FROM %s/account, %s/account_two LIMIT 2000",
                 TestsConstants.TEST_INDEX_BANK, TestsConstants.TEST_INDEX_BANK_TWO));
         Assert.assertTrue(response.has("hits"));
@@ -102,7 +102,7 @@ public class QueryIT extends SQLIntegTestCase {
 
     @Test
     public void indexWithWildcardTest() throws IOException {
-        JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s* LIMIT 1000",
+        JSONObject response = executeQuery(format("SELECT * FROM %s* LIMIT 1000",
                 TestsConstants.TEST_INDEX_BANK));
         Assert.assertTrue(response.has("hits"));
         assertThat(getTotalHits(response), greaterThan(0));
@@ -113,7 +113,7 @@ public class QueryIT extends SQLIntegTestCase {
         String[] arr = new String[] {"age", "account_number"};
         Set<String> expectedSource = new HashSet<>(Arrays.asList(arr));
 
-        JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT age, account_number FROM %s/account",
+        JSONObject response = executeQuery(format("SELECT age, account_number FROM %s/account",
                 TEST_INDEX_ACCOUNT));
 
         JSONArray hits = getHits(response);
@@ -128,7 +128,7 @@ public class QueryIT extends SQLIntegTestCase {
         String[] arr = new String[] {"test field"};
         Set<String> expectedSource = new HashSet<>(Arrays.asList(arr));
 
-        JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT ['test field'] FROM %s/phrase " +
+        JSONObject response = executeQuery(format("SELECT ['test field'] FROM %s/phrase " +
                         "WHERE ['test field'] IS NOT null",
                         TestsConstants.TEST_INDEX_PHRASE));
 
@@ -147,7 +147,7 @@ public class QueryIT extends SQLIntegTestCase {
         String[] arr = new String[] {"myage", "myaccount_number"};
         Set<String> expectedSource = new HashSet<>(Arrays.asList(arr));
 
-        JSONObject result = executeQuery(String.format(Locale.ROOT,
+        JSONObject result = executeQuery(format(
                 "SELECT age AS myage, account_number AS myaccount_number FROM %s/account", TEST_INDEX_ACCOUNT));
         JSONArray hits = getHits(result);
         hits.forEach(hitObj -> {
@@ -158,7 +158,7 @@ public class QueryIT extends SQLIntegTestCase {
 
     @Test
     public void equalityTest() throws IOException {
-        JSONObject response = executeQuery(String.format(Locale.ROOT,
+        JSONObject response = executeQuery(format(
                 "SELECT * FROM %s/account WHERE city = 'Nogal' LIMIT 1000", TEST_INDEX_ACCOUNT));
 
         JSONArray hits = getHits(response);
@@ -168,7 +168,7 @@ public class QueryIT extends SQLIntegTestCase {
 
     @Test
     public void equalityTestPhrase() throws IOException {
-        JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s/phrase WHERE " +
+        JSONObject response = executeQuery(format("SELECT * FROM %s/phrase WHERE " +
                                                          "match_phrase(phrase, 'quick fox here') LIMIT 1000",
                                                          TestsConstants.TEST_INDEX_PHRASE));
 
@@ -181,7 +181,7 @@ public class QueryIT extends SQLIntegTestCase {
     public void greaterThanTest() throws IOException {
         int someAge = 25;
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age > %s LIMIT 1000",
+                        format("SELECT * FROM %s WHERE age > %s LIMIT 1000",
                                 TestsConstants.TEST_INDEX_PEOPLE,
                                 someAge));
 
@@ -197,7 +197,7 @@ public class QueryIT extends SQLIntegTestCase {
     public void greaterThanOrEqualTest() throws IOException {
         int someAge = 25;
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age >= %s LIMIT 1000",
+                        format("SELECT * FROM %s WHERE age >= %s LIMIT 1000",
                                 TEST_INDEX_ACCOUNT,
                                 someAge));
 
@@ -213,7 +213,7 @@ public class QueryIT extends SQLIntegTestCase {
         }
 
         Assert.assertTrue(
-                String.format(Locale.ROOT, "At least one of the documents need to contains age equal to %s", someAge),
+                format("At least one of the documents need to contains age equal to %s", someAge),
                 isEqualFound);
     }
 
@@ -221,7 +221,7 @@ public class QueryIT extends SQLIntegTestCase {
     public void lessThanTest() throws IOException {
         int someAge = 25;
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age < %s LIMIT 1000",
+                        format("SELECT * FROM %s WHERE age < %s LIMIT 1000",
                                 TestsConstants.TEST_INDEX_PEOPLE,
                                 someAge));
 
@@ -237,7 +237,7 @@ public class QueryIT extends SQLIntegTestCase {
     public void lessThanOrEqualTest() throws IOException {
         int someAge = 25;
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age <= %s LIMIT 1000",
+                        format("SELECT * FROM %s WHERE age <= %s LIMIT 1000",
                                 TEST_INDEX_ACCOUNT,
                                 someAge));
 
@@ -253,14 +253,14 @@ public class QueryIT extends SQLIntegTestCase {
         }
 
         Assert.assertTrue(
-                String.format(Locale.ROOT, "At least one of the documents need to contains age equal to %s", someAge),
+                format("At least one of the documents need to contains age equal to %s", someAge),
                 isEqualFound);
     }
 
     @Test
     public void orTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/account " +
                                       "WHERE match_phrase(gender, 'F') OR match_phrase(gender, 'M') " +
                                       "LIMIT 1000", TEST_INDEX_ACCOUNT));
@@ -270,7 +270,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void andTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age=32 AND gender='M' LIMIT 1000",
+                        format("SELECT * FROM %s WHERE age=32 AND gender='M' LIMIT 1000",
                                 TestsConstants.TEST_INDEX_PEOPLE));
 
         JSONArray hits = getHits(response);
@@ -284,7 +284,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void likeTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s WHERE firstname LIKE 'amb%%' LIMIT 1000",
+                        format("SELECT * FROM %s WHERE firstname LIKE 'amb%%' LIMIT 1000",
                                 TEST_INDEX_ACCOUNT));
 
         JSONArray hits = getHits(response);
@@ -295,7 +295,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void notLikeTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s/account WHERE firstname NOT LIKE 'amb%%'",
+                        format("SELECT * FROM %s/account WHERE firstname NOT LIKE 'amb%%'",
                                 TEST_INDEX_ACCOUNT));
 
         JSONArray hits = getHits(response);
@@ -309,7 +309,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void regexQueryTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/dog " +
                                       "WHERE dog_name = REGEXP_QUERY('sn.*', 'INTERSECTION|COMPLEMENT|EMPTY', 10000)",
                                 TestsConstants.TEST_INDEX_DOG));
@@ -326,25 +326,25 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void doubleNotTest() throws IOException {
         JSONObject response1 = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT * FROM %s/account WHERE NOT gender LIKE 'm' AND NOT gender LIKE 'f'",
                                 TEST_INDEX_ACCOUNT));
         Assert.assertEquals(0, getTotalHits(response1));
 
         JSONObject response2 = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT * FROM %s/account WHERE NOT gender LIKE 'm' AND gender NOT LIKE 'f'",
                                 TEST_INDEX_ACCOUNT));
         Assert.assertEquals(0, getTotalHits(response2));
 
         JSONObject response3 = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT * FROM %s/account WHERE gender NOT LIKE 'm' AND gender NOT LIKE 'f'",
                                 TEST_INDEX_ACCOUNT));
         Assert.assertEquals(0, getTotalHits(response3));
 
         JSONObject response4 = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT * FROM %s/account WHERE gender LIKE 'm' AND NOT gender LIKE 'f'",
                                 TEST_INDEX_ACCOUNT));
         // Assert there are results and they all have gender 'm'
@@ -356,14 +356,14 @@ public class QueryIT extends SQLIntegTestCase {
         }
 
         JSONObject response5 = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s/account WHERE NOT (gender = 'm' OR gender = 'f')",
+                        format("SELECT * FROM %s/account WHERE NOT (gender = 'm' OR gender = 'f')",
                                 TEST_INDEX_ACCOUNT));
         Assert.assertEquals(0, getTotalHits(response5));
     }
 
     @Test
     public void limitTest() throws IOException {
-        JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT * FROM %s LIMIT 30",
+        JSONObject response = executeQuery(format("SELECT * FROM %s LIMIT 30",
                         TEST_INDEX_ACCOUNT));
 
         JSONArray hits = getHits(response);
@@ -375,7 +375,7 @@ public class QueryIT extends SQLIntegTestCase {
         int min = 27;
         int max = 30;
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age BETWEEN %s AND %s LIMIT 1000",
+                        format("SELECT * FROM %s WHERE age BETWEEN %s AND %s LIMIT 1000",
                                 TestsConstants.TEST_INDEX_PEOPLE, min, max));
 
         JSONArray hits = getHits(response);
@@ -393,7 +393,7 @@ public class QueryIT extends SQLIntegTestCase {
         int min = 20;
         int max = 37;
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s WHERE age NOT BETWEEN %s AND %s LIMIT 1000",
+                        format("SELECT * FROM %s WHERE age NOT BETWEEN %s AND %s LIMIT 1000",
                                 TestsConstants.TEST_INDEX_PEOPLE, min, max));
 
         JSONArray hits = getHits(response);
@@ -412,7 +412,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void inTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT age FROM %s/phrase WHERE age IN (20, 22) LIMIT 1000",
+                        format("SELECT age FROM %s/phrase WHERE age IN (20, 22) LIMIT 1000",
                                 TestsConstants.TEST_INDEX_PHRASE));
 
         JSONArray hits = getHits(response);
@@ -426,7 +426,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void inTestWithStrings() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT phrase FROM %s/phrase WHERE phrase IN ('quick', 'fox') LIMIT 1000",
                                 TestsConstants.TEST_INDEX_PHRASE));
 
@@ -441,7 +441,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void inTermsTestWithIdentifiersTreatedLikeStrings() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT name " +
+                        format("SELECT name " +
                                       "FROM %s/gotCharacters " +
                                       "WHERE name.firstname = IN_TERMS(daenerys,eddard) " +
                                       "LIMIT 1000",
@@ -459,7 +459,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void inTermsTestWithStrings() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT name " +
+                        format("SELECT name " +
                                       "FROM %s/gotCharacters " +
                                       "WHERE name.firstname = IN_TERMS('daenerys','eddard') " +
                                       "LIMIT 1000",
@@ -477,7 +477,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void inTermsWithNumbers() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT name " +
+                        format("SELECT name " +
                                       "FROM %s/gotCharacters " +
                                       "WHERE name.ofHisName = IN_TERMS(4,2) " +
                                       "LIMIT 1000",
@@ -494,7 +494,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void termQueryWithNumber() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT name FROM %s/gotCharacters WHERE name.ofHisName = term(4) LIMIT 1000",
                                 TestsConstants.TEST_INDEX_GAME_OF_THRONES));
 
@@ -509,7 +509,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void termQueryWithStringIdentifier() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT name " +
+                        format("SELECT name " +
                                       "FROM %s/gotCharacters " +
                                       "WHERE name.firstname = term(brandon) " +
                                       "LIMIT 1000",
@@ -526,7 +526,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void termQueryWithStringLiteral() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT name " +
+                        format("SELECT name " +
                                       "FROM %s/gotCharacters " +
                                       "WHERE name.firstname = term('brandon') " +
                                       "LIMIT 1000",
@@ -545,7 +545,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void notInTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT age FROM %s WHERE age NOT IN (20, 22) LIMIT 1000",
+                        format("SELECT age FROM %s WHERE age NOT IN (20, 22) LIMIT 1000",
                                 TestsConstants.TEST_INDEX_PEOPLE));
 
         JSONArray hits = getHits(response);
@@ -567,7 +567,7 @@ public class QueryIT extends SQLIntegTestCase {
         DateTime dateToCompare = new DateTime(2014, 8, 18, 0, 0, 0);
 
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT insert_time FROM %s/online WHERE insert_time < '2014-08-18'",
+                        format("SELECT insert_time FROM %s/online WHERE insert_time < '2014-08-18'",
                                 TestsConstants.TEST_INDEX_ONLINE));
         JSONArray hits = getHits(response);
         for (int i = 0; i < hits.length(); i++) {
@@ -575,7 +575,7 @@ public class QueryIT extends SQLIntegTestCase {
             JSONObject source = getSource(hit);
             DateTime insertTime = formatter.parseDateTime(source.getString("insert_time"));
 
-            String errorMessage = String.format(Locale.ROOT, "insert_time must be before 2014-08-18. Found: %s",
+            String errorMessage = format("insert_time must be before 2014-08-18. Found: %s",
                     insertTime);
             Assert.assertTrue(errorMessage, insertTime.isBefore(dateToCompare));
         }
@@ -587,7 +587,7 @@ public class QueryIT extends SQLIntegTestCase {
         DateTime dateToCompare = new DateTime(2015, 3, 15, 0, 0, 0);
 
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT odbc_time FROM %s/odbc WHERE odbc_time < {ts '2015-03-15 00:00:00.000'}",
                                 TestsConstants.TEST_INDEX_ODBC));
         JSONArray hits = getHits(response);
@@ -598,7 +598,7 @@ public class QueryIT extends SQLIntegTestCase {
             insertTimeStr = insertTimeStr.replace("{ts '", "").replace("'}", "");
 
             DateTime insertTime = formatter.parseDateTime(insertTimeStr);
-            String errorMessage = String.format(Locale.ROOT, "insert_time must be before 2015-03-15. Found: %s",
+            String errorMessage = format("insert_time must be before 2015-03-15. Found: %s",
                     insertTime);
             Assert.assertTrue(errorMessage, insertTime.isBefore(dateToCompare));
         }
@@ -612,7 +612,7 @@ public class QueryIT extends SQLIntegTestCase {
         DateTime dateLimit2 = new DateTime(2014, 8, 21, 0, 0, 0);
 
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT insert_time " +
+                        format("SELECT insert_time " +
                                       "FROM %s/online " +
                                       "WHERE insert_time BETWEEN '2014-08-18' AND '2014-08-21' " +
                                       "LIMIT 3",
@@ -633,7 +633,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void missFilterSearch() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s/phrase WHERE insert_time2 IS missing",
+                        format("SELECT * FROM %s/phrase WHERE insert_time2 IS missing",
                                 TestsConstants.TEST_INDEX_PHRASE));
 
         JSONArray hits = getHits(response);
@@ -649,7 +649,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void notMissFilterSearch() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s/phrase WHERE insert_time2 IS NOT missing",
+                        format("SELECT * FROM %s/phrase WHERE insert_time2 IS NOT missing",
                                 TestsConstants.TEST_INDEX_PHRASE));
 
         JSONArray hits = getHits(response);
@@ -668,7 +668,7 @@ public class QueryIT extends SQLIntegTestCase {
                 "(gender='m' AND (age> 25 OR account_number>5)) OR (gender='f' AND (age>30 OR account_number < 8)";
 
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/account " +
                                       "WHERE (gender='m' AND (age> 25 OR account_number>5)) " +
                                         "OR (gender='f' AND (age>30 OR account_number < 8))",
@@ -696,7 +696,7 @@ public class QueryIT extends SQLIntegTestCase {
                      "OR (NOT gender='f' AND NOT (age > 30 OR account_number < 8))";
 
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/account " +
                                       "WHERE NOT (gender='m' AND NOT (age > 25 OR account_number > 5)) " +
                                         "OR (NOT gender='f' AND NOT (age > 30 OR account_number < 8))",
@@ -722,7 +722,7 @@ public class QueryIT extends SQLIntegTestCase {
     @SuppressWarnings("unchecked")
     public void orderByAscTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT age FROM %s/account ORDER BY age ASC LIMIT 1000",
+                        format("SELECT age FROM %s/account ORDER BY age ASC LIMIT 1000",
                                 TEST_INDEX_ACCOUNT));
 
         JSONArray hits = getHits(response);
@@ -743,7 +743,7 @@ public class QueryIT extends SQLIntegTestCase {
     @SuppressWarnings("unchecked")
     public void orderByDescTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT age FROM %s/account ORDER BY age DESC LIMIT 1000",
+                        format("SELECT age FROM %s/account ORDER BY age DESC LIMIT 1000",
                                 TEST_INDEX_ACCOUNT));
 
         JSONArray hits = getHits(response);
@@ -764,7 +764,7 @@ public class QueryIT extends SQLIntegTestCase {
     @SuppressWarnings("unchecked")
     public void orderByAscFieldWithSpaceTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/phrase " +
                                       "WHERE `test field` IS NOT null " +
                                       "ORDER BY `test field` ASC " +
@@ -788,7 +788,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void testMultiPartWhere() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/account " +
                                       "WHERE (firstname LIKE 'opal' OR firstname LIKE 'rodriquez') " +
                                         "AND (state like 'oh' OR state like 'hi')",
@@ -800,7 +800,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void testMultiPartWhere2() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/account " +
                                       "WHERE ((account_number > 200 AND account_number < 300) OR gender LIKE 'm') " +
                                         "AND (state LIKE 'hi' OR address LIKE 'avenue')",
@@ -812,7 +812,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void testMultiPartWhere3() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/account " +
                                       "WHERE ((account_number > 25 AND account_number < 75) AND age >35 ) " +
                                         "AND (state LIKE 'md' OR (address LIKE 'avenue' OR address LIKE 'street'))",
@@ -824,7 +824,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void filterPolygonTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/location " +
                                       "WHERE GEO_INTERSECTS(place,'POLYGON ((102 2, 103 2, 103 3, 102 3, 102 2))')",
                                 TestsConstants.TEST_INDEX_LOCATION));
@@ -839,7 +839,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void boundingBox() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT * FROM %s/location WHERE GEO_BOUNDING_BOX(center, 100.0, 1.0, 101, 0.0)",
                                 TestsConstants.TEST_INDEX_LOCATION));
 
@@ -853,7 +853,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void geoDistance() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT * FROM %s/location WHERE GEO_DISTANCE(center, '1km', 100.5, 0.500001)",
                                 TestsConstants.TEST_INDEX_LOCATION));
 
@@ -867,7 +867,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void geoPolygon() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT * FROM %s/location WHERE GEO_POLYGON(center, 100,0, 100.5, 2, 101.0,0)",
                                 TestsConstants.TEST_INDEX_LOCATION));
 
@@ -882,7 +882,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void escapedCharactersCheck() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/gotCharacters " +
                                       "WHERE MATCH_PHRASE(nickname, 'Daenerys \"Stormborn\"') " +
                                       "LIMIT 1000",
@@ -894,7 +894,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void complexObjectSearch() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/gotCharacters " +
                                       "WHERE MATCH_PHRASE(name.firstname, 'Jaime') " +
                                       "LIMIT 1000",
@@ -906,7 +906,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void complexObjectReturnField() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT parents.father " +
+                        format("SELECT parents.father " +
                                       "FROM %s/gotCharacters " +
                                       "WHERE MATCH_PHRASE(name.firstname, 'Brandon') " +
                                       "LIMIT 1000",
@@ -927,7 +927,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Ignore
     @Test
     public void queryWithAtFieldOnWhere() throws IOException {
-        JSONObject response = executeQuery(String.format(Locale.ROOT,
+        JSONObject response = executeQuery(format(
                 "SELECT * FROM %s/gotCharacters where @wolf = 'Summer' LIMIT 1000", TEST_INDEX_GAME_OF_THRONES));
         Assert.assertEquals(1, getTotalHits(response));
         JSONObject hit = getHits(response).getJSONObject(0);
@@ -938,7 +938,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void notLikeTests() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT name " +
+                        format("SELECT name " +
                                       "FROM %s/gotCharacters " +
                                       "WHERE name.firstname NOT LIKE 'd%%' AND name IS NOT NULL " +
                                       "LIMIT 1000",
@@ -951,7 +951,7 @@ public class QueryIT extends SQLIntegTestCase {
             JSONObject source = getSource(hit);
 
             String name = source.getJSONObject("name").getString("firstname");
-            Assert.assertFalse(String.format(Locale.ROOT, "Name [%s] should not match pattern [d%%]", name),
+            Assert.assertFalse(format("Name [%s] should not match pattern [d%%]", name),
                     name.startsWith("d"));
         }
     }
@@ -959,7 +959,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void isNullTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT name " +
+                        format("SELECT name " +
                                       "FROM %s/gotCharacters " +
                                       "WHERE nickname IS NULL " +
                                       "LIMIT 1000",
@@ -971,7 +971,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void isNotNullTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT name " +
+                        format("SELECT name " +
                                       "FROM %s/gotCharacters " +
                                       "WHERE nickname IS NOT NULL " +
                                       "LIMIT 1000",
@@ -983,7 +983,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void useScrollWithoutParams() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT /*! USE_SCROLL*/ age, gender, firstname, balance " +
+                        format("SELECT /*! USE_SCROLL*/ age, gender, firstname, balance " +
                                       "FROM  %s/account " +
                                       "LIMIT 2000",
                                 TEST_INDEX_ACCOUNT));
@@ -998,7 +998,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void useScrollWithParams() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT /*! USE_SCROLL(10, 5000) */ age, gender, firstname, balance FROM  %s/account",
                                 TEST_INDEX_ACCOUNT));
 
@@ -1011,7 +1011,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void useScrollWithOrderByAndParams() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT /*! USE_SCROLL(5, 50000) */ age, gender, firstname, balance " +
                                       "FROM %s/account " +
                                       "ORDER BY age",
@@ -1033,7 +1033,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void innerQueryTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/dog " +
                                       "WHERE holdersName IN (SELECT firstname " +
                                                             "FROM %s/account " +
@@ -1054,7 +1054,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void twoSubQueriesTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/dog " +
                                       "WHERE holdersName IN (SELECT firstname " +
                                                             "FROM %s/account " +
@@ -1081,7 +1081,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void inTermsSubQueryTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/dog " +
                                       "WHERE age = IN_TERMS (SELECT name.ofHisName " +
                                                             "FROM %s/gotCharacters " +
@@ -1103,7 +1103,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void idsQueryOneId() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s/dog WHERE _id = IDS_QUERY(dog, 1)",
+                        format("SELECT * FROM %s/dog WHERE _id = IDS_QUERY(dog, 1)",
                                 TestsConstants.TEST_INDEX_DOG));
 
         JSONArray hits = getHits(response);
@@ -1120,7 +1120,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void idsQueryMultipleId() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s/dog WHERE _id = IDS_QUERY(dog, 1, 2, 3)",
+                        format("SELECT * FROM %s/dog WHERE _id = IDS_QUERY(dog, 1, 2, 3)",
                                 TestsConstants.TEST_INDEX_DOG));
 
         JSONArray hits = getHits(response);
@@ -1137,7 +1137,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void idsQuerySubQueryIds() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/dog " +
                                       "WHERE _id = IDS_QUERY(dog, (SELECT name.ofHisName " +
                                                                   "FROM %s/gotCharacters " +
@@ -1158,7 +1158,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void nestedEqualsTestFieldNormalField() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s/nestedType WHERE nested(message.info)='b'",
+                        format("SELECT * FROM %s/nestedType WHERE nested(message.info)='b'",
                                 TestsConstants.TEST_INDEX_NESTED_TYPE));
 
         Assert.assertEquals(1, getTotalHits(response));
@@ -1167,7 +1167,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void nestedEqualsTestFieldInsideArrays() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * FROM %s/nestedType WHERE nested(message.info) = 'a'",
+                        format("SELECT * FROM %s/nestedType WHERE nested(message.info) = 'a'",
                                 TestsConstants.TEST_INDEX_NESTED_TYPE));
 
         Assert.assertEquals(2, getTotalHits(response));
@@ -1176,7 +1176,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Ignore // Seems like we don't support nested with IN, throwing IllegalArgumentException
     @Test
     public void nestedOnInQuery() throws IOException {
-        JSONObject response = executeQuery(String.format(Locale.ROOT,
+        JSONObject response = executeQuery(format(
                 "SELECT * FROM %s where nested(message.info) IN ('a','b')", TEST_INDEX_NESTED_TYPE));
         Assert.assertEquals(3, getTotalHits(response));
     }
@@ -1184,7 +1184,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void complexNestedQueryBothOnSameObject() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/nestedType " +
                                       "WHERE nested('message', message.info = 'a' AND message.author ='i')",
                                 TestsConstants.TEST_INDEX_NESTED_TYPE));
@@ -1195,7 +1195,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void complexNestedQueryNotBothOnSameObject() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/nestedType " +
                                       "WHERE nested('message', message.info = 'a' AND message.author ='h')",
                                 TestsConstants.TEST_INDEX_NESTED_TYPE));
@@ -1206,7 +1206,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void nestedOnInTermsQuery() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT * " +
+                        format("SELECT * " +
                                       "FROM %s/nestedType " +
                                       "WHERE nested(message.info) = IN_TERMS(a, b)",
                                 TestsConstants.TEST_INDEX_NESTED_TYPE));
@@ -1218,9 +1218,8 @@ public class QueryIT extends SQLIntegTestCase {
 //    @Test
 //    public void childrenEqualsTestFieldNormalField() throws IOException {
 //        JSONObject response = executeQuery(
-//                        String.format(Locale.ROOT, "SELECT * " +
-//                                      "FROM %s/joinType " +
-//                                      "WHERE children(childrenType, info) = 'b'", TestsConstants.TEST_INDEX_JOIN_TYPE));
+//                        format("SELECT * FROM %s/joinType " +
+//                                "WHERE children(childrenType, info) = 'b'", TestsConstants.TEST_INDEX_JOIN_TYPE));
 //
 //        Assert.assertEquals(1, getTotalHits(response));
 //    }
@@ -1228,7 +1227,7 @@ public class QueryIT extends SQLIntegTestCase {
 //    @Test
 //    public void childrenOnInQuery() throws IOException {
 //        JSONObject response = executeQuery(
-//                        String.format(Locale.ROOT, "SELECT * " +
+//                        format("SELECT * " +
 //                                      "FROM %s/joinType " +
 //                                      "WHERE children(childrenType, info) IN ('a', 'b')",
 //                                TestsConstants.TEST_INDEX_JOIN_TYPE));
@@ -1239,7 +1238,7 @@ public class QueryIT extends SQLIntegTestCase {
 //    @Test
 //    public void complexChildrenQueryBothOnSameObject() throws IOException {
 //        JSONObject response = executeQuery(
-//                        String.format(Locale.ROOT, "SELECT * " +
+//                        format("SELECT * " +
 //                                      "FROM %s/joinType " +
 //                                      "WHERE children(childrenType, info = 'a' AND author ='e')",
 //                                TestsConstants.TEST_INDEX_JOIN_TYPE));
@@ -1250,7 +1249,7 @@ public class QueryIT extends SQLIntegTestCase {
 //    @Test
 //    public void complexChildrenQueryNotOnSameObject() throws IOException {
 //        JSONObject response = executeQuery(
-//                        String.format(Locale.ROOT, "SELECT * " +
+//                        format("SELECT * " +
 //                                      "FROM %s/joinType " +
 //                                      "WHERE children(childrenType, info = 'a' AND author ='j')",
 //                                TestsConstants.TEST_INDEX_JOIN_TYPE));
@@ -1261,7 +1260,7 @@ public class QueryIT extends SQLIntegTestCase {
 //    @Test
 //    public void childrenOnInTermsQuery() throws IOException {
 //        JSONObject response = executeQuery(
-//                        String.format(Locale.ROOT, "SELECT * " +
+//                        format("SELECT * " +
 //                                      "FROM %s/joinType " +
 //                                      "WHERE children(childrenType, info) = IN_TERMS(a, b)",
 //                                TestsConstants.TEST_INDEX_JOIN_TYPE));
@@ -1273,7 +1272,8 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void multipleIndicesOneNotExistWithHint() throws IOException {
 
-        JSONObject response = executeQuery(String.format(Locale.ROOT, "SELECT /*! IGNORE_UNAVAILABLE */ * FROM %s,%s ", TEST_INDEX_ACCOUNT,"badindex"));
+        JSONObject response = executeQuery(
+                format("SELECT /*! IGNORE_UNAVAILABLE */ * FROM %s,%s ", TEST_INDEX_ACCOUNT, "badindex"));
 
         Assert.assertTrue(getTotalHits(response) > 0);
     }
@@ -1282,7 +1282,7 @@ public class QueryIT extends SQLIntegTestCase {
     public void multipleIndicesOneNotExistWithoutHint() throws IOException {
         try {
             executeQuery(
-                    String.format(Locale.ROOT, "SELECT * FROM %s, %s", TEST_INDEX_ACCOUNT, "badindex"));
+                    format("SELECT * FROM %s, %s", TEST_INDEX_ACCOUNT, "badindex"));
             Assert.fail("Expected exception, but call succeeded");
         } catch (ResponseException e) {
             Assert.assertEquals(RestStatus.BAD_REQUEST.getStatus(), e.getResponse().getStatusLine().getStatusCode());
@@ -1295,7 +1295,7 @@ public class QueryIT extends SQLIntegTestCase {
     //  to properly update these tests to ESIntegTestCase format
 //    @Test
 //    public void routingRequestOneRounting() throws IOException {
-//        SqlElasticSearchRequestBuilder request = getRequestBuilder(String.format(Locale.ROOT,
+//        SqlElasticSearchRequestBuilder request = getRequestBuilder(format(
 //                                  "SELECT /*! ROUTINGS(hey) */ * FROM %s/account ", TEST_INDEX_ACCOUNT));
 //        SearchRequestBuilder searchRequestBuilder = (SearchRequestBuilder) request.getBuilder();
 //        Assert.assertEquals("hey",searchRequestBuilder.request().routing());
@@ -1303,7 +1303,7 @@ public class QueryIT extends SQLIntegTestCase {
 //
 //    @Test
 //    public void routingRequestMultipleRountings() throws IOException {
-//        SqlElasticSearchRequestBuilder request = getRequestBuilder(String.format(Locale.ROOT,
+//        SqlElasticSearchRequestBuilder request = getRequestBuilder(format(
 //                                  "SELECT /*! ROUTINGS(hey,bye) */ * FROM %s/account ", TEST_INDEX_ACCOUNT));
 //        SearchRequestBuilder searchRequestBuilder = (SearchRequestBuilder) request.getBuilder();
 //        Assert.assertEquals("hey,bye",searchRequestBuilder.request().routing());
@@ -1313,7 +1313,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void scriptFilterNoParams() throws IOException {
 
-        JSONObject result = executeQuery(String.format(Locale.ROOT,
+        JSONObject result = executeQuery(format(
                 "SELECT insert_time FROM %s/online where script('doc[\\'insert_time\''].date.hourOfDay==16') " +
                 "and insert_time <'2014-08-21T00:00:00.000Z'", TEST_INDEX_ONLINE));
         Assert.assertEquals(237, getTotalHits(result));
@@ -1323,7 +1323,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void scriptFilterWithParams() throws IOException {
 
-        JSONObject result = executeQuery(String.format(Locale.ROOT,
+        JSONObject result = executeQuery(format(
                 "SELECT insert_time FROM %s/online where script('doc[\\'insert_time\''].date.hourOfDay==x','x'=16) " +
                 "and insert_time <'2014-08-21T00:00:00.000Z'", TEST_INDEX_ONLINE));
         Assert.assertEquals(237, getTotalHits(result));
@@ -1332,7 +1332,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void highlightPreTagsAndPostTags() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT,
+                        format(
                                 "SELECT /*! HIGHLIGHT(phrase, pre_tags : ['<b>'], post_tags : ['</b>']) */ " +
                                       "* FROM %s/phrase " +
                                       "WHERE phrase LIKE 'fox' " +
@@ -1352,7 +1352,7 @@ public class QueryIT extends SQLIntegTestCase {
     @Test
     public void fieldCollapsingTest() throws IOException {
         JSONObject response = executeQuery(
-                        String.format(Locale.ROOT, "SELECT /*! COLLAPSE({\"field\":\"age\"," +
+                        format("SELECT /*! COLLAPSE({\"field\":\"age\"," +
                                                            "\"inner_hits\":{\"name\": \"account\"," +
                                                                            "\"size\":1," +
                                                                            "\"sort\":[{\"age\":\"asc\"}]}," +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryIT.java
@@ -143,7 +143,6 @@ public class QueryIT extends SQLIntegTestCase {
     // it might be possible to change field names after the query already executed.
     @Test
     public void selectAliases() throws IOException {
-
         String[] arr = new String[] {"myage", "myaccount_number"};
         Set<String> expectedSource = new HashSet<>(Arrays.asList(arr));
 
@@ -1271,7 +1270,6 @@ public class QueryIT extends SQLIntegTestCase {
     @Ignore // the hint does not really work, NoSuchIndexException is thrown
     @Test
     public void multipleIndicesOneNotExistWithHint() throws IOException {
-
         JSONObject response = executeQuery(
                 format("SELECT /*! IGNORE_UNAVAILABLE */ * FROM %s,%s ", TEST_INDEX_ACCOUNT, "badindex"));
 
@@ -1312,7 +1310,6 @@ public class QueryIT extends SQLIntegTestCase {
     @Ignore // Getting parser error: syntax error, expect RPAREN, actual IDENTIFIER insert_time
     @Test
     public void scriptFilterNoParams() throws IOException {
-
         JSONObject result = executeQuery(format(
                 "SELECT insert_time FROM %s/online where script('doc[\\'insert_time\''].date.hourOfDay==16') " +
                 "and insert_time <'2014-08-21T00:00:00.000Z'", TEST_INDEX_ONLINE));
@@ -1322,7 +1319,6 @@ public class QueryIT extends SQLIntegTestCase {
     @Ignore // Getting parser error: syntax error, expect RPAREN, actual IDENTIFIER insert_time
     @Test
     public void scriptFilterWithParams() throws IOException {
-
         JSONObject result = executeQuery(format(
                 "SELECT insert_time FROM %s/online where script('doc[\\'insert_time\''].date.hourOfDay==x','x'=16) " +
                 "and insert_time <'2014-08-21T00:00:00.000Z'", TEST_INDEX_ONLINE));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -81,7 +81,6 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
      */
     @Ignore
     public void normalFieldAlias() throws Exception {
-
         //here is a bug,csv field with spa
         String query = "SELECT " +
                 "address as key,age from " +
@@ -129,7 +128,6 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
      */
     @Ignore
     public void whereConditionLeftFunctionRightVariableEqualTest() throws Exception {
-
         String query = "SELECT " +
                 " * from " +
                 TestsConstants.TEST_INDEX + "/account " +
@@ -144,7 +142,6 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
      */
     @Ignore
     public void whereConditionLeftFunctionRightVariableGreatTest() throws Exception {
-
         String query = "SELECT " +
                 " * from " +
                 TestsConstants.TEST_INDEX + "/account " +
@@ -155,7 +152,6 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
     @Test
     public void concat_ws_fields() throws Exception {
-
         //here is a bug,csv field with spa
         String query = "SELECT " +
                 " concat_ws('-',age,address) as combine,address from " +
@@ -200,7 +196,6 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
      */
     @Ignore
     public void split_field() {
-
         //here is a bug, csv field with spa
         String query = "SELECT " +
                 " split(address,' ')[0],age from " +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -36,6 +36,7 @@ import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstant
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.hitAny;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kvDouble;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kvString;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
@@ -47,7 +48,6 @@ import static org.hamcrest.Matchers.hasValue;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
-
 
 /**
  * Created by allwefantasy on 8/25/16.
@@ -69,8 +69,8 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
 
         IntStream.rangeClosed(0, 9).forEach(i -> {
-                    Assert.assertNotNull(result.query(String.format("/aggregations/key/buckets/%d/key", i)));
-                    Assert.assertNotNull(result.query(String.format("/aggregations/key/buckets/%d/cvalue/value", i)));
+                    Assert.assertNotNull(result.query(format("/aggregations/key/buckets/%d/key", i)));
+                    Assert.assertNotNull(result.query(format("/aggregations/key/buckets/%d/cvalue/value", i)));
                 }
         );
     }
@@ -184,11 +184,13 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
     @Test
     public void functionPow() throws Exception {
         String query = "SELECT pow(account_number, 2) as key,"+
-                "abs(age - 60) as new_age from " + TEST_INDEX_ACCOUNT + "/account WHERE firstname = 'Virginia' and lastname='Ayala' limit 1";
+                "abs(age - 60) as new_age from " + TEST_INDEX_ACCOUNT +
+                "/account WHERE firstname = 'Virginia' and lastname='Ayala' limit 1";
 
         assertThat(
                 executeQuery(query),
-                hitAny(both(kvDouble("/fields/new_age/0", equalTo(21.0))).and(kvDouble("/fields/key/0", equalTo(625.0))))
+                hitAny(both(kvDouble("/fields/new_age/0", equalTo(21.0))).and(kvDouble("/fields/key/0",
+                        equalTo(625.0))))
         );
     }
 
@@ -197,9 +199,9 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
      * @see <a href="https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html">https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html</a>
      */
     @Ignore
-    public void split_field() throws Exception {
+    public void split_field() {
 
-        //here is a bug,csv field with spa
+        //here is a bug, csv field with spa
         String query = "SELECT " +
                 " split(address,' ')[0],age from " +
                 TestsConstants.TEST_INDEX + "/account where address is not null " +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
@@ -91,7 +91,6 @@ public abstract class SQLIntegTestCase extends ESIntegTestCase {
     }
 
     protected Request getSqlRequest(String request, boolean explain) {
-
         Request sqlRequest = new Request("POST", explain ? EXPLAIN_API_ENDPOINT : QUERY_API_ENDPOINT);
         sqlRequest.setJsonEntity(request);
         RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
@@ -102,7 +101,6 @@ public abstract class SQLIntegTestCase extends ESIntegTestCase {
     }
 
     private Request buildGetEndpointRequest(final String sqlQuery) {
-
         final String utf8CharsetName = StandardCharsets.UTF_8.name();
         String urlEncodedQuery = "";
 
@@ -119,41 +117,34 @@ public abstract class SQLIntegTestCase extends ESIntegTestCase {
     }
 
     protected JSONObject executeQuery(final String sqlQuery) throws IOException {
-
         final String requestBody = makeRequest(sqlQuery);
         return executeRequest(requestBody);
     }
 
     protected String explainQuery(final String sqlQuery) throws IOException {
-
         final String requestBody = makeRequest(sqlQuery);
         return executeExplainRequest(requestBody);
     }
 
     protected String executeQueryWithStringOutput(final String sqlQuery) throws IOException {
-
         final String requestString = makeRequest(sqlQuery);
         return executeRequest(requestString, false);
     }
 
     protected JSONObject executeRequest(final String requestBody) throws IOException {
-
         return new JSONObject(executeRequest(requestBody, false));
     }
 
     protected String executeExplainRequest(final String requestBody) throws IOException {
-
         return executeRequest(requestBody, true);
     }
 
     private String executeRequest(final String requestBody, final boolean isExplainQuery) throws IOException {
-
         Request sqlRequest = getSqlRequest(requestBody, isExplainQuery);
         return executeRequest(sqlRequest);
     }
 
     protected String executeRequest(final Request request) throws IOException {
-
         RestClient restClient = ESIntegTestCase.getRestClient();
         Response response = restClient.performRequest(request);
         Assert.assertEquals(200, response.getStatusLine().getStatusCode());
@@ -161,7 +152,6 @@ public abstract class SQLIntegTestCase extends ESIntegTestCase {
     }
 
     protected JSONObject executeQueryWithGetRequest(final String sqlQuery) throws IOException {
-
         final Request request = buildGetEndpointRequest(sqlQuery);
         final String result = executeRequest(request);
         return new JSONObject(result);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
@@ -37,13 +37,14 @@ import java.net.InetSocketAddress;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 
 import static com.amazon.opendistroforelasticsearch.sql.plugin.RestSqlAction.EXPLAIN_API_ENDPOINT;
 import static com.amazon.opendistroforelasticsearch.sql.plugin.RestSqlAction.QUERY_API_ENDPOINT;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 
 @ESIntegTestCase.SuiteScopeTestCase
-@ESIntegTestCase.ClusterScope(scope=ESIntegTestCase.Scope.SUITE, numDataNodes=3, supportsDedicatedMasters=false, transportClientRatio=1)
+@ESIntegTestCase.ClusterScope(scope=ESIntegTestCase.Scope.SUITE, numDataNodes=3, supportsDedicatedMasters=false,
+        transportClientRatio=1)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public abstract class SQLIntegTestCase extends ESIntegTestCase {
 
@@ -100,7 +101,7 @@ public abstract class SQLIntegTestCase extends ESIntegTestCase {
         return sqlRequest;
     }
 
-    protected Request buildGetEndpointRequest(final String sqlQuery) {
+    private Request buildGetEndpointRequest(final String sqlQuery) {
 
         final String utf8CharsetName = StandardCharsets.UTF_8.name();
         String urlEncodedQuery = "";
@@ -112,7 +113,7 @@ public abstract class SQLIntegTestCase extends ESIntegTestCase {
             Assert.fail(utf8CharsetName + " not available");
         }
 
-        final String requestUrl = String.format(Locale.ROOT, "%s?sql=%s",
+        final String requestUrl = format("%s?sql=%s",
                 QUERY_API_ENDPOINT, urlEncodedQuery);
         return new Request("GET", requestUrl);
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ShowIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ShowIT.java
@@ -29,7 +29,6 @@ public class ShowIT extends SQLIntegTestCase {
 
     @Override
     protected void setupSuiteScopeCluster() {
-
         AdminClient adminClient = this.admin();
 
         // Note: not using the existing TEST_INDEX_* indices, since underscore in the names causes issues
@@ -40,30 +39,25 @@ public class ShowIT extends SQLIntegTestCase {
 
     @Test
     public void showAll_matchAll() throws IOException {
-
         showIndexTest("%", 3, false);
     }
 
     @Test
     public void showIndex_matchPrefix() throws IOException {
-
         showIndexTest("abcdefg" + "%", 2, true);
     }
 
     @Test
     public void showIndex_matchSuffix() throws IOException {
-
         showIndexTest("%ijk", 2, true);
     }
 
     @Test
     public void showIndex_matchExact() throws IOException {
-
         showIndexTest("abcdefg", 1, true);
     }
 
     private void showIndexTest(String querySuffix, int expectedMatches, boolean exactMatch) throws IOException {
-
         final String query = "SHOW TABLES LIKE " + querySuffix;
         JSONObject result = executeQuery(query);
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SourceFieldIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SourceFieldIT.java
@@ -56,7 +56,6 @@ public class SourceFieldIT extends SQLIntegTestCase {
 
     @Test
     public void excludeTest() throws IOException {
-
         SearchHits response = query(format("SELECT exclude('*name','*ge'),exclude('b*'),exclude('*ddre*')," +
                 "exclude('gender') FROM %s/account LIMIT 1000", TEST_INDEX_ACCOUNT));
 
@@ -71,7 +70,6 @@ public class SourceFieldIT extends SQLIntegTestCase {
 
     @Test
     public void allTest() throws IOException {
-
         SearchHits response = query(format("SELECT exclude('*name','*ge'),include('b*'),exclude('*ddre*')," +
                 "include('gender') FROM %s/account LIMIT 1000", TEST_INDEX_ACCOUNT));
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SourceFieldIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SourceFieldIT.java
@@ -31,61 +31,67 @@ import java.io.IOException;
 import java.util.Set;
 
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 
 public class SourceFieldIT extends SQLIntegTestCase {
 
-	@Override
-	protected void init() throws Exception {
-		loadIndex(Index.ACCOUNT);
-	}
+    @Override
+    protected void init() throws Exception {
+        loadIndex(Index.ACCOUNT);
+    }
 
-	@Test
-	public void includeTest() throws IOException {
-		SearchHits response = query(String.format("SELECT include('*name','*ge'),include('b*'),include('*ddre*'),include('gender') FROM %s/account LIMIT 1000", TEST_INDEX_ACCOUNT));
-		for (SearchHit hit : response.getHits()) {
-			Set<String> keySet = hit.getSourceAsMap().keySet();
-			for (String field : keySet) {
-				Assert.assertTrue(field.endsWith("name") || field.endsWith("ge") || field.startsWith("b") || field.contains("ddre") || field.equals("gender"));
-			}
-		}
+    @Test
+    public void includeTest() throws IOException {
+        SearchHits response = query(format("SELECT include('*name','*ge'),include('b*'),include('*ddre*')," +
+                "include('gender') FROM %s/account LIMIT 1000", TEST_INDEX_ACCOUNT));
+        for (SearchHit hit : response.getHits()) {
+            Set<String> keySet = hit.getSourceAsMap().keySet();
+            for (String field : keySet) {
+                Assert.assertTrue(field.endsWith("name") || field.endsWith("ge") || field.startsWith("b") ||
+                        field.contains("ddre") || field.equals("gender"));
+            }
+        }
 
-	}
-	
-	@Test
-	public void excludeTest() throws IOException {
+    }
 
-		SearchHits response = query(String.format("SELECT exclude('*name','*ge'),exclude('b*'),exclude('*ddre*'),exclude('gender') FROM %s/account LIMIT 1000", TEST_INDEX_ACCOUNT));
+    @Test
+    public void excludeTest() throws IOException {
 
-		for (SearchHit hit : response.getHits()) {
-			Set<String> keySet = hit.getSourceAsMap().keySet();
-			for (String field : keySet) {
-				Assert.assertFalse(field.endsWith("name") || field.endsWith("ge") || field.startsWith("b") || field.contains("ddre") || field.equals("gender"));
-			}
-		}
-	}
-	
-	@Test
-	public void allTest() throws IOException {
+        SearchHits response = query(format("SELECT exclude('*name','*ge'),exclude('b*'),exclude('*ddre*')," +
+                "exclude('gender') FROM %s/account LIMIT 1000", TEST_INDEX_ACCOUNT));
 
-		SearchHits response = query(String.format("SELECT exclude('*name','*ge'),include('b*'),exclude('*ddre*'),include('gender') FROM %s/account LIMIT 1000", TEST_INDEX_ACCOUNT));
+        for (SearchHit hit : response.getHits()) {
+            Set<String> keySet = hit.getSourceAsMap().keySet();
+            for (String field : keySet) {
+                Assert.assertFalse(field.endsWith("name") || field.endsWith("ge") || field.startsWith("b") ||
+                        field.contains("ddre") || field.equals("gender"));
+            }
+        }
+    }
 
-		for (SearchHit hit : response.getHits()) {
-			Set<String> keySet = hit.getSourceAsMap().keySet();
-			for (String field : keySet) {
-				Assert.assertFalse(field.endsWith("name") || field.endsWith("ge") ||  field.contains("ddre") );
-				Assert.assertTrue(field.startsWith("b") || field.equals("gender"));
-			}
-		}
-	}
+    @Test
+    public void allTest() throws IOException {
 
-	private SearchHits query(String query) throws IOException {
-		final JSONObject jsonObject = executeQuery(query);
+        SearchHits response = query(format("SELECT exclude('*name','*ge'),include('b*'),exclude('*ddre*')," +
+                "include('gender') FROM %s/account LIMIT 1000", TEST_INDEX_ACCOUNT));
 
-		final XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(
-				NamedXContentRegistry.EMPTY,
-				LoggingDeprecationHandler.INSTANCE,
-				jsonObject.toString());
-		return SearchResponse.fromXContent(parser).getHits();
-	}
+        for (SearchHit hit : response.getHits()) {
+            Set<String> keySet = hit.getSourceAsMap().keySet();
+            for (String field : keySet) {
+                Assert.assertFalse(field.endsWith("name") || field.endsWith("ge") || field.contains("ddre"));
+                Assert.assertTrue(field.startsWith("b") || field.equals("gender"));
+            }
+        }
+    }
+
+    private SearchHits query(String query) throws IOException {
+        final JSONObject jsonObject = executeQuery(query);
+
+        final XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(
+                NamedXContentRegistry.EMPTY,
+                LoggingDeprecationHandler.INSTANCE,
+                jsonObject.toString());
+        return SearchResponse.fromXContent(parser).getHits();
+    }
 
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
@@ -22,15 +22,14 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Locale;
 
+import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_BANK;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_BANK_TWO;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_DOG;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_DOG2;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_DOG3;
-import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
-
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -84,7 +83,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testNonResolvingIndexPatternWithExistingIndex() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT * " +
+        String result = explainQuery(format("SELECT * " +
                 "FROM elasticsearch_sql_test_blah_blah*, %s " +
                 "WHERE state = 'DC'", TEST_INDEX_BANK));
         assertThat(result, containsString("\"term\":{\"state.keyword\""));
@@ -108,7 +107,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testNonCompatibleMappings() throws IOException {
         try {
-            explainQuery(String.format(Locale.ROOT, "SELECT * FROM %s, %s ",
+            explainQuery(format("SELECT * FROM %s, %s ",
                     TEST_INDEX_DOG, TEST_INDEX_DOG2));
             Assert.fail("Expected ResponseException, but none was thrown");
         } catch (ResponseException e) {
@@ -123,7 +122,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testEqualFieldMappings() throws IOException {
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT color FROM %s, %s ",
+        String result = explainQuery(format("SELECT color FROM %s, %s ",
                     TEST_INDEX_DOG2, TEST_INDEX_DOG3));
         assertThat(result, containsString("color"));
         assertThat(result, containsString("_source"));
@@ -132,7 +131,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testIdenticalMappings() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT firstname, birthdate, state " +
+        String result = explainQuery(format("SELECT firstname, birthdate, state " +
                         "FROM %s, %s WHERE state = 'WA' OR male = 'true'",
                 TEST_INDEX_BANK, TEST_INDEX_BANK_TWO));
         assertThat(result, containsString("term"));
@@ -143,7 +142,8 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testIdenticalMappingsWithTypes() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT firstname, birthdate, state FROM %s, %s WHERE state = 'WA' OR male = 'true'",
+        String result = explainQuery(format("SELECT firstname, birthdate, state FROM %s, %s " +
+                        "WHERE state = 'WA' OR male = 'true'",
                 TEST_INDEX_BANK + "/account", TEST_INDEX_BANK_TWO + "/account_two"));
         assertThat(result, containsString("term"));
         assertThat(result, containsString("state.keyword"));
@@ -154,7 +154,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testIdenticalMappingsWithPartialType() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT firstname, birthdate, state " +
+        String result = explainQuery(format("SELECT firstname, birthdate, state " +
                         "FROM %s, %s WHERE state = 'WA' OR male = 'true'",
                 TEST_INDEX_BANK + "/account", TEST_INDEX_BANK_TWO));
         assertThat(result, containsString("term"));
@@ -165,7 +165,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testTextFieldOnly() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT firstname, birthdate, state " +
+        String result = explainQuery(format("SELECT firstname, birthdate, state " +
                 "FROM %s WHERE firstname = 'Abbas'", TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
         assertThat(result, not(containsString("firstname.")));
@@ -174,7 +174,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testTextAndKeywordAppendsKeywordAlias() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT firstname, birthdate, state " +
+        String result = explainQuery(format("SELECT firstname, birthdate, state " +
                 "FROM %s WHERE state = 'WA' OR lastname = 'Chen'", TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
         assertThat(result, containsString("state.keyword"));
@@ -184,7 +184,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testBooleanFieldNoKeywordAlias() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT * FROM %s WHERE male = 'false'",
+        String result = explainQuery(format("SELECT * FROM %s WHERE male = 'false'",
                 TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
         assertThat(result, not(containsString("male.")));
@@ -193,7 +193,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testDateFieldNoKeywordAlias() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT * FROM %s WHERE birthdate = '2018-08-19'",
+        String result = explainQuery(format("SELECT * FROM %s WHERE birthdate = '2018-08-19'",
                 TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
         assertThat(result, not(containsString("birthdate.")));
@@ -202,7 +202,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testNumberNoKeywordAlias() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT * FROM %s WHERE age = 32",
+        String result = explainQuery(format("SELECT * FROM %s WHERE age = 32",
                 TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
         assertThat(result, not(containsString("age.")));
@@ -211,7 +211,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void inTestInWhere() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "select * from %s " +
+        String result = explainQuery(format("select * from %s " +
                 "where state IN ('WA' , 'PA' , 'TN')", TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
         assertThat(result, containsString("state.keyword"));
@@ -221,7 +221,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Ignore // TODO: enable when subqueries are fixed
     public void inTestInWhereSubquery() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "select * from %s where " +
+        String result = explainQuery(format("select * from %s where " +
                         "state IN (select state from %s where city = 'Nicholson')",
                 TEST_INDEX_BANK + "/account", TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
@@ -231,7 +231,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testKeywordAliasGroupBy() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT firstname, state FROM %s " +
+        String result = explainQuery(format("SELECT firstname, state FROM %s " +
                 "GROUP BY firstname, state", TEST_INDEX_BANK + "/account"));
         assertThat(result, containsString("term"));
         assertThat(result, containsString("state.keyword"));
@@ -241,7 +241,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testKeywordAliasOrderBy() throws IOException {
 
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT * FROM %s ORDER BY state, lastname ",
+        String result = explainQuery(format("SELECT * FROM %s ORDER BY state, lastname ",
                 TEST_INDEX_BANK));
         assertThat(result, containsString("\"state.keyword\":{\"order\":\"asc\""));
         assertThat(result, containsString("\"lastname\":{\"order\":\"asc\"}"));
@@ -252,7 +252,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     public void testJoinWhere() throws IOException {
 
         String expectedOutput = TestUtils.fileToString("src/test/resources/expectedOutput/term_join_where", true);
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT a.firstname, a.lastname , b.city " +
+        String result = explainQuery(format("SELECT a.firstname, a.lastname , b.city " +
                 "FROM %s a JOIN %s b ON a.city = b.city where a.city IN ('Nicholson', 'Yardville')",
                 TEST_INDEX_ACCOUNT, TEST_INDEX_ACCOUNT ));
 
@@ -262,7 +262,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     public void testJoinAliasMissing() throws IOException {
         try {
-            explainQuery(String.format(Locale.ROOT, "SELECT a.firstname, a.lastname , b.city " +
+            explainQuery(format("SELECT a.firstname, a.lastname , b.city " +
                     "FROM %s a JOIN %s b ON a.city = b.city where city IN ('Nicholson', 'Yardville')",
                     TEST_INDEX_ACCOUNT, TEST_INDEX_ACCOUNT));
             Assert.fail("Expected ResponseException, but none was thrown");
@@ -280,7 +280,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     public void testMultiQuery() throws IOException {
 
         String expectedOutput = TestUtils.fileToString("src/test/resources/expectedOutput/term_union_where", true);
-        String result = explainQuery(String.format(Locale.ROOT, "SELECT firstname FROM %s/account " +
+        String result = explainQuery(format("SELECT firstname FROM %s/account " +
                         "WHERE firstname = 'Amber' UNION ALL SELECT dog_name as firstname FROM %s/dog " +
                         "WHERE holdersName = 'Hattie' OR dog_name = 'rex'", TEST_INDEX_ACCOUNT, TEST_INDEX_DOG));
         assertThat(result.replaceAll("\\s+",""), equalTo(expectedOutput.replaceAll("\\s+","")));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
@@ -82,7 +82,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testNonResolvingIndexPatternWithExistingIndex() throws IOException {
-
         String result = explainQuery(format("SELECT * " +
                 "FROM elasticsearch_sql_test_blah_blah*, %s " +
                 "WHERE state = 'DC'", TEST_INDEX_BANK));
@@ -130,7 +129,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testIdenticalMappings() throws IOException {
-
         String result = explainQuery(format("SELECT firstname, birthdate, state " +
                         "FROM %s, %s WHERE state = 'WA' OR male = 'true'",
                 TEST_INDEX_BANK, TEST_INDEX_BANK_TWO));
@@ -141,7 +139,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testIdenticalMappingsWithTypes() throws IOException {
-
         String result = explainQuery(format("SELECT firstname, birthdate, state FROM %s, %s " +
                         "WHERE state = 'WA' OR male = 'true'",
                 TEST_INDEX_BANK + "/account", TEST_INDEX_BANK_TWO + "/account_two"));
@@ -153,7 +150,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testIdenticalMappingsWithPartialType() throws IOException {
-
         String result = explainQuery(format("SELECT firstname, birthdate, state " +
                         "FROM %s, %s WHERE state = 'WA' OR male = 'true'",
                 TEST_INDEX_BANK + "/account", TEST_INDEX_BANK_TWO));
@@ -164,7 +160,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testTextFieldOnly() throws IOException {
-
         String result = explainQuery(format("SELECT firstname, birthdate, state " +
                 "FROM %s WHERE firstname = 'Abbas'", TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
@@ -173,7 +168,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testTextAndKeywordAppendsKeywordAlias() throws IOException {
-
         String result = explainQuery(format("SELECT firstname, birthdate, state " +
                 "FROM %s WHERE state = 'WA' OR lastname = 'Chen'", TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
@@ -183,7 +177,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testBooleanFieldNoKeywordAlias() throws IOException {
-
         String result = explainQuery(format("SELECT * FROM %s WHERE male = 'false'",
                 TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
@@ -192,7 +185,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testDateFieldNoKeywordAlias() throws IOException {
-
         String result = explainQuery(format("SELECT * FROM %s WHERE birthdate = '2018-08-19'",
                 TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
@@ -201,7 +193,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testNumberNoKeywordAlias() throws IOException {
-
         String result = explainQuery(format("SELECT * FROM %s WHERE age = 32",
                 TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
@@ -210,7 +201,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void inTestInWhere() throws IOException {
-
         String result = explainQuery(format("select * from %s " +
                 "where state IN ('WA' , 'PA' , 'TN')", TEST_INDEX_BANK));
         assertThat(result, containsString("term"));
@@ -220,7 +210,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     @Ignore // TODO: enable when subqueries are fixed
     public void inTestInWhereSubquery() throws IOException {
-
         String result = explainQuery(format("select * from %s where " +
                         "state IN (select state from %s where city = 'Nicholson')",
                 TEST_INDEX_BANK + "/account", TEST_INDEX_BANK));
@@ -230,7 +219,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testKeywordAliasGroupBy() throws IOException {
-
         String result = explainQuery(format("SELECT firstname, state FROM %s " +
                 "GROUP BY firstname, state", TEST_INDEX_BANK + "/account"));
         assertThat(result, containsString("term"));
@@ -240,7 +228,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
 
     @Test
     public void testKeywordAliasOrderBy() throws IOException {
-
         String result = explainQuery(format("SELECT * FROM %s ORDER BY state, lastname ",
                 TEST_INDEX_BANK));
         assertThat(result, containsString("\"state.keyword\":{\"order\":\"asc\""));
@@ -250,7 +237,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     @Ignore // TODO: verify the returned query is correct and fix the expected output
     public void testJoinWhere() throws IOException {
-
         String expectedOutput = TestUtils.fileToString("src/test/resources/expectedOutput/term_join_where", true);
         String result = explainQuery(format("SELECT a.firstname, a.lastname , b.city " +
                 "FROM %s a JOIN %s b ON a.city = b.city where a.city IN ('Nicholson', 'Yardville')",
@@ -278,7 +264,6 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     @Test
     @Ignore // TODO: enable when subqueries are fixed
     public void testMultiQuery() throws IOException {
-
         String expectedOutput = TestUtils.fileToString("src/test/resources/expectedOutput/term_union_where", true);
         String result = explainQuery(format("SELECT firstname FROM %s/account " +
                         "WHERE firstname = 'Amber' UNION ALL SELECT dog_name as firstname FROM %s/dog " +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -367,7 +367,6 @@ public class TestUtils {
              final BufferedReader br = new BufferedReader(streamReader)) {
 
             while (true) {
-
                 String actionLine = br.readLine();
                 if (actionLine == null || actionLine.trim().isEmpty()) {
                     break;
@@ -413,7 +412,6 @@ public class TestUtils {
     }
 
     public static String getResponseBody(Response response) throws IOException {
-
         return getResponseBody(response, false);
     }
 
@@ -422,7 +420,6 @@ public class TestUtils {
 
         try (final InputStream is = response.getEntity().getContent();
              final BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
-
             String line;
             while ((line = br.readLine()) != null) {
                 sb.append(line);
@@ -436,7 +433,6 @@ public class TestUtils {
 
     public static String fileToString(final String filePathFromProjectRoot, final boolean removeNewLines)
             throws IOException {
-
         final String absolutePath = getResourceFilePath(filePathFromProjectRoot);
 
         try (final InputStream stream = new FileInputStream(absolutePath);
@@ -447,7 +443,6 @@ public class TestUtils {
             String line = br.readLine();
 
             while (line != null) {
-
                 stringBuilder.append(line);
                 if (!removeNewLines) {
                     stringBuilder.append(format("%n"));
@@ -466,7 +461,6 @@ public class TestUtils {
      * @return list of permutations
      */
     public static List<List<String>> getPermutations(final List<String> items) {
-
         if (items.size() > 5) {
             throw new IllegalArgumentException("Inefficient test, please refactor");
         }
@@ -474,7 +468,6 @@ public class TestUtils {
         final List<List<String>> result = new LinkedList<>();
 
         if (items.isEmpty() || 1 == items.size()) {
-
             final List<String> onlyElement = new ArrayList<>();
             if (1 == items.size()) {
                 onlyElement.add(items.get(0));
@@ -484,7 +477,6 @@ public class TestUtils {
         }
 
         for (int i = 0; i < items.size(); ++i) {
-
             final List<String> smallerSet = new ArrayList<>();
 
             if (i != 0) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -38,8 +38,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Collectors;
+
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 
 public class TestUtils {
 
@@ -357,7 +358,7 @@ public class TestUtils {
     }
 
     public static void loadBulk(Client client, String jsonPath, String defaultIndex) throws Exception {
-        System.out.println(String.format("Loading file %s into elasticsearch cluster", jsonPath));
+        System.out.println(format("Loading file %s into elasticsearch cluster", jsonPath));
         String absJsonPath = getResourceFilePath(jsonPath);
 
         BulkRequest bulkRequest = new BulkRequest();
@@ -426,7 +427,7 @@ public class TestUtils {
             while ((line = br.readLine()) != null) {
                 sb.append(line);
                 if (retainNewLines) {
-                    sb.append(String.format(Locale.ROOT, "%n"));
+                    sb.append(format("%n"));
                 }
             }
         }
@@ -449,7 +450,7 @@ public class TestUtils {
 
                 stringBuilder.append(line);
                 if (!removeNewLines) {
-                    stringBuilder.append(String.format(Locale.ROOT, "%n"));
+                    stringBuilder.append(format("%n"));
                 }
                 line = br.readLine();
             }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestsConstants.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestsConstants.java
@@ -24,7 +24,6 @@ public class TestsConstants {
 
     public final static String TEST_INDEX_ONLINE = TEST_INDEX + "_online";
     public final static String TEST_INDEX_ACCOUNT = TEST_INDEX + "_account";
-    public final static String TEST_INDEX_ACCOUNT_TEMP = TEST_INDEX + "_account_temp";
     public final static String TEST_INDEX_PHRASE = TEST_INDEX + "_phrase";
     public final static String TEST_INDEX_DOG = TEST_INDEX + "_dog";
     public final static String TEST_INDEX_DOG2 = TEST_INDEX + "_dog2";

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
@@ -25,18 +25,20 @@ import com.amazon.opendistroforelasticsearch.sql.parser.ElasticSqlExprParser;
 import com.amazon.opendistroforelasticsearch.sql.parser.SqlParser;
 import com.amazon.opendistroforelasticsearch.sql.query.maker.QueryMaker;
 import com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.query.RangeQueryBuilder;
-import org.hamcrest.*;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static com.amazon.opendistroforelasticsearch.sql.util.HasFieldWithValue.hasFieldWithValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
 
 public class DateFormatTest {
 
@@ -47,23 +49,29 @@ public class DateFormatTest {
         List<QueryBuilder> q = query(SELECT_CNT_FROM_DATE + "WHERE date_format(creationDate, 'YYYY') < '2018'");
 
         assertThat(q, hasQueryWithValue("fieldName", equalTo("creationDate")));
-        assertThat(q, hasQueryWithValueGetter(MatcherUtils.featureValueOf("has format", equalTo("YYYY"), f->((RangeQueryBuilder)f).format())));
+        assertThat(q, hasQueryWithValueGetter(MatcherUtils.featureValueOf("has format", equalTo("YYYY"),
+                f->((RangeQueryBuilder)f).format())));
     }
 
     @Test
     public void equalCondition() {
-        List<QueryBuilder> q = query(SELECT_CNT_FROM_DATE + "WHERE date_format(creationDate, 'YYYY-MM-dd') = '2018-04-02'");
+        List<QueryBuilder> q = query(SELECT_CNT_FROM_DATE +
+                "WHERE date_format(creationDate, 'YYYY-MM-dd') = '2018-04-02'");
 
-        assertThat(q, hasQueryWithValueGetter(MatcherUtils.featureValueOf("has format", equalTo("YYYY-MM-dd"), f->((RangeQueryBuilder)f).format())));
+        assertThat(q, hasQueryWithValueGetter(MatcherUtils.featureValueOf("has format", equalTo("YYYY-MM-dd"),
+                f->((RangeQueryBuilder)f).format())));
 
-        // Equality query for date_format is created with a rangeQuery where the 'from' and 'to' values are equal to the value we are equating to
-        assertThat(q, hasQueryWithValue("from", equalTo(BytesRefs.toBytesRef("2018-04-02")))); // converting string to bytes ref as RangeQueryBuilder stores it this way
+        // Equality query for date_format is created with a rangeQuery where the 'from' and 'to'
+        // values are equal to the value we are equating to
+        // NOTE: converting string to bytes ref as RangeQueryBuilder stores it this way
+        assertThat(q, hasQueryWithValue("from", equalTo(BytesRefs.toBytesRef("2018-04-02"))));
         assertThat(q, hasQueryWithValue("to", equalTo(BytesRefs.toBytesRef("2018-04-02"))));
     }
 
     @Test
     public void notEqualCondition() {
-        List<QueryBuilder> q = query(SELECT_CNT_FROM_DATE + "WHERE date_format(creationDate, 'YYYY-MM-dd') <> '2018-04-02'");
+        List<QueryBuilder> q = query(SELECT_CNT_FROM_DATE +
+                "WHERE date_format(creationDate, 'YYYY-MM-dd') <> '2018-04-02'");
 
         assertThat(q, hasNotQueryWithValue("from", equalTo(BytesRefs.toBytesRef("2018-04-02"))));
         assertThat(q, hasNotQueryWithValue("to", equalTo(BytesRefs.toBytesRef("2018-04-02"))));
@@ -71,7 +79,8 @@ public class DateFormatTest {
 
     @Test
     public void greaterThanCondition() {
-        List<QueryBuilder> q = query(SELECT_CNT_FROM_DATE + "WHERE date_format(creationDate, 'YYYY-MM-dd') > '2018-04-02'");
+        List<QueryBuilder> q = query(SELECT_CNT_FROM_DATE +
+                "WHERE date_format(creationDate, 'YYYY-MM-dd') > '2018-04-02'");
 
         assertThat(q, hasQueryWithValue("from", equalTo(BytesRefs.toBytesRef("2018-04-02"))));
         assertThat(q, hasQueryWithValue("includeLower", equalTo(false)));
@@ -80,7 +89,8 @@ public class DateFormatTest {
 
     @Test
     public void greaterThanOrEqualToCondition() {
-        List<QueryBuilder> q = query(SELECT_CNT_FROM_DATE + "WHERE date_format(creationDate, 'YYYY-MM-dd') >= '2018-04-02'");
+        List<QueryBuilder> q = query(SELECT_CNT_FROM_DATE +
+                "WHERE date_format(creationDate, 'YYYY-MM-dd') >= '2018-04-02'");
 
         assertThat(q, hasQueryWithValue("from", equalTo(BytesRefs.toBytesRef("2018-04-02"))));
         assertThat(q, hasQueryWithValue("to", equalTo(null)));
@@ -90,9 +100,11 @@ public class DateFormatTest {
 
     @Test
     public void timeZoneCondition() {
-        List<QueryBuilder> q = query(SELECT_CNT_FROM_DATE + "WHERE date_format(creationDate, 'YYYY-MM-dd', 'America/Phoenix') > '2018-04-02'");
+        List<QueryBuilder> q = query(SELECT_CNT_FROM_DATE +
+                "WHERE date_format(creationDate, 'YYYY-MM-dd', 'America/Phoenix') > '2018-04-02'");
 
-        // Used hasProperty here as getter followed convention for obtaining ID and Feature Matcher was having issues with generic type to obtain value
+        // Used hasProperty here as getter followed convention for obtaining ID
+        // and Feature Matcher was having issues with generic type to obtain value
         assertThat(q, hasQueryWithValue("timeZone", hasProperty("id", equalTo("America/Phoenix"))));
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFunctionsTest.java
@@ -20,12 +20,12 @@ import com.amazon.opendistroforelasticsearch.sql.parser.SqlParser;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
-import static org.junit.Assert.assertTrue;
 import static com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents.getScriptFieldFromQuery;
 import static com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents.getScriptFilterFromQuery;
 import static com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents.scriptContainsString;
 import static com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents.scriptHasPattern;
+import static org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
+import static org.junit.Assert.assertTrue;
 
 public class DateFunctionsTest {
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/ESClientTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/ESClientTest.java
@@ -65,7 +65,8 @@ public class ESClientTest {
     @Test
     public void multiSearchRetryOneTime() {
         ESClient esClient = new ESClient(client);
-        MultiSearchResponse.Item[] res = esClient.multiSearch(new MultiSearchRequest().add(new SearchRequest()).add(new SearchRequest()));
+        MultiSearchResponse.Item[] res = esClient.multiSearch(new MultiSearchRequest()
+                                            .add(new SearchRequest()).add(new SearchRequest()));
         Assert.assertEquals(res.length, 2);
         Assert.assertFalse(res[0].isFailure());
         Assert.assertFalse(res[1].isFailure());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/HavingTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/HavingTest.java
@@ -36,13 +36,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
+import static com.amazon.opendistroforelasticsearch.sql.util.HasFieldWithValue.hasFieldWithValue;
 import static java.util.stream.Collectors.toMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static com.amazon.opendistroforelasticsearch.sql.util.HasFieldWithValue.hasFieldWithValue;
 
 
 public class HavingTest {
@@ -54,7 +54,8 @@ public class HavingTest {
     private static final String GROUP_BY_AGE = "GROUP BY age ";
     private static final String SELECT_CNT_FROM_BANK_GROUP_BY_AGE = SELECT_CNT + FROM_BANK + GROUP_BY_AGE;
     private static final String SELECT_CNT_AVG_FROM_BANK_GROUP_BY_AGE = SELECT_CNT_AVG + FROM_BANK + GROUP_BY_AGE;
-    private static final String SELECT_CNT_AVG_SUM_FROM_BANK_GROUP_BY_AGE = SELECT_CNT_AVG_SUM + FROM_BANK + GROUP_BY_AGE;
+    private static final String SELECT_CNT_AVG_SUM_FROM_BANK_GROUP_BY_AGE =
+            SELECT_CNT_AVG_SUM + FROM_BANK + GROUP_BY_AGE;
 
     @Test
     public void singleCondition() {
@@ -181,7 +182,8 @@ public class HavingTest {
     @Test
     public void nestedConditions() {
         assertThat(
-            query(SELECT_CNT_AVG_SUM_FROM_BANK_GROUP_BY_AGE + "HAVING i <= 10000 OR NOT (a < 10 OR a > 30) AND c <= 10"),
+            query(SELECT_CNT_AVG_SUM_FROM_BANK_GROUP_BY_AGE +
+                    "HAVING i <= 10000 OR NOT (a < 10 OR a > 30) AND c <= 10"),
             contains(
                 bucketSelector(
                     hasScript("params.i <= 10000 || ((params.a >= 10 && params.a <= 30) && params.c <= 10)")
@@ -242,4 +244,3 @@ public class HavingTest {
         return hasFieldWithValue("script", "has script", is(new Script(expectedCode)));
     }
 }
-

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/JSONRequestTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/JSONRequestTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLFeatureNotSupportedException;
 
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -41,14 +42,15 @@ public class JSONRequestTest {
 
     @Test
     public void searchSanity() throws IOException {
-        String result = explain(String.format("{\"query\":\"" +
+        String result = explain(format("{\"query\":\"" +
                 "SELECT * " +
                 "FROM %s " +
                 "WHERE firstname LIKE 'A%%' AND age > 20 " +
                 "GROUP BY gender " +
                 "ORDER BY _score\"}", TestsConstants.TEST_INDEX_ACCOUNT));
         String expectedOutput = Files.toString(
-                new File(getResourcePath() + "src/test/resources/expectedOutput/search_explain.json"), StandardCharsets.UTF_8)
+                new File(getResourcePath() + "src/test/resources/expectedOutput/search_explain.json"),
+                StandardCharsets.UTF_8)
                 .replaceAll("\r", "");
 
         assertThat(removeSpaces(result), equalTo(removeSpaces(expectedOutput)));
@@ -56,12 +58,14 @@ public class JSONRequestTest {
 
     @Test
     public void aggregationQuery() throws IOException {
-        String result = explain(String.format("{\"query\":\"" +
+        String result = explain(format("{\"query\":\"" +
                 "SELECT a, CASE WHEN gender='0' THEN 'aaa' ELSE 'bbb' END AS a2345, count(c) " +
                 "FROM %s " +
-                "GROUP BY terms('field'='a','execution_hint'='global_ordinals'), a2345\"}", TestsConstants.TEST_INDEX_ACCOUNT));
+                "GROUP BY terms('field'='a','execution_hint'='global_ordinals'), a2345\"}",
+                TestsConstants.TEST_INDEX_ACCOUNT));
         String expectedOutput = Files.toString(
-                new File(getResourcePath() + "src/test/resources/expectedOutput/aggregation_query_explain.json"), StandardCharsets.UTF_8)
+                new File(getResourcePath() + "src/test/resources/expectedOutput/aggregation_query_explain.json"),
+                StandardCharsets.UTF_8)
                 .replaceAll("\r", "");
 
         assertThat(removeSpaces(result), equalTo(removeSpaces(expectedOutput)));
@@ -69,12 +73,13 @@ public class JSONRequestTest {
 
     @Test
     public void deleteSanity() throws IOException {
-        String result = explain(String.format("{\"query\":\"" +
+        String result = explain(format("{\"query\":\"" +
                 "DELETE " +
                 "FROM %s " +
                 "WHERE firstname LIKE 'A%%' AND age > 20\"}", TestsConstants.TEST_INDEX_ACCOUNT));
         String expectedOutput = Files.toString(
-                new File(getResourcePath() + "src/test/resources/expectedOutput/delete_explain.json"), StandardCharsets.UTF_8)
+                new File(getResourcePath() + "src/test/resources/expectedOutput/delete_explain.json"),
+                StandardCharsets.UTF_8)
                 .replaceAll("\r", "");
 
         assertThat(removeSpaces(result), equalTo(removeSpaces(expectedOutput)));
@@ -95,13 +100,14 @@ public class JSONRequestTest {
          *   }
          * }
          */
-        String result = explain(String.format("{\"query\":\"" +
+        String result = explain(format("{\"query\":\"" +
                 "SELECT * " +
                 "FROM %s " +
                 "WHERE age > 25\"," +
                 "\"filter\":{\"range\":{\"balance\":{\"lte\":30000}}}}", TestsConstants.TEST_INDEX_ACCOUNT));
         String expectedOutput = Files.toString(
-                new File(getResourcePath() + "src/test/resources/expectedOutput/json_filter_explain.json"), StandardCharsets.UTF_8)
+                new File(getResourcePath() + "src/test/resources/expectedOutput/json_filter_explain.json"),
+                StandardCharsets.UTF_8)
                 .replaceAll("\r", "");
 
         assertThat(removeSpaces(result), equalTo(removeSpaces(expectedOutput)));
@@ -122,7 +128,9 @@ public class JSONRequestTest {
         }
     }
 
-    private String translate(String sql, JSONObject jsonRequest) throws SQLFeatureNotSupportedException, SqlParseException {
+    private String translate(String sql, JSONObject jsonRequest)
+                                throws SQLFeatureNotSupportedException, SqlParseException {
+
         Client mockClient = Mockito.mock(Client.class);
         CheckScriptContents.stubMockClient(mockClient);
         QueryAction queryAction = ESActionFactory.create(mockClient, sql);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/MathFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/MathFunctionsTest.java
@@ -23,8 +23,6 @@ import org.junit.Test;
 
 import static org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
 import static org.junit.Assert.assertTrue;
-import static com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents.scriptContainsString;
-import static com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents.scriptHasPattern;
 
 public class MathFunctionsTest {
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/NestedFieldRewriterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/NestedFieldRewriterTest.java
@@ -179,7 +179,8 @@ public class NestedFieldRewriterTest {
             query("SELECT region " +
                   "FROM team " +
                   "WHERE department = 'IT' AND " +
-                  "      nested(\"employees\", employees.age = 26 OR (employees.firstname = 'John' AND employees.lastname = 'Smith')) AND " +
+                  "      nested(\"employees\", employees.age = 26 " +
+                  "   OR (employees.firstname = 'John' AND employees.lastname = 'Smith')) AND " +
                   "      region = 'US' AND " +
                   "      nested(\"manager\", manager.name = 'Alice' AND manager.age = 50)")
         );

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/PreparedStatementRequestTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/PreparedStatementRequestTest.java
@@ -76,7 +76,7 @@ public class PreparedStatementRequestTest {
         List<PreparedStatementRequest.PreparedStatementParameter> params = new ArrayList<>();
         params.add(new PreparedStatementRequest.StringParameter("value"));
 
-        PreparedStatementRequest psr = new PreparedStatementRequest(sqlTemplate, new JSONObject(), params);
+        new PreparedStatementRequest(sqlTemplate, new JSONObject(), params);
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/QueryFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/QueryFunctionsTest.java
@@ -199,27 +199,32 @@ public class QueryFunctionsTest {
     }
 
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void emptyQueryShouldThrowSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+    public void emptyQueryShouldThrowSQLFeatureNotSupportedException()
+                        throws SQLFeatureNotSupportedException, SqlParseException {
         ESActionFactory.create(Mockito.mock(Client.class), "");
     }
 
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void emptyNewLineQueryShouldThrowSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+    public void emptyNewLineQueryShouldThrowSQLFeatureNotSupportedException()
+                        throws SQLFeatureNotSupportedException, SqlParseException {
         ESActionFactory.create(Mockito.mock(Client.class), "\n");
     }
 
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void emptyNewLineQueryShouldThrowSQLFeatureNotSupportedException2() throws SQLFeatureNotSupportedException, SqlParseException {
+    public void emptyNewLineQueryShouldThrowSQLFeatureNotSupportedException2()
+                        throws SQLFeatureNotSupportedException, SqlParseException {
         ESActionFactory.create(Mockito.mock(Client.class), "\r\n");
     }
 
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void queryWithoutSpaceShouldSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+    public void queryWithoutSpaceShouldSQLFeatureNotSupportedException()
+                        throws SQLFeatureNotSupportedException, SqlParseException {
         ESActionFactory.create(Mockito.mock(Client.class), "SELE");
     }
 
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void spacesOnlyQueryShouldThrowSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
+    public void spacesOnlyQueryShouldThrowSQLFeatureNotSupportedException()
+                        throws SQLFeatureNotSupportedException, SqlParseException {
         ESActionFactory.create(Mockito.mock(Client.class), "      ");
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/SqlRequestFactoryTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/SqlRequestFactoryTest.java
@@ -94,14 +94,21 @@ public class SqlRequestFactoryTest {
 
         Assert.assertTrue(sqlRequest instanceof  PreparedStatementRequest);
         PreparedStatementRequest preparedStatementRequest = (PreparedStatementRequest) sqlRequest;
-        Assert.assertEquals("select * from my_table where int_param = ? and double_param = ? and string_param = ? and date_param = ? and null_param = ?", preparedStatementRequest.getPreparedStatement());
-        Assert.assertEquals("select * from my_table where int_param = 1 and double_param = 2.0 and string_param = 'string_value' and date_param = '2000-01-01' and null_param = null", preparedStatementRequest.getSql());
+        Assert.assertEquals("select * from my_table where int_param = ? and double_param = ? and " +
+                "string_param = ? and date_param = ? and null_param = ?",
+                preparedStatementRequest.getPreparedStatement());
+        Assert.assertEquals("select * from my_table where int_param = 1 and double_param = 2.0 and " +
+                "string_param = 'string_value' and date_param = '2000-01-01' and null_param = null",
+                preparedStatementRequest.getSql());
         Assert.assertEquals(5, preparedStatementRequest.getParameters().size());
         Assert.assertTrue(preparedStatementRequest.getParameters().get(0).getValue() instanceof Long);
         Assert.assertTrue(preparedStatementRequest.getParameters().get(1).getValue() instanceof Double);
-        Assert.assertTrue(preparedStatementRequest.getParameters().get(2) instanceof PreparedStatementRequest.StringParameter);
-        Assert.assertTrue(preparedStatementRequest.getParameters().get(3) instanceof PreparedStatementRequest.StringParameter);
-        Assert.assertTrue(preparedStatementRequest.getParameters().get(4) instanceof PreparedStatementRequest.NullParameter);
+        Assert.assertTrue(
+                preparedStatementRequest.getParameters().get(2) instanceof PreparedStatementRequest.StringParameter);
+        Assert.assertTrue(
+                preparedStatementRequest.getParameters().get(3) instanceof PreparedStatementRequest.StringParameter);
+        Assert.assertTrue(
+                preparedStatementRequest.getParameters().get(4) instanceof PreparedStatementRequest.NullParameter);
     }
 
     @Test
@@ -141,7 +148,8 @@ public class SqlRequestFactoryTest {
         Assert.assertEquals(5, preparedStatementRequest.getParameters().size());
         Assert.assertTrue(preparedStatementRequest.getParameters().get(0).getValue() instanceof Long);
         Assert.assertTrue(preparedStatementRequest.getParameters().get(1).getValue() instanceof Double);
-        Assert.assertTrue(preparedStatementRequest.getParameters().get(2) instanceof PreparedStatementRequest.StringParameter);
+        Assert.assertTrue(
+                preparedStatementRequest.getParameters().get(2) instanceof PreparedStatementRequest.StringParameter);
         System.out.println(preparedStatementRequest.getParameters().get(3));
         Assert.assertTrue(preparedStatementRequest.getParameters().get(3).getValue() instanceof Boolean);
         Assert.assertTrue(preparedStatementRequest.getParameters().get(4).getValue() instanceof Long);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SqlParserTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SqlParserTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
@@ -53,6 +52,7 @@ import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstant
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_DOG;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_GAME_OF_THRONES;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ODBC;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
 import static org.hamcrest.Matchers.equalTo;
 
 public class SqlParserTest {
@@ -275,7 +275,7 @@ public class SqlParserTest {
 
     @Test
     public void joinConditionWithComplexObjectComparisonRightSide() throws SqlParseException {
-        String query = String.format(Locale.ROOT, "select c.name.firstname,c.parents.father , h.name,h.words " +
+        String query = format("select c.name.firstname,c.parents.father , h.name,h.words " +
                 "from %s/gotCharacters c " +
                 "JOIN %s/gotCharacters h " +
                 "on h.name = c.name.lastname  " +
@@ -290,7 +290,7 @@ public class SqlParserTest {
 
     @Test
     public void joinConditionWithComplexObjectComparisonLeftSide() throws SqlParseException {
-        String query = String.format(Locale.ROOT,
+        String query = format(
                 "select c.name.firstname,c.parents.father , h.name,h.words from %s/gotCharacters c " +
                 "JOIN %s/gotCharacters h " +
                 "on c.name.lastname = h.name  " +
@@ -306,7 +306,7 @@ public class SqlParserTest {
 
     @Test
     public void limitHintsOnJoin() throws SqlParseException {
-        String query = String.format(Locale.ROOT,"select /*! JOIN_TABLES_LIMIT(1000,null) */ " +
+        String query = format("select /*! JOIN_TABLES_LIMIT(1000,null) */ " +
                 "c.name.firstname,c.parents.father , h.name,h.words from %s/gotCharacters c " +
                 "use KEY (termsFilter) " +
                 "JOIN %s/gotCharacters h " +
@@ -327,7 +327,7 @@ public class SqlParserTest {
 
     @Test
     public void hashTermsFilterHint() throws SqlParseException {
-        String query = String.format(Locale.ROOT, "select /*! HASH_WITH_TERMS_FILTER*/ " +
+        String query = format("select /*! HASH_WITH_TERMS_FILTER*/ " +
                 "c.name.firstname,c.parents.father , h.name,h.words from %s/gotCharacters c " +
                 "use KEY (termsFilter) " +
                 "JOIN %s/gotCharacters h " +
@@ -343,7 +343,7 @@ public class SqlParserTest {
 
     @Test
     public void multipleHints() throws SqlParseException {
-        String query = String.format(Locale.ROOT, "select /*! HASH_WITH_TERMS_FILTER*/ " +
+        String query = format("select /*! HASH_WITH_TERMS_FILTER*/ " +
                 "/*! JOIN_TABLES_LIMIT(1000,null) */ " +
                 " /*! JOIN_TABLES_LIMIT(100,200) */ " +
                 "c.name.firstname,c.parents.father , h.name,h.words from %s/gotCharacters c " +
@@ -371,7 +371,7 @@ public class SqlParserTest {
 
     @Test
     public void searchWithOdbcTimeFormatParse() throws SqlParseException {
-        String query = String.format(Locale.ROOT, "SELECT insert_time FROM %s/odbc " +
+        String query = format("SELECT insert_time FROM %s/odbc " +
                 "WHERE insert_time < {ts '2015-03-15 00:00:00.000'}", TEST_INDEX_ODBC);
         SQLExpr sqlExpr = queryToExpr(query);
         Select select = parser.parseSelect((SQLQueryExpr) sqlExpr);
@@ -503,7 +503,7 @@ public class SqlParserTest {
 
     @Test
     public void innerQueryTest() throws SqlParseException {
-        String query = String.format(Locale.ROOT, "select * from %s/dog where holdersName " +
+        String query = format("select * from %s/dog where holdersName " +
                 "IN (select firstname from %s/account where firstname = 'eliran')",
                 TEST_INDEX_DOG, TestsConstants.TEST_INDEX_ACCOUNT);
         SQLExpr sqlExpr = queryToExpr(query);
@@ -514,7 +514,7 @@ public class SqlParserTest {
 
     @Test
     public void inTermsSubQueryTest() throws SqlParseException {
-        String query = String.format(Locale.ROOT, "select * from %s/dog where " +
+        String query = format("select * from %s/dog where " +
                 "holdersName = IN_TERMS (select firstname from %s/account where firstname = 'eliran')",
                 TEST_INDEX_DOG, TestsConstants.TEST_INDEX_ACCOUNT);
         SQLExpr sqlExpr = queryToExpr(query);
@@ -526,7 +526,7 @@ public class SqlParserTest {
 
     @Test
     public void innerQueryTestTwoQueries() throws SqlParseException {
-        String query = String.format(Locale.ROOT, "select * from %s/dog where holdersName IN " +
+        String query = format("select * from %s/dog where holdersName IN " +
                 "(select firstname from %s/account where firstname = 'eliran') and " +
                 "age IN (select name.ofHisName from %s/gotCharacters) ",
                 TEST_INDEX_DOG, TestsConstants.TEST_INDEX_ACCOUNT, TEST_INDEX_GAME_OF_THRONES);
@@ -803,7 +803,7 @@ public class SqlParserTest {
 
     @Test
     public void parseJoinWithOneTableOrderByAttachToCorrectTable() throws SqlParseException {
-        String query = String.format(Locale.ROOT, "select c.name.firstname , d.words from %s/gotCharacters c " +
+        String query = format("select c.name.firstname , d.words from %s/gotCharacters c " +
                         "JOIN %s/gotCharacters d on d.name = c.house " +
                         "order by c.name.firstname"
                 , TEST_INDEX_GAME_OF_THRONES, TEST_INDEX_GAME_OF_THRONES);
@@ -816,7 +816,7 @@ public class SqlParserTest {
 
     @Test
     public void parseJoinWithOneTableOrderByRemoveAlias() throws SqlParseException {
-        String query = String.format(Locale.ROOT, "select c.name.firstname , d.words from %s/gotCharacters c " +
+        String query = format("select c.name.firstname , d.words from %s/gotCharacters c " +
                         "JOIN %s/gotCharacters d on d.name = c.house " +
                         "order by c.name.firstname"
                 , TEST_INDEX_GAME_OF_THRONES, TEST_INDEX_GAME_OF_THRONES);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerBatchTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerBatchTest.java
@@ -27,11 +27,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.runners.Parameterized.Parameters;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.hit;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.hits;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kv;
+import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.runners.Parameterized.Parameters;
 
 /**
  * Batch prefetch testing. Test against different combination of algorithm block size and scroll page size.
@@ -188,7 +189,7 @@ public class QueryPlannerBatchTest extends QueryPlannerTest {
     public void departmentInnerJoinEmployee() {
         assertThat(
             query(
-                String.format(
+                format(
                     TEST_SQL1 + TEST_SQL2_JOIN1 + TEST_SQL3,
                     blockSize, pageSize, "INNER JOIN"),
                 departments(pageSize, departments),
@@ -202,7 +203,7 @@ public class QueryPlannerBatchTest extends QueryPlannerTest {
     public void employeeInnerJoinDepartment() {
         assertThat(
             query(
-                String.format(
+                format(
                     TEST_SQL1 + TEST_SQL2_JOIN2 + TEST_SQL3,
                     blockSize, pageSize, "INNER JOIN"),
                 employees(pageSize, employees),
@@ -216,7 +217,7 @@ public class QueryPlannerBatchTest extends QueryPlannerTest {
     public void departmentLeftJoinEmployee() {
         assertThat(
             query(
-                String.format(
+                format(
                     TEST_SQL1 + TEST_SQL2_JOIN1 + TEST_SQL3,
                     blockSize, pageSize, "LEFT JOIN"),
                 departments(pageSize, departments),
@@ -230,7 +231,7 @@ public class QueryPlannerBatchTest extends QueryPlannerTest {
     public void employeeLeftJoinDepartment() {
         assertThat(
             query(
-                String.format(
+                format(
                     TEST_SQL1 + TEST_SQL2_JOIN2 + TEST_SQL3,
                     blockSize, pageSize, "LEFT JOIN"),
                 employees(pageSize, employees),

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerExecuteTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerExecuteTest.java
@@ -429,7 +429,8 @@ public class QueryPlannerExecuteTest extends QueryPlannerTest {
     public void simpleQueryWithTableLimit() {
         MatcherAssert.assertThat(
             query(
-                "SELECT /*! JOIN_TABLES_LIMIT(1, 5) */ d.name, e.lastname FROM employee e JOIN department d ON d.id = e.departmentId",
+                "SELECT /*! JOIN_TABLES_LIMIT(1, 5) */ d.name, e.lastname FROM employee e JOIN department d " +
+                        "ON d.id = e.departmentId",
                 employees(
                     employee(1, "Alice", "1"),
                     employee(2, "Hank", "1")
@@ -452,7 +453,8 @@ public class QueryPlannerExecuteTest extends QueryPlannerTest {
     public void simpleQueryWithOrderBy() {
         MatcherAssert.assertThat(
             query(
-                "SELECT d.name, e.lastname FROM employee e JOIN department d ON d.id = e.departmentId ORDER BY e.lastname",
+                "SELECT d.name, e.lastname FROM employee e JOIN department d ON d.id = e.departmentId "
+                        + "ORDER BY e.lastname",
                 employees(
                     employee(1, "Hank", "1"),
                     employee(2, "Alice", "2"),
@@ -785,5 +787,4 @@ public class QueryPlannerExecuteTest extends QueryPlannerTest {
             )
         );
     }
-
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
@@ -121,8 +121,9 @@ public abstract class QueryPlannerTest {
             @Override
             public SearchResponse answer(InvocationOnMock invocation) {
                 /*
-                 * This works based on assumption that first call comes from Scroll-1, all the following calls come from Scroll-2.
-                 * Because Scroll-1 only open scroll once and must be ahead of Scroll-2 which opens multiple times later.
+                 * This works based on assumption that first call comes from Scroll-1, all the following
+                 * calls come from Scroll-2. Because Scroll-1 only open scroll once and must be ahead of
+                 * Scroll-2 which opens multiple times later.
                  */
                 return callCnt++ == 0 ? response1 : response2;
             }
@@ -157,7 +158,7 @@ public abstract class QueryPlannerTest {
         when(mockReqBuilder.addScrollId(any())).thenReturn(mockReqBuilder);
         when(mockReqBuilder.get()).thenAnswer(new Answer<ClearScrollResponse>() {
             @Override
-            public ClearScrollResponse answer(InvocationOnMock invocation) throws Throwable {
+            public ClearScrollResponse answer(InvocationOnMock invocation) {
                 mockHits2.reset();
                 return new ClearScrollResponse(true, 0);
             }
@@ -272,7 +273,8 @@ public abstract class QueryPlannerTest {
             hit.sourceRef(new BytesArray("{\"lastname\":\"" + lastname + "\"}"));
         }
         else {
-            hit.sourceRef(new BytesArray("{\"lastname\":\"" + lastname + "\",\"departmentId\":\"" + departmentId + "\"}"));
+            hit.sourceRef(new BytesArray("{\"lastname\":\"" + lastname + "\",\"departmentId\":\"" +
+                    departmentId + "\"}"));
         }
         return hit;
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/spatial/WktToGeoJsonConverterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/spatial/WktToGeoJsonConverterTest.java
@@ -85,7 +85,8 @@ public class WktToGeoJsonConverterTest {
     public void convertPolygon_NegativeCoordinates_ShouldConvert(){
         String wkt = "POLYGON ((-30 10, 40 40, 20 40, 10 20, -30 10))";
         String geoJson = WktToGeoJsonConverter.toGeoJson(wkt);
-        String expectedGeoJson = "{\"type\":\"Polygon\", \"coordinates\": [[[-30,10],[40,40],[20,40],[10,20],[-30,10]]]}";
+        String expectedGeoJson = "{\"type\":\"Polygon\", \"coordinates\": " +
+                "[[[-30,10],[40,40],[20,40],[10,20],[-30,10]]]}";
         Assert.assertEquals(expectedGeoJson,geoJson);
     }
 
@@ -101,7 +102,8 @@ public class WktToGeoJsonConverterTest {
     public void convertPolygonWithHole_NoRedundantSpaces_ShouldConvert(){
         String wkt = "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))";
         String geoJson = WktToGeoJsonConverter.toGeoJson(wkt);
-        String expectedGeoJson = "{\"type\":\"Polygon\", \"coordinates\": [[[35,10],[45,45],[15,40],[10,20],[35,10]],[[20,30],[35,35],[30,20],[20,30]]]}";
+        String expectedGeoJson = "{\"type\":\"Polygon\", \"coordinates\": " +
+                "[[[35,10],[45,45],[15,40],[10,20],[35,10]],[[20,30],[35,35],[30,20],[20,30]]]}";
         Assert.assertEquals(expectedGeoJson,geoJson);
     }
 
@@ -109,7 +111,8 @@ public class WktToGeoJsonConverterTest {
     public void convertPolygonWithHole_WithRedundantSpaces_ShouldConvert(){
         String wkt = "POLYGON ( (35 10, 45 45, 15 40, 10 20, 35 10 ), (20 30 , 35 35, 30 20,   20 30 ) ) ";
         String geoJson = WktToGeoJsonConverter.toGeoJson(wkt);
-        String expectedGeoJson = "{\"type\":\"Polygon\", \"coordinates\": [[[35,10],[45,45],[15,40],[10,20],[35,10]],[[20,30],[35,35],[30,20],[20,30]]]}";
+        String expectedGeoJson = "{\"type\":\"Polygon\", \"coordinates\": " +
+                "[[[35,10],[45,45],[15,40],[10,20],[35,10]],[[20,30],[35,35],[30,20],[20,30]]]}";
         Assert.assertEquals(expectedGeoJson,geoJson);
     }
 
@@ -148,14 +151,18 @@ public class WktToGeoJsonConverterTest {
     public void convertMultiPolygon_WithRedundantSpaces_ShouldConvert(){
         String wkt = "MULTIPOLYGON ( ((30 20, 45 40, 10 40, 30 20) ) , ((15 5, 40 10, 10 20, 5 10, 15 5)))";
         String geoJson = WktToGeoJsonConverter.toGeoJson(wkt);
-        String expectedGeoJson = "{\"type\":\"MultiPolygon\", \"coordinates\": [[[[30,20],[45,40],[10,40],[30,20]]],[[[15,5],[40,10],[10,20],[5,10],[15,5]]]]}";
+        String expectedGeoJson = "{\"type\":\"MultiPolygon\", \"coordinates\": " +
+                "[[[[30,20],[45,40],[10,40],[30,20]]],[[[15,5],[40,10],[10,20],[5,10],[15,5]]]]}";
         Assert.assertEquals(expectedGeoJson,geoJson);
     }
     @Test
     public void convertMultiPolygon_OnePolygonHaveHoles_ShouldConvert(){
-        String wkt = "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20),(20 30, 35 35, 30 20, 20 30)),((15 5, 40 10, 10 20, 5 10, 15 5)))";
+        String wkt = "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20),(20 30, 35 35, 30 20, 20 30))," +
+                "((15 5, 40 10, 10 20, 5 10, 15 5)))";
         String geoJson = WktToGeoJsonConverter.toGeoJson(wkt);
-        String expectedGeoJson = "{\"type\":\"MultiPolygon\", \"coordinates\": [[[[30,20],[45,40],[10,40],[30,20]],[[20,30],[35,35],[30,20],[20,30]]],[[[15,5],[40,10],[10,20],[5,10],[15,5]]]]}";
+        String expectedGeoJson = "{\"type\":\"MultiPolygon\", \"coordinates\": " +
+                "[[[[30,20],[45,40],[10,40],[30,20]],[[20,30],[35,35],[30,20],[20,30]]]," +
+                "[[[15,5],[40,10],[10,20],[5,10],[15,5]]]]}";
         Assert.assertEquals(expectedGeoJson,geoJson);
     }
 
@@ -179,14 +186,16 @@ public class WktToGeoJsonConverterTest {
     public void convertMultiLineString_NoRedundantSpaces_ShouldConvert(){
         String wkt = "MULTILINESTRING ((10 10, 20 20, 10 40),(40 40, 30 30, 40 20, 30 10))";
         String geoJson = WktToGeoJsonConverter.toGeoJson(wkt);
-        String expectedGeoJson = "{\"type\":\"MultiLineString\", \"coordinates\": [[[10,10],[20,20],[10,40]],[[40,40],[30,30],[40,20],[30,10]]]}";
+        String expectedGeoJson = "{\"type\":\"MultiLineString\", \"coordinates\": " +
+                "[[[10,10],[20,20],[10,40]],[[40,40],[30,30],[40,20],[30,10]]]}";
         Assert.assertEquals(expectedGeoJson,geoJson);
     }
     @Test
     public void convertMultiLineString_WithRedundantSpaces_ShouldConvert(){
         String wkt = "MULTILINESTRING ( (10 10, 20 20, 10   40 ) , (40 40, 30 30, 40 20, 30 10))";
         String geoJson = WktToGeoJsonConverter.toGeoJson(wkt);
-        String expectedGeoJson = "{\"type\":\"MultiLineString\", \"coordinates\": [[[10,10],[20,20],[10,40]],[[40,40],[30,30],[40,20],[30,10]]]}";
+        String expectedGeoJson = "{\"type\":\"MultiLineString\", \"coordinates\": " +
+                "[[[10,10],[20,20],[10,40]],[[40,40],[30,30],[40,20],[30,10]]]}";
         Assert.assertEquals(expectedGeoJson,geoJson);
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/StringUtilsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/StringUtilsTest.java
@@ -1,0 +1,86 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.utils;
+
+import com.amazon.opendistroforelasticsearch.sql.utils.StringUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class StringUtilsTest {
+
+    private Locale originalLocale;
+
+    @Before
+    public void saveOriginalLocale() {
+
+        originalLocale = Locale.getDefault();
+    }
+
+    @After
+    public void restoreOriginalLocale() {
+
+        Locale.setDefault(originalLocale);
+    }
+
+    @Test
+    public void toLower() {
+
+        final String input = "SAMPLE STRING";
+        final String output = StringUtils.toLower(input);
+
+        Assert.assertThat(output, equalTo("sample string"));
+
+        // See https://docs.oracle.com/javase/10/docs/api/java/lang/String.html#toLowerCase(java.util.Locale)
+        // for the choice of these characters and the locale.
+        final String upper = "\u0130 \u0049";
+        Locale.setDefault(Locale.forLanguageTag("tr"));
+
+        Assert.assertThat(upper.toUpperCase(Locale.ROOT), equalTo(StringUtils.toUpper(upper)));
+    }
+
+    @Test
+    public void toUpper() {
+
+        final String input = "sample string";
+        final String output = StringUtils.toUpper(input);
+
+        Assert.assertThat(output, equalTo("SAMPLE STRING"));
+
+        // See https://docs.oracle.com/javase/10/docs/api/java/lang/String.html#toUpperCase(java.util.Locale)
+        // for the choice of these characters and the locale.
+        final String lower = "\u0069 \u0131";
+        Locale.setDefault(Locale.forLanguageTag("tr"));
+
+        Assert.assertThat(lower.toUpperCase(Locale.ROOT), equalTo(StringUtils.toUpper(lower)));
+    }
+
+    @Test
+    public void format() {
+
+        Locale.setDefault(Locale.forLanguageTag("tr"));
+        final String upper = "\u0130 \u0049";
+        final String lower = "\u0069 \u0131";
+
+        final String output = StringUtils.format("%s %s", upper, lower);
+        Assert.assertThat(output, equalTo(String.format(Locale.ROOT, "%s %s", upper, lower)));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/StringUtilsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/StringUtilsTest.java
@@ -31,19 +31,16 @@ public class StringUtilsTest {
 
     @Before
     public void saveOriginalLocale() {
-
         originalLocale = Locale.getDefault();
     }
 
     @After
     public void restoreOriginalLocale() {
-
         Locale.setDefault(originalLocale);
     }
 
     @Test
     public void toLower() {
-
         final String input = "SAMPLE STRING";
         final String output = StringUtils.toLower(input);
 
@@ -59,7 +56,6 @@ public class StringUtilsTest {
 
     @Test
     public void toUpper() {
-
         final String input = "sample string";
         final String output = StringUtils.toUpper(input);
 
@@ -75,7 +71,6 @@ public class StringUtilsTest {
 
     @Test
     public void format() {
-
         Locale.setDefault(Locale.forLanguageTag("tr"));
         final String upper = "\u0130 \u0049";
         final String lower = "\u0069 \u0131";

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/CheckScriptContents.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/CheckScriptContents.java
@@ -57,6 +57,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -78,7 +79,7 @@ public class CheckScriptContents {
             SearchRequestBuilder request = (SearchRequestBuilder) requestBuilder.getBuilder();
             List<ScriptField> scriptFields = request.request().source().scriptFields();
 
-            assertTrue(scriptFields.size() == 1);
+            assertEquals(1, scriptFields.size());
 
             return scriptFields.get(0);
 
@@ -92,7 +93,7 @@ public class CheckScriptContents {
             Select select = parser.parseSelect((SQLQueryExpr) queryToExpr(query));
             Where where = select.getWhere();
 
-            assertTrue(where.getWheres().size() == 1);
+            assertEquals(1, where.getWheres().size());
             assertTrue(((Condition) (where.getWheres().get(0))).getValue() instanceof ScriptFilter);
 
             return (ScriptFilter) (((Condition) (where.getWheres().get(0))).getValue());
@@ -239,8 +240,10 @@ public class CheckScriptContents {
         when(mockService.state()).thenReturn(mockState);
         when(mockState.metaData()).thenReturn(mockMetaData);
         try {
-            ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> builder = ImmutableOpenMap.builder();
-            builder.put(TestsConstants.TEST_INDEX_BANK, IndexMetaData.fromXContent(createParser(mappings)).getMappings());
+            ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> builder =
+                    ImmutableOpenMap.builder();
+            builder.put(TestsConstants.TEST_INDEX_BANK,
+                    IndexMetaData.fromXContent(createParser(mappings)).getMappings());
             when(mockMetaData.findMappings(any(), any(), any())).thenReturn(builder.build());
         }
         catch (IOException e) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
@@ -73,7 +73,7 @@ public class MatcherUtils {
         return featureValueOf("SearchHits", arrayContaining(hitMatchers), SearchHits::getHits);
     }
 
-    @SuppressWarnings("unchecked")
+    @SafeVarargs
     public static Matcher<SearchHit> hit(Matcher<Map<String, Object>>... entryMatchers) {
         return featureValueOf("SearchHit", allOf(entryMatchers), SearchHit::getSourceAsMap);
     }
@@ -84,6 +84,7 @@ public class MatcherUtils {
         return (Matcher) hasEntry(key, value);
     }
 
+    @SafeVarargs
     public static Matcher<JSONObject> hitAny(Matcher<JSONObject>... matcher) {
         return featureValueOf("SearchHits", hasItems(matcher), actual -> {
             JSONArray array = (JSONArray) (actual.query("/hits/hits"));


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Just creating utility methods not to make everyone use `Locale.ROOT` all the time. Plus fixed some warnings. Replaced all the usages of `String.format` in test classes, someone (maybe me) will need to do for non-test as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
