### PR TITLE
Added support for PERCENTILES in JDBC driver

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/exception/SqlFeatureNotImplementedException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/exception/SqlFeatureNotImplementedException.java
@@ -1,0 +1,19 @@
+package com.amazon.opendistroforelasticsearch.sql.exception;
+
+/**
+ * Intended for cases when we knowingly omitted some case, letting users know that we didn't implemented feature, but
+ * it may be implemented in future.
+ */
+public class SqlFeatureNotImplementedException extends RuntimeException {
+    static final long serialVersionUID = 1;
+
+    public SqlFeatureNotImplementedException() { }
+
+    public SqlFeatureNotImplementedException(String message) {
+        super(message);
+    }
+
+    public SqlFeatureNotImplementedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/exception/SqlFeatureNotImplementedException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/exception/SqlFeatureNotImplementedException.java
@@ -7,8 +7,6 @@ package com.amazon.opendistroforelasticsearch.sql.exception;
 public class SqlFeatureNotImplementedException extends RuntimeException {
     private static final long serialVersionUID = 1;
 
-    public SqlFeatureNotImplementedException() { super();}
-
     public SqlFeatureNotImplementedException(String message) {
         super(message);
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/exception/SqlFeatureNotImplementedException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/exception/SqlFeatureNotImplementedException.java
@@ -1,3 +1,17 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
 package com.amazon.opendistroforelasticsearch.sql.exception;
 
 /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/exception/SqlFeatureNotImplementedException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/exception/SqlFeatureNotImplementedException.java
@@ -5,9 +5,9 @@ package com.amazon.opendistroforelasticsearch.sql.exception;
  * it may be implemented in future.
  */
 public class SqlFeatureNotImplementedException extends RuntimeException {
-    static final long serialVersionUID = 1;
+    private static final long serialVersionUID = 1;
 
-    public SqlFeatureNotImplementedException() { }
+    public SqlFeatureNotImplementedException() { super();}
 
     public SqlFeatureNotImplementedException(String message) {
         super(message);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -570,11 +571,18 @@ public class SelectResultSet extends ResultSet {
 
                 data.put(percentiles.getName(), StreamSupport
                         .stream(percentiles.spliterator(), false)
-                        .collect(Collectors.toMap(Percentile::getPercent, Percentile::getValue)));
+                        .collect(
+                                Collectors.toMap(
+                                        Percentile::getPercent,
+                                        Percentile::getValue,
+                                        (v1, v2) -> {
+                                            throw new IllegalArgumentException(
+                                                    String.format("Duplicate key for values %s and %s", v1, v2));},
+                                        TreeMap::new)));
             }
             else {
                 throw new SqlFeatureNotImplementedException("Aggregation type " + aggregation.getType()
-                        + " is not yet supported");
+                        + " is not yet implemented");
             }
         }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -29,8 +29,8 @@ public class JdbcTestIT extends SQLIntegTestCase {
 
     public void testPercentilesQuery() {
         JSONObject response = executeJdbcRequest(
-                "SELECT percentiles(age, 25.0, 50.0, 75.0, 99.9) age_percentiles" +
-                        " FROM elasticsearch-sql_test_index_people");
+            "SELECT percentiles(age, 25.0, 50.0, 75.0, 99.9) age_percentiles " +
+            "FROM elasticsearch-sql_test_index_people");
 
         assertThat(response.getJSONArray("datarows").length(), equalTo(1));
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -24,6 +24,22 @@ public class JdbcTestIT extends SQLIntegTestCase {
     @Override
     protected void init() throws Exception {
         loadIndex(Index.ONLINE);
+        loadIndex(Index.PEOPLE);
+    }
+
+    public void testPercentilesQuery() {
+        JSONObject response = executeJdbcRequest(
+                "SELECT percentiles(age, 25.0, 50.0, 75.0, 99.9) age_percentiles" +
+                        " FROM elasticsearch-sql_test_index_people");
+
+        assertThat(response.getJSONArray("datarows").length(), equalTo(1));
+
+        JSONObject percentileRow = (JSONObject) response.query("/datarows/0/0");
+
+        assertThat(percentileRow.getDouble("25.0"), equalTo(31.5));
+        assertThat(percentileRow.getDouble("50.0"), equalTo(33.5));
+        assertThat(percentileRow.getDouble("75.0"), equalTo(36.5));
+        assertThat(percentileRow.getDouble("99.9"), equalTo(39.0));
     }
 
     public void testDateTimeInQuery() {


### PR DESCRIPTION
Adds PERCENTILE output to JDBC 

```json
GET /_opendistro/_sql?format=jdbc
{
  "query": "SELECT percentiles(age, 25.0, 50.0, 75.0, 99.9) age_percentiles FROM peoples"
}

{
  "schema": [{
    "name": "age_percentiles",
    "type": "double"
  }],
  "total": 1,
  "datarows": [[{
    "75.0": 36.5,
    "99.9": 39,
    "25.0": 31.5,
    "50.0": 33.5
  }]],
  "size": 1,
  "status": 200
}
```

Added new unchecked exception that enables us to say that we clearly know that feature is not implemented (differentiating it from not supported)

Fixes #26


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
