### PR TITLE
Response type of explain request as "application/json" (Returning response type accidentally reverted by previous commit)

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
@@ -162,7 +162,7 @@ public class RestSqlAction extends BaseRestHandler {
                                    final Client client, final RestChannel channel) throws Exception {
         if (isExplainRequest(request)) {
             final String jsonExplanation = queryAction.explain().explain();
-            channel.sendResponse(new BytesRestResponse(OK, jsonExplanation));
+            channel.sendResponse(new BytesRestResponse(OK, "application/json; charset=UTF-8", jsonExplanation));
         } else {
             Map<String, String> params = request.params();
             RestExecutor restExecutor = ActionRequestRestExecutorFactory.createExecutor(params.get("format"),


### PR DESCRIPTION
*Description of changes:*

Sets response type for explain request

This is the same as [This commit](https://github.com/opendistro-for-elasticsearch/sql/commit/ddfbcef395998435310fbc3c138c82d91dd29b1b), that was accidentally reverted [here](https://github.com/opendistro-for-elasticsearch/sql/commit/070e7ca5b1e7a3265f230088b41d199ad8707aba)

Testing: integration test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
