### PR TITLE
Set response of "_explain" request as json content type

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
@@ -104,7 +104,7 @@ public class RestSqlAction extends BaseRestHandler {
 
             if (request.path().endsWith("/_explain")) {
                 final String jsonExplanation = queryAction.explain().explain();
-                return sendResponse(jsonExplanation, OK);
+                return channel -> channel.sendResponse(new BytesRestResponse(OK, "application/json; charset=UTF-8", jsonExplanation));
             } else {
                 Map<String, String> params = request.params();
                 RestExecutor restExecutor = ActionRequestRestExecutorFactory.createExecutor(params.get("format"),

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ExplainIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ExplainIT.java
@@ -16,6 +16,10 @@
 package com.amazon.opendistroforelasticsearch.sql.esintgtest;
 
 import com.google.common.io.Files;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -196,5 +200,15 @@ public class ExplainIT extends SQLIntegTestCase {
         String result = explainQuery(query);
 
         Assert.assertThat(result.replaceAll("\\s+", ""), equalTo(expectedOutput.replaceAll("\\s+", "")));
+    }
+
+    public void testContentTypeOfExplainRequestShouldBeJson() throws IOException {
+        String query = makeRequest("SELECT firstname FROM elasticsearch-sql_test_index_account");
+        Request request = getSqlRequest(query, true);
+
+        RestClient restClient = ESIntegTestCase.getRestClient();
+        Response response = restClient.performRequest(request);
+
+        assertEquals("application/json; charset=UTF-8", response.getHeader("content-type"));
     }
 }


### PR DESCRIPTION
*Description of changes:*

As of now this is quality of life improvement, that will enable client tools that can render json, render response of "_explain" nicely.

![Example](https://user-images.githubusercontent.com/1936087/61157090-efbbc780-a4a9-11e9-98f1-ec74fc523589.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
