### PR TITLE
Fix bug, terminate integTestCluster even when integration test failed

### DIFF
--- a/build-tools/sqlplugin-coverage.gradle
+++ b/build-tools/sqlplugin-coverage.gradle
@@ -77,7 +77,11 @@ jacocoTestReport {
 
 // See https://www.eclemma.org/jacoco/trunk/doc/api/org/jacoco/agent/rt/IAgent.html
 task dumpCoverage {
-    doFirst {
+    onlyIf {
+        // ignore the integ test coverage result when integTestRunner failed.
+        integTestRunner.getState().getFailure() == null
+    }
+    doFirst () {
         def serverUrl = "service:jmx:rmi:///jndi/rmi://127.0.0.1:7777/jmxrmi"
         def connector = JMXConnectorFactory.connect(new JMXServiceURL(serverUrl))
         try {
@@ -91,7 +95,7 @@ task dumpCoverage {
 }
 
 project.gradle.projectsEvaluated {
-    dumpCoverage.dependsOn integTestRunner
+    integTestRunner.finalizedBy dumpCoverage
     tasks['integTestCluster#stop'].dependsOn dumpCoverage
     jacocoTestReport.dependsOn dumpCoverage
 }


### PR DESCRIPTION
*Issue #, if available:* #132 

*Description of changes:*
dumpCoverage is the depedency of integTestCluster#stop and dumpCoverage dependsOn integTestRunner. In current implementation, if the integTestRunner failed, the task integTestCluster#stop will not been executed, the integ ES cluster will keep running.
The PR guarantee the dumpCoverage will be executed even when integTestRunner failed and do one improment is only pull the integration coverage from integ ES cluster when integ test running successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
