### PR TITLE
More records in the aggregation query output for script functions, is…

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/AggregationQueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/AggregationQueryAction.java
@@ -76,11 +76,10 @@ public class AggregationQueryAction extends QueryAction {
             if (!groupBy.isEmpty()) {
                 Field field = groupBy.get(0);
 
-
                 //make groupby can reference to field alias
                 lastAgg = getGroupAgg(field, select);
 
-                if (lastAgg != null && lastAgg instanceof TermsAggregationBuilder && !(field instanceof MethodField)) {
+                if (lastAgg instanceof TermsAggregationBuilder && !(field instanceof MethodField)) {
                     //if limit size is too small, increasing shard  size is required
                     if (select.getRowCount() < 200) {
                         ((TermsAggregationBuilder) lastAgg).shardSize(2000);
@@ -92,9 +91,13 @@ public class AggregationQueryAction extends QueryAction {
                             }
                         }
                     }
-                    if(select.getRowCount()>0) {
+                    if (select.getRowCount() > 0) {
                         ((TermsAggregationBuilder) lastAgg).size(select.getRowCount());
                     }
+                }
+
+                if (lastAgg instanceof TermsAggregationBuilder && field instanceof ScriptMethodField && select.getRowCount() > 0) {
+                    ((TermsAggregationBuilder) lastAgg).size(select.getRowCount());
                 }
 
                 if (field.isNested()) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/AggregationQueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/AggregationQueryAction.java
@@ -79,25 +79,31 @@ public class AggregationQueryAction extends QueryAction {
                 //make groupby can reference to field alias
                 lastAgg = getGroupAgg(field, select);
 
-                if (lastAgg instanceof TermsAggregationBuilder && !(field instanceof MethodField)) {
-                    //if limit size is too small, increasing shard  size is required
-                    if (select.getRowCount() < 200) {
-                        ((TermsAggregationBuilder) lastAgg).shardSize(2000);
-                        for (Hint hint : select.getHints()) {
-                            if (hint.getType() == HintType.SHARD_SIZE) {
-                                if (hint.getParams() != null && hint.getParams().length != 0 && hint.getParams()[0] != null) {
-                                    ((TermsAggregationBuilder) lastAgg).shardSize((Integer) hint.getParams()[0]);
+                if (lastAgg instanceof TermsAggregationBuilder) {
+
+                    // TODO: Consider removing that condition
+                    // in theory we should be able to apply this for all types of fiels, but
+                    // this change requires too much of related integration tests (e.g. there are comparisons against
+                    // raw javascript dsl, so I'd like to scope the changes as of now to one particular fix for
+                    // scripted functions
+
+                    if (!(field instanceof MethodField) || field instanceof ScriptMethodField) {
+                        //if limit size is too small, increasing shard  size is required
+                        if (select.getRowCount() < 200) {
+                            ((TermsAggregationBuilder) lastAgg).shardSize(2000);
+                            for (Hint hint : select.getHints()) {
+                                if (hint.getType() == HintType.SHARD_SIZE) {
+                                    if (hint.getParams() != null && hint.getParams().length != 0 && hint.getParams()[0] != null) {
+                                        ((TermsAggregationBuilder) lastAgg).shardSize((Integer) hint.getParams()[0]);
+                                    }
                                 }
                             }
                         }
-                    }
-                    if (select.getRowCount() > 0) {
-                        ((TermsAggregationBuilder) lastAgg).size(select.getRowCount());
-                    }
-                }
 
-                if (lastAgg instanceof TermsAggregationBuilder && field instanceof ScriptMethodField && select.getRowCount() > 0) {
-                    ((TermsAggregationBuilder) lastAgg).size(select.getRowCount());
+                        if (select.getRowCount() > 0) {
+                            ((TermsAggregationBuilder) lastAgg).size(select.getRowCount());
+                        }
+                    }
                 }
 
                 if (field.isNested()) {


### PR DESCRIPTION
Issue #156 
Issue #opendistro-for-elasticsearch/sql-jdbc#23

*Description of changes:*

Changes DSL, generated for aggregation query to have more records returned by default.
Testing: 

unit tests,

    ./gradlew build,

and manual testing via kibana ui

```
GET /_opendistro/_sql
{
  "query": """
  SELECT date_format(utc_time, 'Y-MM-dd') x, count(*) 
  FROM kibana_sample_data_logs
  WHERE host='www.elastic.co'
  GROUP BY date_format(utc_time, 'Y-MM-dd')
  """
}
```

to 
```
GET /kibana_sample_data_logs/_search
{
  "from": 0,
  "size": 0,

...

  "_source": {
    "includes": [
      "script",
      "COUNT"
    ],
    "excludes": []
  },
  "stored_fields": "x",
  "script_fields": {
    "x": {
      "script": {
        "source": "def date_format_1282644910 = DateTimeFormatter.ofPattern('Y-MM-dd').withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(doc['utc_time'].value.getMillis()));return date_format_1282644910;",
        "lang": "painless"
      },
      "ignore_failure": false
    }
  },
  "aggregations": {
    "x": {
      "terms": {
        "script": {
          "source": "def date_format_1282644910 = DateTimeFormatter.ofPattern('Y-MM-dd').withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(doc['utc_time'].value.getMillis()));return date_format_1282644910;",
          "lang": "painless"
        },
        "size": 200, <----------------------------------------------------------------------------------------------------------
        "min_doc_count": 1,
        "shard_min_doc_count": 0,
        "show_term_doc_count_error": false,
        "order": [
          {
            "_count": "desc"
          },
          {
            "_key": "asc"
          }
        ]
      },
      "aggregations": {
        "COUNT(*)": {
          "value_count": {
            "field": "_index"
          }
        }
      }
    }
  }
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
