### PR TITLE
Support certain types of query with deeply nested field

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/From.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/From.java
@@ -108,6 +108,12 @@ class From extends SQLClause<SQLTableSource> {
         Identifier table = new Identifier((SQLIdentifierExpr) ((SQLExprTableSource) expr).getExpr());
         if (table.path().equals(scope.getParentAlias())) {
             scope.addAliasFullPath(emptyIfNull(expr.getAlias()), table.name());
+        } else {
+            String fullPath = scope.getFullPath(table.path());
+
+            if (!fullPath.isEmpty()) {
+                scope.addAliasFullPath(emptyIfNull(expr.getAlias()),fullPath + "." + table.name());
+            }
         }
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/From.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/From.java
@@ -106,14 +106,12 @@ class From extends SQLClause<SQLTableSource> {
         }
 
         Identifier table = new Identifier((SQLIdentifierExpr) ((SQLExprTableSource) expr).getExpr());
-        if (table.path().equals(scope.getParentAlias())) {
-            scope.addAliasFullPath(emptyIfNull(expr.getAlias()), table.name());
-        } else {
-            String fullPath = scope.getFullPath(table.path());
 
-            if (!fullPath.isEmpty()) {
-                scope.addAliasFullPath(emptyIfNull(expr.getAlias()),fullPath + "." + table.name());
-            }
+        // the top level parent table has an empty path. Don't add it to {alias -> path} mapping
+        if (!table.path().isEmpty()) {
+            String fullPath = scope.getFullPath(table.path());
+            String prefix = fullPath.isEmpty() ? "" : fullPath + ".";
+            scope.addAliasFullPath(emptyIfNull(expr.getAlias()), prefix + table.name());
         }
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/Identifier.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/Identifier.java
@@ -60,7 +60,7 @@ class Identifier extends SQLClause<SQLIdentifierExpr> {
     }
 
     private int separatorIndex() {
-        return expr.getName().indexOf(SEPARATOR);
+        return expr.getName().lastIndexOf(SEPARATOR);
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/Identifier.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/Identifier.java
@@ -52,14 +52,14 @@ class Identifier extends SQLClause<SQLIdentifierExpr> {
     }
 
     String path() {
-        return separatorIndex() == -1 ? "" : expr.getName().substring(0, separatorIndex());
+        return lastSeparatorIndex() == -1 ? "" : expr.getName().substring(0, lastSeparatorIndex());
     }
 
     String name() {
-        return expr.getName().substring(separatorIndex() + 1);
+        return expr.getName().substring(lastSeparatorIndex() + 1);
     }
 
-    private int separatorIndex() {
+    private int lastSeparatorIndex() {
         return expr.getName().lastIndexOf(SEPARATOR);
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#152
Only supporting plain Elasticsearch output for now.

*Description of changes:*
- Fixed `aliasFullPath` mapping in `Scope` to store more than one level of nesting path and its alias.
- Fixed the logic of creating nested query in DSL with deeply nested fields. The goal is, for nested field, its corresponding DSL also need to be nested.

*Support query* (See tests for more details)
- Select All: 
    - `SELECT * FROM employees e, e.projects p, p.address a`
- Deeper select all:
    - `SELECT * FROM employees e, e.projects p, p.address a, a.country c`
- Deep select all from different nesting levels:
    - `SELECT * FROM employees e, e.projects p, p.address a, e.comments c, c.message m`
- Select multiple nested fields from different nesting level (regular, 1st, 2nd):
    - `SELECT title, p.started_year, a.city, FROM employees e, e.projects p, p.address a`
- Deep select nested fields: 
    - `SELECT p.name, a.city, p.year, a.state FROM employees e, e.projects p, p.address a`

*Testing*
- Passed gradle build tests
- Added unit tests and integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
