### PR TITLE
Adding a utility class to be used instead of String for locale-dependent methods

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/StringUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/StringUtils.java
@@ -1,0 +1,86 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.utils;
+
+import java.util.Locale;
+
+/**
+ * Helper class for wrapping locale-dependent methods
+ * of {@link String} class in equivalent locale-independent
+ * methods which always use {@link Locale#ROOT|.
+ */
+public class StringUtils {
+
+    /**
+     * Returns a formatted string using the specified format string and
+     * arguments, as well as the {@link Locale#ROOT} locale.
+     *
+     * @param  format
+     *         format string
+     *
+     * @param  args
+     *         arguments referenced by the format specifiers in the format string
+     *
+     * @throws  java.util.IllegalFormatException
+     *          If a format string contains an illegal syntax, a format
+     *          specifier that is incompatible with the given arguments,
+     *          insufficient arguments given the format string, or other
+     *          illegal conditions.
+     *
+     * @return  A formatted string
+     *
+     * @see java.lang.String#format(Locale, String, Object...)
+     */
+    public static String format(final String format, Object... args) {
+        return String.format(Locale.ROOT, format, args);
+    }
+
+    /**
+     * Converts all of the characters in this {@code String} to lower
+     * case using the rules of the {@link Locale#ROOT} locale. This is equivalent to calling
+     * {@link String#toLowerCase(Locale)} with {@link Locale#ROOT}.
+     *
+     * @param input
+     *        the input String
+     *
+     * @return  the {@code String}, converted to lowercase
+     *
+     * @see     java.lang.String#toLowerCase(Locale)
+     */
+    public static String toLower(final String input) {
+        return input.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Converts all of the characters in this {@code String} to upper
+     * case using the rules of the {@link Locale#ROOT} locale. This is equivalent to calling
+     * {@link String#toUpperCase(Locale)} with {@link Locale#ROOT}.
+     *
+     * @param input
+     *        the input String
+     *
+     * @return  the {@code String}, converted to uppercase
+     *
+     * @see     java.lang.String#toUpperCase(Locale)
+     */
+    public static String toUpper(final String input) {
+        return input.toUpperCase(Locale.ROOT);
+    }
+
+    private StringUtils() {
+        throw new AssertionError(getClass().getCanonicalName() + " is a utility class and must not be initialized");
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/StringUtilsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/StringUtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.utils;
+
+import com.amazon.opendistroforelasticsearch.sql.utils.StringUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class StringUtilsTest {
+
+    private Locale originalLocale;
+
+    @Before
+    public void saveOriginalLocale() {
+        originalLocale = Locale.getDefault();
+    }
+
+    @After
+    public void restoreOriginalLocale() {
+        Locale.setDefault(originalLocale);
+    }
+
+    @Test
+    public void toLower() {
+        final String input = "SAMPLE STRING";
+        final String output = StringUtils.toLower(input);
+
+        Assert.assertThat(output, equalTo("sample string"));
+
+        // See https://docs.oracle.com/javase/10/docs/api/java/lang/String.html#toLowerCase(java.util.Locale)
+        // for the choice of these characters and the locale.
+        final String upper = "\u0130 \u0049";
+        Locale.setDefault(Locale.forLanguageTag("tr"));
+
+        Assert.assertThat(upper.toUpperCase(Locale.ROOT), equalTo(StringUtils.toUpper(upper)));
+    }
+
+    @Test
+    public void toUpper() {
+        final String input = "sample string";
+        final String output = StringUtils.toUpper(input);
+
+        Assert.assertThat(output, equalTo("SAMPLE STRING"));
+
+        // See https://docs.oracle.com/javase/10/docs/api/java/lang/String.html#toUpperCase(java.util.Locale)
+        // for the choice of these characters and the locale.
+        final String lower = "\u0069 \u0131";
+        Locale.setDefault(Locale.forLanguageTag("tr"));
+
+        Assert.assertThat(lower.toUpperCase(Locale.ROOT), equalTo(StringUtils.toUpper(lower)));
+    }
+
+    @Test
+    public void format() {
+        Locale.setDefault(Locale.forLanguageTag("tr"));
+        final String upper = "\u0130 \u0049";
+        final String lower = "\u0069 \u0131";
+
+        final String output = StringUtils.format("%s %s", upper, lower);
+        Assert.assertThat(output, equalTo(String.format(Locale.ROOT, "%s %s", upper, lower)));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This is a subset of change introduced in PR #106 , to just add the utility class along with its unit tests while the bigger change is pending some more feedback from the members of sql team.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
