### PR TITLE
7.3 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,9 @@
 buildscript {
 
     ext {
-        es_version = System.getProperty("es.version", "7.2.0")
+        // When upgrading to version after 7.3.0, must remove also
+        // project substitution from configurations.all (line 39)
+        es_version = System.getProperty("es.version", "7.3.0")
     }
     // This isn't applying from repositories.gradle so repeating it here
     repositories {
@@ -30,14 +32,19 @@ buildscript {
 
 plugins {
     id 'nebula.ospackage' version "5.3.0"
+    id 'java-library'
 }
 
-//****************************************************************************/
-// Build configurations
-//****************************************************************************/
+/*
+Temporary fix, must be removed after 7.3.0 See
+https://github.com/elastic/elasticsearch/issues/45073
 
-plugins {
-    id 'java-library'
+Also must remove include ':rest-api-spec' from settings.gradle
+*/
+configurations.all {
+  resolutionStrategy.dependencySubstitution {
+    substitute project(':rest-api-spec') with module ("org.elasticsearch:rest-api-spec:${es_version}")
+  }
 }
 
 // Repository on root level is for dependencies that project code depends on. And this block must be placed after plugins{}
@@ -46,7 +53,7 @@ repositories {
 }
 
 ext {
-    opendistroVersion = '1.2.0'
+    opendistroVersion = '1.3.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -73,6 +80,8 @@ esplugin {
     name 'opendistro_sql' // zip file name and plugin name in ${elasticsearch.plugin.name} read by ES when plugin loading
     description 'Open Distro for Elasticsearch SQL'
     classname 'com.amazon.opendistroforelasticsearch.sql.plugin.SqlPlug'
+    licenseFile rootProject.file("LICENSE.txt")
+    noticeFile rootProject.file("NOTICE")
 }
 
 // Set source and target to be compatible with Java 8

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@
 #   permissions and limitations under the License.
 #
 
-version=1.1
+version=1.3

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,3 +14,6 @@
  */
 
 rootProject.name = 'opendistro-sql'
+
+
+include ':rest-api-spec'

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/ESClientTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/ESClientTest.java
@@ -43,7 +43,7 @@ public class ESClientTest {
     protected Client client;
 
     @Before
-    public void init() throws IOException {
+    public void init() {
         MockitoAnnotations.initMocks(this);
         ActionFuture<MultiSearchResponse> mockFuture = mock(ActionFuture.class);
         when(client.multiSearch(any())).thenReturn(mockFuture);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/ESClientTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/ESClientTest.java
@@ -51,8 +51,8 @@ public class ESClientTest {
         MultiSearchResponse response = mock(MultiSearchResponse.class);
         when(mockFuture.actionGet()).thenReturn(response);
 
-        MultiSearchResponse.Item item0 = new MultiSearchResponse.Item(new SearchResponse(StreamInput.wrap("item0".getBytes())), null);
-        MultiSearchResponse.Item item1 = new MultiSearchResponse.Item(new SearchResponse(StreamInput.wrap("item1".getBytes())), new Exception());
+        MultiSearchResponse.Item item0 = new MultiSearchResponse.Item(mock(SearchResponse.class), null);
+        MultiSearchResponse.Item item1 = new MultiSearchResponse.Item(mock(SearchResponse.class), new Exception());
         MultiSearchResponse.Item[] itemsRetry0 = new MultiSearchResponse.Item[]{item0, item1};
         MultiSearchResponse.Item[] itemsRetry1 = new MultiSearchResponse.Item[]{item0};
         when(response.getResponses()).thenAnswer(new Answer<MultiSearchResponse.Item[]>() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/ESClientTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/ESClientTest.java
@@ -22,7 +22,6 @@ import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,8 +29,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
-import java.io.IOException;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/ESClientTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/ESClientTest.java
@@ -22,6 +22,7 @@ import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +30,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
+import java.io.IOException;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -40,7 +43,7 @@ public class ESClientTest {
     protected Client client;
 
     @Before
-    public void init() {
+    public void init() throws IOException {
         MockitoAnnotations.initMocks(this);
         ActionFuture<MultiSearchResponse> mockFuture = mock(ActionFuture.class);
         when(client.multiSearch(any())).thenReturn(mockFuture);
@@ -48,8 +51,8 @@ public class ESClientTest {
         MultiSearchResponse response = mock(MultiSearchResponse.class);
         when(mockFuture.actionGet()).thenReturn(response);
 
-        MultiSearchResponse.Item item0 = new MultiSearchResponse.Item(new SearchResponse(), null);
-        MultiSearchResponse.Item item1 = new MultiSearchResponse.Item(new SearchResponse(), new Exception());
+        MultiSearchResponse.Item item0 = new MultiSearchResponse.Item(new SearchResponse(StreamInput.wrap("item0".getBytes())), null);
+        MultiSearchResponse.Item item1 = new MultiSearchResponse.Item(new SearchResponse(StreamInput.wrap("item1".getBytes())), new Exception());
         MultiSearchResponse.Item[] itemsRetry0 = new MultiSearchResponse.Item[]{item0, item1};
         MultiSearchResponse.Item[] itemsRetry1 = new MultiSearchResponse.Item[]{item0};
         when(response.getResponses()).thenAnswer(new Answer<MultiSearchResponse.Item[]>() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerBatchTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerBatchTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerBatchTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerBatchTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
@@ -20,7 +20,6 @@ import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
 import com.alibaba.druid.sql.parser.ParserException;
 import com.alibaba.druid.sql.parser.SQLExprParser;
 import com.alibaba.druid.sql.parser.Token;
-import com.amazon.opendistroforelasticsearch.sql.request.SqlRequest;
 import com.amazon.opendistroforelasticsearch.sql.domain.JoinSelect;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.parser.ElasticSqlExprParser;
@@ -30,6 +29,7 @@ import com.amazon.opendistroforelasticsearch.sql.query.SqlElasticRequestBuilder;
 import com.amazon.opendistroforelasticsearch.sql.query.join.ESJoinQueryActionFactory;
 import com.amazon.opendistroforelasticsearch.sql.query.planner.HashJoinQueryPlanRequestBuilder;
 import com.amazon.opendistroforelasticsearch.sql.query.planner.core.QueryPlanner;
+import com.amazon.opendistroforelasticsearch.sql.request.SqlRequest;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
@@ -47,7 +47,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -56,11 +55,9 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -69,7 +66,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
@@ -81,9 +81,11 @@ public abstract class QueryPlannerTest {
     @Mock
     protected Client client;
 
+    @Mock
     private SearchResponse response1;
     private static final String SCROLL_ID1 = "1";
 
+    @Mock
     private SearchResponse response2;
     private static final String SCROLL_ID2 = "2";
 
@@ -109,11 +111,8 @@ public abstract class QueryPlannerTest {
     }
 
     @Before
-    public void init() throws IOException {
+    public void init() {
         MockitoAnnotations.initMocks(this);
-
-        response1 = mock(SearchResponse.class);
-        response2 = mock(SearchResponse.class);
 
         ActionFuture mockFuture = mock(ActionFuture.class);
         when(client.execute(any(), any())).thenReturn(mockFuture);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
@@ -47,6 +47,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -59,6 +60,7 @@ import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -67,6 +69,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -78,12 +81,10 @@ public abstract class QueryPlannerTest {
     @Mock
     protected Client client;
 
-    @Spy
-    private SearchResponse response1 = new SearchResponse();
+    private SearchResponse response1;
     private static final String SCROLL_ID1 = "1";
 
-    @Spy
-    private SearchResponse response2 = new SearchResponse();
+    private SearchResponse response2;
     private static final String SCROLL_ID2 = "2";
 
     @BeforeClass
@@ -108,8 +109,11 @@ public abstract class QueryPlannerTest {
     }
 
     @Before
-    public void init() {
+    public void init() throws IOException {
         MockitoAnnotations.initMocks(this);
+
+        response1 = spy(new SearchResponse(StreamInput.wrap("response1".getBytes())));
+        response2 = spy(new SearchResponse(StreamInput.wrap("response2".getBytes())));
 
         ActionFuture mockFuture = mock(ActionFuture.class);
         when(client.execute(any(), any())).thenReturn(mockFuture);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
@@ -112,8 +112,8 @@ public abstract class QueryPlannerTest {
     public void init() throws IOException {
         MockitoAnnotations.initMocks(this);
 
-        response1 = spy(new SearchResponse(StreamInput.wrap("response1".getBytes())));
-        response2 = spy(new SearchResponse(StreamInput.wrap("response2".getBytes())));
+        response1 = mock(SearchResponse.class);
+        response2 = mock(SearchResponse.class);
 
         ActionFuture mockFuture = mock(ActionFuture.class);
         when(client.execute(any(), any())).thenReturn(mockFuture);


### PR DESCRIPTION
*Description of changes:*
Changes necessary for Elastic 7.3 support

### Testing

./gradlew build

then installed built plugin and ran couple of queries on 7.3.0 of elastic oss


```
> $ rpm -qip build/distributions/opendistro-sql-1.3.0.0.rpm    [±7.3-support ✓]
Name        : opendistro-sql
Epoch       : 0
Version     : 1.3.0.0
Release     : 0.1
Architecture: noarch
Install Date: (not installed)
Group       : (none)
Size        : 7023601
License     : ASL-2.0
Signature   : (none)
Source RPM  : opendistro-sql-1.3.0.0-0.1-src.rpm
Build Date  : Mon 19 Aug 2019 10:42:40 AM PDT
Build Host  : u092fd1490a3754.ant.amazon.com
Relocations : /usr 
Packager    : Amazon
Vendor      : Amazon
URL         : https://opendistro.github.io/elasticsearch/downloads
Summary     : SQL plugin for OpenDistro for Elasticsearch.  Reference documentation can be found at https://opendistro.github.io/for-elasticsearch-docs/.
Description :
Open Distro for Elasticsearch SQL                              
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
