### PR TITLE
Case functions support: LOWER, UPPER

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -317,7 +317,7 @@ public class SelectResultSet extends ResultSet {
                 // (similar to Strategy pattern)
 
                 return SQLFunctions.getScriptFunctionReturnType(
-                        ((ScriptMethodField) field).getFunctionName().toLowerCase());
+                        ((ScriptMethodField) field).getFunctionName());
             }
             default:
                 throw new UnsupportedOperationException(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -317,7 +317,7 @@ public class SelectResultSet extends ResultSet {
                 // (similar to Strategy pattern)
 
                 return SQLFunctions.getScriptFunctionReturnType(
-                        ((ScriptMethodField) field).getFunctionName());
+                        ((ScriptMethodField) field).getFunctionName().toLowerCase());
             }
             default:
                 throw new UnsupportedOperationException(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -28,7 +28,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.elasticsearch.common.collect.Tuple;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,7 +52,7 @@ public class SQLFunctions {
     );
 
     private static final Set<String> stringOperators = Sets.newHashSet(
-            "split", "concat_ws", "substring", "trim"
+            "split", "concat_ws", "substring", "trim", "lower", "upper"
     );
 
     private static final Set<String> binaryOperators = Sets.newHashSet(
@@ -74,6 +76,19 @@ public class SQLFunctions {
             utilityFunctions)
             .flatMap(Set::stream).collect(Collectors.toSet());
 
+    private HashMap<String, Integer> generatedIds = new HashMap<>();
+
+    /**
+     * Generates next id for given method name. The id's are increasing for each method name, so
+     * nextId("a"), nextId("a"), nextId("b") will return a_1, a_2, b_1
+     */
+    public String nextId(String methodName) {
+        int val = generatedIds.getOrDefault(methodName, 0);
+        val++;
+        generatedIds.put(methodName, val);
+        return methodName + "_" + val;
+    }
+
     /**
      * Is the function actually translated into Elastic DSL script during execution?
      */
@@ -85,6 +100,19 @@ public class SQLFunctions {
                                                  boolean returnValue) {
         Tuple<String, String> functionStr = null;
         switch (methodName) {
+            case "lower": {
+                functionStr = lower(
+                        (SQLExpr) paramers.get(0).value,
+                        getLocaleForCaseChangingFunction(paramers));
+                break;
+            }
+            case "upper": {
+                functionStr = upper(
+                        (SQLExpr) paramers.get(0).value,
+                        getLocaleForCaseChangingFunction(paramers));
+                break;
+            }
+
             // Split is currently not supported since its using .split() in painless which is not whitelisted
             case "split":
                 if (paramers.size() == 3) {
@@ -253,10 +281,24 @@ public class SQLFunctions {
         return functionStr;
     }
 
-    private int generatedId = 0;
+    public String getLocaleForCaseChangingFunction(List<KVValue> paramers) {
+        String locale;
+        if (paramers.size() == 1) {
+            locale = Locale.getDefault().getLanguage();
+        } else {
+            locale = Util.expr2Object((SQLExpr) paramers.get(1).value).toString();
+        }
+        return locale;
+    }
 
-    public String nextId(String methodName) {
-        return methodName + "_" + (++generatedId);
+    public Tuple<String, String> upper(SQLExpr field, String locale) {
+        String name = nextId("upper");
+        return new Tuple<>(name, def(name, upper(getPropertyOrValue(field), locale)));
+    }
+
+    public Tuple<String, String> lower(SQLExpr field, String locale) {
+        String name = nextId("lower");
+        return new Tuple<>(name, def(name, lower(getPropertyOrValue(field), locale)));
     }
 
     private static String def(String name, String value) {
@@ -527,7 +569,14 @@ public class SQLFunctions {
                     + def(name, valueName + "."
                     + func("substring", false, Integer.toString(pos), Integer.toString(len))));
         }
+    }
 
+    private String lower(String property, String culture) {
+        return property + ".toLowerCase(Locale.forLanguageTag(\"" + culture + "\"))";
+    }
+
+    private String upper(String property, String culture) {
+        return property + ".toUpperCase(Locale.forLanguageTag(\"" + culture + "\"))";
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -7,7 +7,7 @@
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
  *
- *   or in the "license" file accompanying this file. This file is distbuted
+ *   or in the "license" file accompanying this file. This file is distributed
  *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  *   express or implied. See the License for the specific language governing
  *   permissions and limitations under the License.

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.collect.Tuple;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -76,17 +77,14 @@ public class SQLFunctions {
             utilityFunctions)
             .flatMap(Set::stream).collect(Collectors.toSet());
 
-    private HashMap<String, Integer> generatedIds = new HashMap<>();
+    private Map<String, Integer> generatedIds = new HashMap<>();
 
     /**
      * Generates next id for given method name. The id's are increasing for each method name, so
      * nextId("a"), nextId("a"), nextId("b") will return a_1, a_2, b_1
      */
     public String nextId(String methodName) {
-        int val = generatedIds.getOrDefault(methodName, 0);
-        val++;
-        generatedIds.put(methodName, val);
-        return methodName + "_" + val;
+        return methodName + "_" + generatedIds.merge(methodName, 1, Integer::sum);
     }
 
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -7,7 +7,7 @@
  *
  *       http://www.apache.org/licenses/LICENSE-2.0
  *
- *   or in the "license" file accompanying this file. This file is distributed
+ *   or in the "license" file accompanying this file. This file is distbuted
  *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  *   express or implied. See the License for the specific language governing
  *   permissions and limitations under the License.
@@ -89,6 +89,7 @@ public class SQLFunctions {
         return methodName + "_" + val;
     }
 
+
     /**
      * Is the function actually translated into Elastic DSL script during execution?
      */
@@ -103,13 +104,16 @@ public class SQLFunctions {
             case "lower": {
                 functionStr = lower(
                         (SQLExpr) paramers.get(0).value,
-                        getLocaleForCaseChangingFunction(paramers));
+                        getLocaleForCaseChangingFunction(paramers),
+                        name
+                );
                 break;
             }
             case "upper": {
                 functionStr = upper(
                         (SQLExpr) paramers.get(0).value,
-                        getLocaleForCaseChangingFunction(paramers));
+                        getLocaleForCaseChangingFunction(paramers),
+                        name);
                 break;
             }
 
@@ -291,14 +295,26 @@ public class SQLFunctions {
         return locale;
     }
 
-    public Tuple<String, String> upper(SQLExpr field, String locale) {
+    public Tuple<String, String> upper(SQLExpr field, String locale, String valueName) {
         String name = nextId("upper");
-        return new Tuple<>(name, def(name, upper(getPropertyOrValue(field), locale)));
+
+        if (valueName == null) {
+            return new Tuple<>(name, def(name, upper(getPropertyOrValue(field), locale)));
+        } else {
+            return new Tuple<>(name, getPropertyOrValue(field) + "; "
+                    + def(name, valueName + "." + upper(getPropertyOrValue(field), locale)));
+        }
     }
 
-    public Tuple<String, String> lower(SQLExpr field, String locale) {
+    public Tuple<String, String> lower(SQLExpr field, String locale, String valueName) {
         String name = nextId("lower");
-        return new Tuple<>(name, def(name, lower(getPropertyOrValue(field), locale)));
+
+        if (valueName == null) {
+            return new Tuple<>(name, def(name, lower(getPropertyOrValue(field), locale)));
+        } else {
+            return new Tuple<>(name, getPropertyOrValue(field) + "; "
+                    + def(name, valueName + "." + lower(getPropertyOrValue(field), locale)));
+        }
     }
 
     private static String def(String name, String value) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -158,14 +158,7 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
         assertThat(
                 executeQuery(query),
-                MatcherUtils.featureValueOf("SearchHits", hasItems((Matcher<JSONObject>[]) new Matcher[]{kvString("/key", equalTo("AMBER"))}), actual -> {
-                    JSONArray array = (JSONArray) (actual.query("/aggregations/UPPER_2/buckets"));
-                    List<JSONObject> results = new ArrayList<>(array.length());
-                    for (Object element : array) {
-                        results.add((JSONObject) element);
-                    }
-                    return results;
-                }));
+                hitAny("/aggregations/UPPER_2/buckets", kvString("/key", equalTo("AMBER"))));
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -130,13 +130,14 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
         // "IL".toLowerCase() in a Turkish locale returns "ıl"
         // https://stackoverflow.com/questions/11063102/using-locales-with-javas-tolowercase-and-touppercase
 
-        String query = "SELECT LOWER(state, 'tr') " +
+        String query = "SELECT LOWER(state.keyword, 'tr') " +
                 "FROM elasticsearch-sql_test_index_account/account " +
                 "WHERE account_number=1";
 
         assertThat(
                 executeQuery(query),
-                hitAny(kvString("/fields/LOWER_0/0", equalTo("ıl")))
+                hitAny(
+                        kvString("/fields/LOWER_1/0", equalTo("ıl")))
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -114,13 +114,13 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
         String query = "SELECT LOWER(firstname) " +
                 "FROM elasticsearch-sql_test_index_account/account " +
                 "WHERE UPPER(lastname)='DUKE' " +
-                "ORDER BY UPPER(lastname) ";
+                "ORDER BY upper(lastname) ";
 
         assertThat(
                 executeQuery(query),
                 hitAny(
                         kvString("/_source/address", equalTo("880 Holmes Lane")),
-                        kvString("/fields/LOWER_0/0", equalTo("amber")))
+                        kvString("/fields/LOWER_1/0", equalTo("amber")))
         );
     }
 
@@ -136,7 +136,7 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
         assertThat(
                 executeQuery(query),
-                hitAny("/aggregations/UPPER_1/buckets",
+                hitAny("/aggregations/UPPER_2/buckets",
                         kvString("/key", equalTo("AMBER"))
         ));
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -41,7 +41,18 @@ import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstant
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.hitAny;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kvDouble;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kvString;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasValue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
 
 
 /**

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -124,6 +124,21 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
         );
     }
 
+    @Test
+    public void caseChangeTestWithLocale() throws IOException {
+        // Uses Turkish locale to check if we pass correct locale for case changing functions
+        // "IL".toLowerCase() in a Turkish locale returns "ıl"
+        // https://stackoverflow.com/questions/11063102/using-locales-with-javas-tolowercase-and-touppercase
+
+        String query = "SELECT LOWER(state, 'tr') " +
+                "FROM elasticsearch-sql_test_index_account/account " +
+                "WHERE account_number=1";
+
+        assertThat(
+                executeQuery(query),
+                hitAny(kvString("/fields/LOWER_0/0", equalTo("ıl")))
+        );
+    }
 
     @Test
     public void caseChangeWithAggregationTest() throws IOException {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -111,15 +111,16 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
     @Test
     public void caseChangeTest() throws IOException {
-        String query = "SELECT LOWER(e.firstname) " +
-                "FROM elasticsearch-sql_test_index_account/account e " +
-                "WHERE UPPER(e.lastname)='DUKE' ";
+        String query = "SELECT LOWER(firstname) " +
+                "FROM elasticsearch-sql_test_index_account/account " +
+                "WHERE UPPER(lastname)='DUKE' " +
+                "ORDER BY UPPER(lastname) ";
 
         assertThat(
                 executeQuery(query),
                 hitAny(
                         kvString("/_source/address", equalTo("880 Holmes Lane")),
-                        kvString("/fields/LOWER_1/0", equalTo("amber")))
+                        kvString("/fields/LOWER_0/0", equalTo("amber")))
         );
     }
 
@@ -131,9 +132,12 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
                 "WHERE LOWER(e.lastname)='duke' " +
                 "GROUP BY UPPER(e.firstname) ";
 
+        System.out.println(executeQuery(query));
+
         assertThat(
                 executeQuery(query),
-                hitAny("/aggregations/UPPER_2/buckets", kvString("/key", equalTo("AMBER"))
+                hitAny("/aggregations/UPPER_1/buckets",
+                        kvString("/key", equalTo("AMBER"))
         ));
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -110,6 +110,34 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
     }
 
     @Test
+    public void caseChangeTest() throws IOException {
+        String query = "SELECT LOWER(e.firstname) " +
+                "FROM elasticsearch-sql_test_index_account/account e " +
+                "WHERE UPPER(e.lastname)='DUKE' ";
+
+        assertThat(
+                executeQuery(query),
+                hitAny(
+                        kvString("/_source/address", equalTo("880 Holmes Lane")),
+                        kvString("/fields/LOWER_1/0", equalTo("amber")))
+        );
+    }
+
+
+    @Test
+    public void caseChangeWithAggregationTest() throws IOException {
+        String query = "SELECT UPPER(e.firstname), COUNT(*)" +
+                "FROM elasticsearch-sql_test_index_account/account e " +
+                "WHERE LOWER(e.lastname)='duke' " +
+                "GROUP BY UPPER(e.firstname) ";
+
+        assertThat(
+                executeQuery(query),
+                hitAny("/aggregations/UPPER_2/buckets", kvString("/key", equalTo("AMBER"))
+        ));
+    }
+
+    @Test
     public void concat_ws_field_and_string() throws Exception {
         //here is a bug,csv field with spa
         String query = "SELECT " +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.sql.esintgtest;
 
 
+import com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -24,29 +25,23 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.hamcrest.Matcher;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.IntStream;
 
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.hitAny;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kvDouble;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kvString;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.both;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasValue;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 
 
 /**
@@ -152,9 +147,14 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
         assertThat(
                 executeQuery(query),
-                hitAny("/aggregations/UPPER_2/buckets",
-                        kvString("/key", equalTo("AMBER"))
-        ));
+                MatcherUtils.featureValueOf("SearchHits", hasItems((Matcher<JSONObject>[]) new Matcher[]{kvString("/key", equalTo("AMBER"))}), actual -> {
+                    JSONArray array = (JSONArray) (actual.query("/aggregations/UPPER_2/buckets"));
+                    List<JSONObject> results = new ArrayList<>(array.length());
+                    for (Object element : array) {
+                        results.add((JSONObject) element);
+                    }
+                    return results;
+                }));
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -154,8 +154,6 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
                 "WHERE LOWER(e.lastname)='duke' " +
                 "GROUP BY UPPER(e.firstname) ";
 
-        System.out.println(executeQuery(query));
-
         assertThat(
                 executeQuery(query),
                 hitAny("/aggregations/UPPER_2/buckets", kvString("/key", equalTo("AMBER"))));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -74,11 +74,23 @@ public class TestUtils {
                 "          }," +
                 "          \"firstname\": {\n" +
                 "            \"type\": \"text\",\n" +
-                "            \"fielddata\": true\n" +
+                "            \"fielddata\": true,\n" +
+                "            \"fields\": {\n" +
+                "              \"keyword\": {\n" +
+                "                \"type\": \"keyword\",\n" +
+                "                \"ignore_above\": 256\n" +
+                "              }" +
+                "            }" +
                 "          }," +
                 "          \"lastname\": {\n" +
                 "            \"type\": \"text\",\n" +
-                "            \"fielddata\": true\n" +
+                "            \"fielddata\": true,\n" +
+                "            \"fields\": {\n" +
+                "              \"keyword\": {\n" +
+                "                \"type\": \"keyword\",\n" +
+                "                \"ignore_above\": 256\n" +
+                "              }" +
+                "            }" +
                 "          }," +
                 "          \"state\": {\n" +
                 "            \"type\": \"text\",\n" +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -72,6 +72,14 @@ public class TestUtils {
                 "            \"type\": \"text\",\n" +
                 "            \"fielddata\": true\n" +
                 "          }," +
+                "          \"firstname\": {\n" +
+                "            \"type\": \"text\",\n" +
+                "            \"fielddata\": true\n" +
+                "          }," +
+                "          \"lastname\": {\n" +
+                "            \"type\": \"text\",\n" +
+                "            \"fielddata\": true\n" +
+                "          }," +
                 "          \"state\": {\n" +
                 "            \"type\": \"text\",\n" +
                 "            \"fielddata\": true,\n" +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
@@ -100,7 +100,6 @@ public class MatcherUtils {
         return hitAny("/hits/hits", matcher);
     }
 
-
     public static Matcher<JSONObject> hitAll(Matcher<JSONObject>... matcher) {
         return featureValueOf("SearchHits", containsInAnyOrder(matcher), actual -> {
             JSONArray array = (JSONArray) (actual.query("/hits/hits"));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
@@ -85,19 +85,15 @@ public class MatcherUtils {
         return (Matcher) hasEntry(key, value);
     }
 
-    public static Matcher<JSONObject> hitAny(String query, Matcher<JSONObject>... matcher) {
+    public static Matcher<JSONObject> hitAny(Matcher<JSONObject>... matcher) {
         return featureValueOf("SearchHits", hasItems(matcher), actual -> {
-            JSONArray array = (JSONArray) (actual.query(query));
+            JSONArray array = (JSONArray) (actual.query("/hits/hits"));
             List<JSONObject> results = new ArrayList<>(array.length());
             for (Object element : array) {
                 results.add((JSONObject)element);
             }
             return results;
         });
-    }
-
-    public static Matcher<JSONObject> hitAny(Matcher<JSONObject>... matcher) {
-        return hitAny("/hits/hits", matcher);
     }
 
     public static Matcher<JSONObject> hitAll(Matcher<JSONObject>... matcher) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
@@ -85,15 +85,19 @@ public class MatcherUtils {
         return (Matcher) hasEntry(key, value);
     }
 
-    public static Matcher<JSONObject> hitAny(Matcher<JSONObject>... matcher) {
+    public static Matcher<JSONObject> hitAny(String query, Matcher<JSONObject>... matcher) {
         return featureValueOf("SearchHits", hasItems(matcher), actual -> {
-            JSONArray array = (JSONArray) (actual.query("/hits/hits"));
+            JSONArray array = (JSONArray) (actual.query(query));
             List<JSONObject> results = new ArrayList<>(array.length());
             for (Object element : array) {
                 results.add((JSONObject)element);
             }
             return results;
         });
+    }
+
+    public static Matcher<JSONObject> hitAny(Matcher<JSONObject>... matcher) {
+        return hitAny("/hits/hits", matcher);
     }
 
     public static Matcher<JSONObject> hitAll(Matcher<JSONObject>... matcher) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
@@ -85,9 +85,9 @@ public class MatcherUtils {
         return (Matcher) hasEntry(key, value);
     }
 
-    public static Matcher<JSONObject> hitAny(Matcher<JSONObject>... matcher) {
+    public static Matcher<JSONObject> hitAny(String query, Matcher<JSONObject>... matcher) {
         return featureValueOf("SearchHits", hasItems(matcher), actual -> {
-            JSONArray array = (JSONArray) (actual.query("/hits/hits"));
+            JSONArray array = (JSONArray) (actual.query(query));
             List<JSONObject> results = new ArrayList<>(array.length());
             for (Object element : array) {
                 results.add((JSONObject)element);
@@ -95,6 +95,11 @@ public class MatcherUtils {
             return results;
         });
     }
+
+    public static Matcher<JSONObject> hitAny(Matcher<JSONObject>... matcher) {
+        return hitAny("/hits/hits", matcher);
+    }
+
 
     public static Matcher<JSONObject> hitAll(Matcher<JSONObject>... matcher) {
         return featureValueOf("SearchHits", containsInAnyOrder(matcher), actual -> {


### PR DESCRIPTION
Issue #128 

*Description of changes:*
* Added 2 new functions LOWER and UPPER that receive field name as a first parameter and, potentially, locale 

* Changed identifier generation strategy to id per function name instead of global id

While I feel that SQLFunctions should be refactored, to expedite the process as of now I'm adding just functions implemented by analogy with trim() and substring() functions

### Testing
integration testing, testing via kibana

Itegration tests include ORDER BY and GROUP BY clauses to ensure that everything is working.
Found 2 new issues that will be addressed separately: #176 , #175 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
