### PR TITLE
date format needs to be in UTC for proper comparison

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFormatIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFormatIT.java
@@ -133,11 +133,11 @@ public class DateFormatIT extends SQLIntegTestCase {
         JSONArray hits =
                 getHits(executeQuery("SELECT all_client, insert_time " +
                         " FROM " + TestsConstants.TEST_INDEX_ONLINE +
-                        " ORDER BY date_format(insert_time, 'dd-MM-YYYY') DESC, insert_time " +
+                        " ORDER BY date_format(insert_time, 'dd-MM-YYYY', 'UTC') DESC, insert_time " +
                         " LIMIT 10"));
 
         assertThat(new DateTime(getSource(hits.getJSONObject(0)).get("insert_time"), DateTimeZone.UTC),
-                is(new DateTime("2014-08-24T07:00:55.481Z", DateTimeZone.UTC)));
+                is(new DateTime("2014-08-24T00:00:41.221Z", DateTimeZone.UTC)));
     }
 
     @Test


### PR DESCRIPTION
Date format needs to be in UTC for proper comparison. This issue blocks builds for 7.2 release

*Issue #, if available:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
