### PR TITLE
Add support for function calls in select for JDBC calls.

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Field.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Field.java
@@ -119,4 +119,9 @@ public class Field implements Cloneable{
     protected Object clone() throws CloneNotSupportedException {
         return new Field(new String(this.name), new String(this.alias));
     }
+
+    /** Returns true if the field is script field. */
+    public boolean isScriptField() {
+        return false;
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/MethodField.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/MethodField.java
@@ -116,4 +116,9 @@ public class MethodField extends Field {
 
         return this.getParamsAsMap().get("children").toString();
     }
+
+    @Override
+    public boolean isScriptField() {
+	    return "script".equals(getName());
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
@@ -27,7 +27,7 @@ public class Order {
     private Field sortField;
 
     public boolean isScript() {
-        return sortField != null && sortField instanceof ScriptMethodField;
+        return sortField != null && sortField.isScriptField();
     }
 
     public Order(String nestedPath, String name, String type, Field sortField) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
@@ -21,20 +21,20 @@ package com.amazon.opendistroforelasticsearch.sql.domain;
  *
  */
 public class Order {
-	private String nestedPath;
-	private String name;
-	private String type;
-    private boolean isScript;
+    private String nestedPath;
+    private String name;
+    private String type;
+    private Field sortField;
 
     public boolean isScript() {
-        return isScript;
+        return sortField != null && sortField instanceof ScriptMethodField;
     }
 
-	public Order(String nestedPath, String name, String type, boolean isScript) {
+    public Order(String nestedPath, String name, String type, Field sortField) {
         this.nestedPath = nestedPath;
-		this.name = name;
-		this.type = type;
-        this.isScript = isScript;
+        this.name = name;
+        this.type = type;
+		this.sortField = sortField;
 	}
 
     public String getNestedPath() {
@@ -46,19 +46,22 @@ public class Order {
     }
 
     public String getName() {
-		return name;
-	}
+        return name;
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public String getType() {
-		return type;
-	}
+    public String getType() {
+        return type;
+    }
 
-	public void setType(String type) {
-		this.type = type;
-	}
+    public void setType(String type) {
+        this.type = type;
+    }
 
+    public Field getSortField() {
+        return sortField;
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Order.java
@@ -34,8 +34,8 @@ public class Order {
         this.nestedPath = nestedPath;
         this.name = name;
         this.type = type;
-		this.sortField = sortField;
-	}
+        this.sortField = sortField;
+    }
 
     public String getNestedPath() {
         return nestedPath;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/ScriptMethodField.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/ScriptMethodField.java
@@ -29,4 +29,9 @@ public class ScriptMethodField extends MethodField {
     public String getFunctionName() {
         return functionName;
     }
+
+    @Override
+    public boolean isScriptField() {
+        return true;
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/ScriptMethodField.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/ScriptMethodField.java
@@ -1,0 +1,32 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.domain;
+
+import java.util.List;
+
+/** Stores information about function name for script fields */
+public class ScriptMethodField extends MethodField {
+    private final String functionName;
+
+    public ScriptMethodField(String functionName, List<KVValue> params, String option, String alias) {
+        super("script", params, option, alias);
+        this.functionName = functionName;
+    }
+
+    public String getFunctionName() {
+        return functionName;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Select.java
@@ -95,11 +95,11 @@ public class Select extends Query {
 		return rowCount;
 	}
 
-	public void addOrderBy(String nestedPath, String name, String type, boolean isScriptField) {
+	public void addOrderBy(String nestedPath, String name, String type, Field field) {
 		if ("_score".equals(name)) {
 			isQuery = true;
 		}
-		this.orderBys.add(new Order(nestedPath, name, type, isScriptField));
+		this.orderBys.add(new Order(nestedPath, name, type, field));
 	}
 
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -277,12 +277,12 @@ public class SelectResultSet extends ResultSet {
             case "max":
                 return Schema.Type.DOUBLE;
             case "script": {
-                ScriptMethodField smf = (ScriptMethodField) field;
-                // TODO: this information is disconnected from the function definitions in SQLFunctions.
+                // TODO: return type information is disconnected from the function definitions in SQLFunctions.
                 // Refactor SQLFunctions to have functions self-explanatory (types, scripts) and pluggable
                 // (similar to Strategy pattern)
 
-                return SQLFunctions.getScriptFunctionReturnType(smf.getFunctionName());
+                return SQLFunctions.getScriptFunctionReturnType(
+                        ((ScriptMethodField) field).getFunctionName());
             }
             default:
                 throw new UnsupportedOperationException(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.executor.format;
 
+import com.amazon.opendistroforelasticsearch.sql.utils.SQLFunctions;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsResponse;
 import org.elasticsearch.client.Client;
@@ -279,17 +280,9 @@ public class SelectResultSet extends ResultSet {
                 ScriptMethodField smf = (ScriptMethodField) field;
                 // TODO: this information is disconnected from the function definitions in SQLFunctions.
                 // Refactor SQLFunctions to have functions self-explanatory (types, scripts) and pluggable
-                // (similar to Strategy pattern).
+                // (similar to Strategy pattern)
 
-                switch (smf.getFunctionName()) {
-                    case "date_format": {
-                        return Schema.Type.TEXT;
-                    }
-                    default:
-                        throw new UnsupportedOperationException(
-                                String.format("The following method is not supported in Schema: %s",
-                                        smf.getFunctionName()));
-                }
+                return SQLFunctions.getScriptFunctionReturnType(smf.getFunctionName());
             }
             default:
                 throw new UnsupportedOperationException(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
@@ -19,6 +19,7 @@ import com.alibaba.druid.sql.ast.expr.*;
 import com.amazon.opendistroforelasticsearch.sql.domain.Field;
 import com.amazon.opendistroforelasticsearch.sql.domain.KVValue;
 import com.amazon.opendistroforelasticsearch.sql.domain.MethodField;
+import com.amazon.opendistroforelasticsearch.sql.domain.ScriptMethodField;
 import com.amazon.opendistroforelasticsearch.sql.domain.Where;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import org.elasticsearch.common.collect.Tuple;
@@ -221,7 +222,6 @@ public class FieldMaker {
 
     public static MethodField makeMethodField(String name, List<SQLExpr> arguments, SQLAggregateOption option, String alias, String tableAlias, boolean first) throws SqlParseException {
         List<KVValue> paramers = new LinkedList<>();
-        String finalMethodName = name;
 
         for (SQLExpr object : arguments) {
 
@@ -229,7 +229,7 @@ public class FieldMaker {
 
                 SQLBinaryOpExpr binaryOpExpr = (SQLBinaryOpExpr) object;
 
-                if (SQLFunctions.isBuiltInFunction(binaryOpExpr.getOperator().toString())) {
+                if (SQLFunctions.isBuiltInScriptFunction(binaryOpExpr.getOperator().toString())) {
                     SQLMethodInvokeExpr mExpr = makeBinaryMethodField(binaryOpExpr, alias, first);
                     MethodField abc = makeMethodField(mExpr.getMethodName(), mExpr.getParameters(), null, null, tableAlias, false);
                     paramers.add(new KVValue(abc.getParams().get(0).toString(), new SQLCharExpr(abc.getParams().get(1).toString())));
@@ -265,7 +265,7 @@ public class FieldMaker {
                     }
 
                     paramers.add(new KVValue("children", childrenType));
-                } else if (SQLFunctions.isBuiltInFunction(methodName)) {
+                } else if (SQLFunctions.isBuiltInScriptFunction(methodName)) {
                     //throw new SqlParseException("only support script/nested as inner functions");
                     MethodField abc = makeMethodField(methodName, mExpr.getParameters(), null, null, tableAlias, false);
                     paramers.add(new KVValue(abc.getParams().get(0).toString(), new SQLCharExpr(abc.getParams().get(1).toString())));
@@ -283,12 +283,13 @@ public class FieldMaker {
         }
 
         //just check we can find the function
-        if (SQLFunctions.isBuiltInFunction(finalMethodName)) {
+        boolean builtInScriptFunction = SQLFunctions.isBuiltInScriptFunction(name);
+        if (builtInScriptFunction) {
             if (alias == null && first) {
-                alias = SQLFunctions.randomize("field");
+                alias = SQLFunctions.randomize(name);
             }
             //should check if field and first .
-            Tuple<String, String> newFunctions = SQLFunctions.function(finalMethodName.toLowerCase(), paramers,
+            Tuple<String, String> newFunctions = SQLFunctions.function(name.toLowerCase(), paramers,
                     paramers.isEmpty() ? null : paramers.get(0).key, first);
             paramers.clear();
             if (!first) {
@@ -299,7 +300,6 @@ public class FieldMaker {
             }
 
             paramers.add(new KVValue(newFunctions.v2()));
-            finalMethodName = "script";
         }
         if (first) {
             List<KVValue> tempParamers = new LinkedList<>();
@@ -312,6 +312,12 @@ public class FieldMaker {
             paramers.addAll(tempParamers);
         }
 
-        return new MethodField(finalMethodName, paramers, option == null ? null : option.name(), alias);
+        if (!builtInScriptFunction) {
+          return new MethodField(
+              name, paramers, option == null ? null : option.name(), alias);
+            }
+        else {
+            return new ScriptMethodField(name, paramers, option == null ? null : option.name(), alias);
+        }
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
@@ -229,7 +229,7 @@ public class FieldMaker {
 
                 SQLBinaryOpExpr binaryOpExpr = (SQLBinaryOpExpr) object;
 
-                if (SQLFunctions.isBuiltInScriptFunction(binaryOpExpr.getOperator().toString())) {
+                if (SQLFunctions.isFunctionTranslatedToScript(binaryOpExpr.getOperator().toString())) {
                     SQLMethodInvokeExpr mExpr = makeBinaryMethodField(binaryOpExpr, alias, first);
                     MethodField abc = makeMethodField(mExpr.getMethodName(), mExpr.getParameters(), null, null, tableAlias, false);
                     paramers.add(new KVValue(abc.getParams().get(0).toString(), new SQLCharExpr(abc.getParams().get(1).toString())));
@@ -265,7 +265,7 @@ public class FieldMaker {
                     }
 
                     paramers.add(new KVValue("children", childrenType));
-                } else if (SQLFunctions.isBuiltInScriptFunction(methodName)) {
+                } else if (SQLFunctions.isFunctionTranslatedToScript(methodName)) {
                     //throw new SqlParseException("only support script/nested as inner functions");
                     MethodField abc = makeMethodField(methodName, mExpr.getParameters(), null, null, tableAlias, false);
                     paramers.add(new KVValue(abc.getParams().get(0).toString(), new SQLCharExpr(abc.getParams().get(1).toString())));
@@ -283,7 +283,7 @@ public class FieldMaker {
         }
 
         //just check we can find the function
-        boolean builtInScriptFunction = SQLFunctions.isBuiltInScriptFunction(name);
+        boolean builtInScriptFunction = SQLFunctions.isFunctionTranslatedToScript(name);
         if (builtInScriptFunction) {
             if (alias == null && first) {
                 alias = SQLFunctions.randomize(name);
@@ -315,8 +315,7 @@ public class FieldMaker {
         if (builtInScriptFunction) {
             return new ScriptMethodField(name, paramers, option == null ? null : option.name(), alias);
         } else {
-          return new MethodField(
-              name, paramers, option == null ? null : option.name(), alias);
+          return new MethodField(name, paramers, option == null ? null : option.name(), alias);
         }
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
@@ -312,12 +312,11 @@ public class FieldMaker {
             paramers.addAll(tempParamers);
         }
 
-        if (!builtInScriptFunction) {
+        if (builtInScriptFunction) {
+            return new ScriptMethodField(name, paramers, option == null ? null : option.name(), alias);
+        } else {
           return new MethodField(
               name, paramers, option == null ? null : option.name(), alias);
-            }
-        else {
-            return new ScriptMethodField(name, paramers, option == null ? null : option.name(), alias);
         }
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SqlParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SqlParser.java
@@ -219,12 +219,7 @@ public class SqlParser {
             Field field = FieldMaker.makeField(expr, null, null);
 
             String orderByName;
-            if (field instanceof ScriptMethodField) {
-                // TODO The consumer of ordering doesn't know the type of the expression, and elasticsearch needs to
-                // specify it for the script field ordering. Explore opportinities to supply that information to
-                // client code. One of the options is to have metadata store about functions that will supply
-                // return type of the result function here.
-
+            if (field.isScriptField()) {
                 MethodField methodField = (MethodField) field;
 
                 // 0 - generated field name

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SqlParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SqlParser.java
@@ -31,6 +31,7 @@ import com.amazon.opendistroforelasticsearch.sql.domain.From;
 import com.amazon.opendistroforelasticsearch.sql.domain.Having;
 import com.amazon.opendistroforelasticsearch.sql.domain.JoinSelect;
 import com.amazon.opendistroforelasticsearch.sql.domain.MethodField;
+import com.amazon.opendistroforelasticsearch.sql.domain.ScriptMethodField;
 import com.amazon.opendistroforelasticsearch.sql.domain.Select;
 import com.amazon.opendistroforelasticsearch.sql.domain.TableOnJoinSelect;
 import com.amazon.opendistroforelasticsearch.sql.domain.Where;
@@ -218,7 +219,7 @@ public class SqlParser {
             Field field = FieldMaker.makeField(expr, null, null);
 
             String orderByName;
-            if (isScriptField(field)) {
+            if (field instanceof ScriptMethodField) {
                 // TODO The consumer of ordering doesn't know the type of the expression, and elasticsearch needs to
                 // specify it for the script field ordering. Explore opportinities to supply that information to
                 // client code. One of the options is to have metadata store about functions that will supply
@@ -236,13 +237,8 @@ public class SqlParser {
 
             orderByName = orderByName.replace("`", "");
             if (alias != null) orderByName = orderByName.replaceFirst(alias + "\\.", "");
-            select.addOrderBy(field.getNestedPath(), orderByName, type, isScriptField(field));
-
+            select.addOrderBy(field.getNestedPath(), orderByName, type, field);
         }
-    }
-
-    private boolean isScriptField(Field field) {
-        return field instanceof MethodField && field.getName().equals("script");
     }
 
     private void findLimit(MySqlSelectQueryBlock.Limit limit, Select select) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/WhereParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/WhereParser.java
@@ -205,7 +205,7 @@ public class WhereParser {
     private boolean isAllowedMethodOnConditionLeft(SQLMethodInvokeExpr method, SQLBinaryOperator operator) {
         return (method.getMethodName().toLowerCase().equals("nested") ||
                 method.getMethodName().toLowerCase().equals("children") ||
-                SQLFunctions.isBuiltInScriptFunction(method.getMethodName())
+                SQLFunctions.isFunctionTranslatedToScript(method.getMethodName())
         ) &&
                 !operator.isLogical();
     }
@@ -496,13 +496,13 @@ public class WhereParser {
         }
 
         if (soExpr.getLeft() instanceof SQLMethodInvokeExpr) {
-            if (!SQLFunctions.isBuiltInScriptFunction(((SQLMethodInvokeExpr) soExpr.getLeft()).getMethodName())) {
+            if (!SQLFunctions.isFunctionTranslatedToScript(((SQLMethodInvokeExpr) soExpr.getLeft()).getMethodName())) {
                 return null;
             }
         }
 
         if (soExpr.getRight() instanceof SQLMethodInvokeExpr) {
-            if (!SQLFunctions.isBuiltInScriptFunction(((SQLMethodInvokeExpr) soExpr.getRight()).getMethodName())) {
+            if (!SQLFunctions.isFunctionTranslatedToScript(((SQLMethodInvokeExpr) soExpr.getRight()).getMethodName())) {
                 return null;
             }
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/WhereParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/WhereParser.java
@@ -205,7 +205,7 @@ public class WhereParser {
     private boolean isAllowedMethodOnConditionLeft(SQLMethodInvokeExpr method, SQLBinaryOperator operator) {
         return (method.getMethodName().toLowerCase().equals("nested") ||
                 method.getMethodName().toLowerCase().equals("children") ||
-                SQLFunctions.isBuiltInFunction(method.getMethodName())
+                SQLFunctions.isBuiltInScriptFunction(method.getMethodName())
         ) &&
                 !operator.isLogical();
     }
@@ -496,13 +496,13 @@ public class WhereParser {
         }
 
         if (soExpr.getLeft() instanceof SQLMethodInvokeExpr) {
-            if (!SQLFunctions.isBuiltInFunction(((SQLMethodInvokeExpr) soExpr.getLeft()).getMethodName())) {
+            if (!SQLFunctions.isBuiltInScriptFunction(((SQLMethodInvokeExpr) soExpr.getLeft()).getMethodName())) {
                 return null;
             }
         }
 
         if (soExpr.getRight() instanceof SQLMethodInvokeExpr) {
-            if (!SQLFunctions.isBuiltInFunction(((SQLMethodInvokeExpr) soExpr.getRight()).getMethodName())) {
+            if (!SQLFunctions.isBuiltInScriptFunction(((SQLMethodInvokeExpr) soExpr.getRight()).getMethodName())) {
                 return null;
             }
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -73,7 +73,8 @@ public class SQLFunctions {
             utilityFunctions)
             .flatMap(Set::stream).collect(Collectors.toSet());
 
-    public static boolean isBuiltInScriptFunction(String function) {
+    /** Is the function actually translated into Elastic DSL script during execution? */
+    public static boolean isFunctionTranslatedToScript(String function) {
         return builtInFunctions.contains(function.toLowerCase());
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -72,7 +72,7 @@ public class SQLFunctions {
             utilityFunctions)
             .flatMap(Set::stream).collect(Collectors.toSet());
 
-    public static boolean isBuiltInFunction(String function) {
+    public static boolean isBuiltInScriptFunction(String function) {
         return builtInFunctions.contains(function.toLowerCase());
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -19,6 +19,7 @@ import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.expr.*;
 import com.amazon.opendistroforelasticsearch.sql.domain.KVValue;
+import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -506,4 +507,23 @@ public class SQLFunctions {
 
     }
 
+    /**
+     * Returns return type of script function. This is simple approach, that might be not the best solution in the long
+     * term. For example - for JDBC, if the column type in index is INTEGER, and the query is "select column+5", current
+     * approach will return type of result column as DOUBLE, although there is enough information to understand that
+     * it might be safely treated as INTEGER.
+     */
+    public static Schema.Type getScriptFunctionReturnType(String functionName) {
+        if (dateFunctions.contains(functionName) || stringOperators.contains(functionName))
+            return Schema.Type.TEXT;
+
+        if (mathConstants.contains(functionName) || numberOperators.contains(functionName)
+                || trigFunctions.contains(functionName) || binaryOperators.contains(functionName))
+            return Schema.Type.DOUBLE;
+
+        throw new UnsupportedOperationException(
+                String.format(
+                        "The following method is not supported in Schema: %s",
+                        functionName));
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -28,15 +28,26 @@ public class JdbcTestIT extends SQLIntegTestCase {
 
     public void testDateTimeInQuery() {
         String query = "SELECT date_format(insert_time, 'dd-MM-YYYY') FROM elasticsearch-sql_test_index_online limit 1";
-        String response = executeJdbcRequest(query);
 
-        JSONObject parsed = new JSONObject(response);
+        JSONObject parsed = new JSONObject(executeJdbcRequest(query));
 
         assertThat(
                 parsed.getJSONArray("datarows")
                         .getJSONArray(0)
                         .getString(0),
                 equalTo("17-08-2014"));
+    }
+
+    public void testDivisionInQuery() {
+        String query = "SELECT all_client/10 from elasticsearch-sql_test_index_online ORDER BY all_client desc limit 1";
+
+        JSONObject parsed = new JSONObject(executeJdbcRequest(query));
+
+        assertThat(
+                parsed.getJSONArray("datarows")
+                        .getJSONArray(0)
+                        .getDouble(0),
+                equalTo(16827.0));
     }
 
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -39,7 +39,7 @@ public class JdbcTestIT extends SQLIntegTestCase {
     }
 
     public void testDivisionInQuery() {
-        String query = "SELECT all_client/10 from elasticsearch-sql_test_index_online ORDER BY all_client desc limit 1";
+        String query = "SELECT all_client/10 from elasticsearch-sql_test_index_online ORDER BY all_client/10 desc limit 1";
 
         JSONObject parsed = new JSONObject(executeJdbcRequest(query));
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -1,0 +1,46 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.esintgtest;
+
+import org.json.JSONObject;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class JdbcTestIT extends SQLIntegTestCase {
+
+    @Override
+    protected void init() throws Exception {
+        loadIndex(Index.ONLINE);
+    }
+
+    public void testDateTimeInQuery() {
+        String query = "SELECT date_format(insert_time, 'dd-MM-YYYY') FROM elasticsearch-sql_test_index_online limit 1";
+        String response = executeJdbcRequest(query);
+
+        JSONObject parsed = new JSONObject(response);
+
+        assertThat(
+                parsed.getJSONArray("datarows")
+                        .getJSONArray(0)
+                        .getString(0),
+                equalTo("17-08-2014"));
+    }
+
+
+    private String executeJdbcRequest(String query){
+        return executeQuery(query, "jdbc");
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
@@ -103,6 +103,25 @@ public abstract class SQLIntegTestCase extends ESIntegTestCase {
         return sqlRequest;
     }
 
+    protected String executeQuery(String query, String requestType) {
+        try {
+            String endpoint = "/_opendistro/_sql?format=" + requestType;
+            String requestBody = makeRequest(query);
+
+            Request sqlRequest = new Request("POST", endpoint);
+            sqlRequest.setJsonEntity(requestBody);
+
+            RestClient restClient = ESIntegTestCase.getRestClient();
+            Response response = restClient.performRequest(sqlRequest);
+            Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            String responseString = TestUtils.getResponseBody(response, true);
+
+            return responseString;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     protected Request buildGetEndpointRequest(final String sqlQuery) {
 
         final String utf8CharsetName = StandardCharsets.UTF_8.name();


### PR DESCRIPTION
*Issue #*:[108](https://github.com/opendistro-for-elasticsearch/sql/issues/108)

*Description of changes: *

The script fields, that are used to implement date_format, have name "script", and the original function name is lost. Because of lost original function name, the result converter can't add type information. Also the SelectResultSet didn't copied any fields into output, so fixed that part as well.

This fix will fix the issue for date_format function, and will give a way for future built-in script functions. 

Testing: unit tests, integration tests, manual test via kibana.

Also now the prefixes for auto-generated fields will start with function name, instead of not-helping "field".

```
POST _opendistro/_sql?format=jdbc
{
  "query": "SELECT date_format(utc_time, 'dd-MM-YYYY'), bytes/10 from kibana_sample_data_logs ORDER BY bytes/10 desc limit 2 "
}
```
returns
```json
{
  "schema": [
    {
      "name": "date_format_1541758184",
      "type": "text"
    },
    {
      "name": "divide_1874722970",
      "type": "double"
    }
  ],
  "total": 10000,
  "datarows": [
    [
      "18-09-2018",
      1998
    ],
    [
      "13-08-2018",
      1995
    ]
  ],
  "size": 2,
  "status": 200
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
