### PR TITLE
Properly add order to scripted fields

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
@@ -162,7 +162,7 @@ public class RestSqlAction extends BaseRestHandler {
                                    final Client client, final RestChannel channel) throws Exception {
         if (isExplainRequest(request)) {
             final String jsonExplanation = queryAction.explain().explain();
-            channel.sendResponse(new BytesRestResponse(OK, jsonExplanation));
+            channel.sendResponse(new BytesRestResponse(OK, "application/json; charset=UTF-8", jsonExplanation));
         } else {
             Map<String, String> params = request.params();
             RestExecutor restExecutor = ActionRequestRestExecutorFactory.createExecutor(params.get("format"),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/AggregationQueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/AggregationQueryAction.java
@@ -15,11 +15,13 @@
 
 package com.amazon.opendistroforelasticsearch.sql.query;
 
+import com.alibaba.druid.sql.ast.SQLExpr;
 import com.amazon.opendistroforelasticsearch.sql.domain.Field;
 import com.amazon.opendistroforelasticsearch.sql.domain.Having;
 import com.amazon.opendistroforelasticsearch.sql.domain.KVValue;
 import com.amazon.opendistroforelasticsearch.sql.domain.MethodField;
 import com.amazon.opendistroforelasticsearch.sql.domain.Order;
+import com.amazon.opendistroforelasticsearch.sql.domain.ScriptMethodField;
 import com.amazon.opendistroforelasticsearch.sql.domain.Select;
 import com.amazon.opendistroforelasticsearch.sql.domain.Where;
 import com.amazon.opendistroforelasticsearch.sql.domain.hints.Hint;
@@ -179,6 +181,8 @@ public class AggregationQueryAction extends QueryAction {
         // add order
         if (lastAgg != null && select.getOrderBys().size() > 0) {
             for (Order order : select.getOrderBys()) {
+
+                // check "standard" fields
                 KVValue temp = groupMap.get(order.getName());
                 if (temp != null) {
                     TermsAggregationBuilder termsBuilder = (TermsAggregationBuilder) temp.value;
@@ -197,7 +201,10 @@ public class AggregationQueryAction extends QueryAction {
                         default:
                             throw new SqlParseException(order.getName() + " can not to order");
                     }
+                } else if (order.isScript()) {
+                    // Do not add scripted fields into sort, they must be sorted inside of aggregation
                 } else {
+                    // TODO: Is there a legit case when we want to add field into sort for aggregation queries?
                     request.addSort(order.getName(), SortOrder.valueOf(order.getType()));
                 }
             }
@@ -214,7 +221,7 @@ public class AggregationQueryAction extends QueryAction {
         return sqlElasticRequestBuilder;
     }
 
-    private AggregationBuilder getGroupAgg(Field field, Select select2) throws SqlParseException {
+    private AggregationBuilder getGroupAgg(Field field, Select select) throws SqlParseException {
         boolean refrence = false;
         AggregationBuilder lastAgg = null;
         for (Field temp : select.getFields()) {
@@ -231,8 +238,32 @@ public class AggregationQueryAction extends QueryAction {
         }
 
         if (!refrence) lastAgg = aggMaker.makeGroupAgg(field);
-        
+
+        // find if we have order for that aggregation. As of now only special case for script fields
+        if (field.isScriptField()) {
+            addOrderByScriptFieldIfPresent((ScriptMethodField) field, select, lastAgg);
+        }
+
         return lastAgg;
+    }
+
+    private void addOrderByScriptFieldIfPresent(ScriptMethodField field, Select select, AggregationBuilder lastAgg) {
+        // This is a hacky way, but it's the best that could be done now.
+
+        // TODO: Explore other ways to correlate different fields/functions in the query (params?)
+        ScriptMethodField groupByScriptField = field;
+        SQLExpr groupByExpression = groupByScriptField.getExpression();
+        for (Order order : select.getOrderBys()) {
+            if (order.isScript()) {
+                ScriptMethodField orderByScriptField = (ScriptMethodField) order.getSortField();
+                SQLExpr orderByExpression = orderByScriptField.getExpression();
+
+                if (groupByExpression.equals(orderByExpression)) {
+                    TermsAggregationBuilder termsAggregationBuilder = (TermsAggregationBuilder) lastAgg;
+                    termsAggregationBuilder.order(BucketOrder.key(isASC(order)));
+                }
+            }
+        }
     }
 
     private AggregationBuilder wrapNestedIfNeeded(AggregationBuilder nestedBuilder, boolean reverseNested) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
@@ -130,7 +130,8 @@ public class DateFormatTest {
     public static String getScriptAggregationKey(JSONObject aggregation, String prefix) {
         return aggregation.keySet()
                 .stream()
-                .filter(x -> x.startsWith(prefix)).findFirst()
+                .filter(x -> x.startsWith(prefix))
+                .findFirst()
                 .orElseThrow(()-> new RuntimeException("Can't find key" + prefix + " in aggregation " + aggregation));
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
@@ -128,7 +128,10 @@ public class DateFormatTest {
     }
 
     public static String getScriptAggregationKey(JSONObject aggregation, String prefix) {
-        return aggregation.keySet().stream().filter(x -> x.startsWith(prefix)).findFirst().get();
+        return aggregation.keySet()
+                .stream()
+                .filter(x -> x.startsWith(prefix)).findFirst()
+                .orElseThrow(()-> new RuntimeException("Can't find key" + prefix + " in aggregation " + aggregation));
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFormatTest.java
@@ -24,14 +24,16 @@ import com.amazon.opendistroforelasticsearch.sql.domain.Select;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.parser.ElasticSqlExprParser;
 import com.amazon.opendistroforelasticsearch.sql.parser.SqlParser;
+import com.amazon.opendistroforelasticsearch.sql.query.AggregationQueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.maker.QueryMaker;
 import com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.hamcrest.*;
-import org.junit.Ignore;
+import org.json.JSONObject;
 import org.junit.Test;
 
 import java.util.List;
@@ -39,6 +41,7 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static com.amazon.opendistroforelasticsearch.sql.util.HasFieldWithValue.hasFieldWithValue;
+import static org.mockito.Mockito.mock;
 
 public class DateFormatTest {
 
@@ -88,15 +91,44 @@ public class DateFormatTest {
     }
 
     @Test
-    @Ignore("06/27/2019: During implementing of ORDER BY date_format found that this fails as well. " +
-            "Will investigate after order by fix submitted, to scope amount of fixes.")
-    public void orderByWithGroupByTest() {
+    public void groupByWithDescOrder() throws SqlParseException {
         String query = "SELECT date_format(utc_time, 'dd-MM-YYYY'), count(*) " +
                 "FROM kibana_sample_data_logs " +
                 "GROUP BY date_format(utc_time, 'dd-MM-YYYY') " +
                 "ORDER BY date_format(utc_time, 'dd-MM-YYYY') DESC";
 
+        JSONObject sort = getAggregationOrder(query);
+        assertThat(sort.getString("_key"), is("desc"));
+    }
+
+    @Test
+    public void groupByWithAscOrder() throws SqlParseException {
+        String query = "SELECT date_format(utc_time, 'dd-MM-YYYY'), count(*) " +
+                "FROM kibana_sample_data_logs " +
+                "GROUP BY date_format(utc_time, 'dd-MM-YYYY') " +
+                "ORDER BY date_format(utc_time, 'dd-MM-YYYY')";
+
+        JSONObject sort = getAggregationOrder(query);
+        assertThat(sort.getString("_key"), is("asc"));
+    }
+
+    public JSONObject getAggregationOrder(String query) throws SqlParseException {
         Select select = getSelect(query);
+
+        Client client = mock(Client.class);
+        AggregationQueryAction queryAction = new AggregationQueryAction(client, select);
+
+        String elasticDsl = queryAction.explain().explain();
+        JSONObject elasticQuery = new JSONObject(elasticDsl);
+
+        JSONObject aggregations = elasticQuery.getJSONObject("aggregations");
+        String dateFormatAggregationKey = getScriptAggregationKey(aggregations, "date_format");
+
+        return aggregations.getJSONObject(dateFormatAggregationKey).getJSONObject("terms").getJSONObject("order");
+    }
+
+    public static String getScriptAggregationKey(JSONObject aggregation, String prefix) {
+        return aggregation.keySet().stream().filter(x -> x.startsWith(prefix)).findFirst().get();
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:* [104](https://github.com/opendistro-for-elasticsearch/sql/issues/104)

*Description of changes:*

In previous PRs, the fields were associated with corresponding SQLExpressions. During aggregation construction now it's possible to see if group by fields and order by fields are related to the same expression and correctly add order by clause into aggregation query.

For aggregation queries the script fields won't be added into "sort" part of aggregation query

```
POST _opendistro/_sql 
{
  "query" : "SELECT date_format(insert_time, 'dd-MM-YYYY'), min(all_client) FROM online group by date_format(insert_time, 'dd-MM-YYYY') order by date_format(insert_time, 'dd-MM-YYYY') desc"
}
```

generates correct order by in aggregation, and removes that field from order, like it was done previously

```json
  "aggregations": {
    "date_format_1260712542": {
      "terms": {
        "script": {
          "source": "def date_format_1122616994 = DateTimeFormatter.ofPattern('dd-MM-YYYY').withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(doc['utc_time'].value.getMillis()));return date_format_1122616994;",
          "lang": "painless"
        },
        "size": 10,
        "min_doc_count": 1,
        "shard_min_doc_count": 0,
        "show_term_doc_count_error": false,
        "order": {
          "_key": "desc"
        }
      },
      "aggregations": {
        **"AVG(bytes)": {
          "avg": {
            "field": "bytes"
          }
        }**
      }
    }
```

Testing: unit test, integration test, manual test via kibana UI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
