### PR TITLE
Support using attributes aliases in nested query where condition

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/Identifier.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/Identifier.java
@@ -51,8 +51,13 @@ class Identifier extends SQLClause<SQLIdentifierExpr> {
         }
     }
 
+    /**
+     * return the path of the expr name. e.g.
+     * if (expr.name = p.name), return p
+     * if (expr.name = p), return p
+     */
     String path() {
-        return separatorIndex() == -1 ? "" : expr.getName().substring(0, separatorIndex());
+        return separatorIndex() == -1 ? expr.getName() : expr.getName().substring(0, separatorIndex());
     }
 
     String name() {
@@ -87,7 +92,7 @@ class Identifier extends SQLClause<SQLIdentifierExpr> {
         if (fullPath.isEmpty()) {
             throw new IllegalStateException("Full path not found for identifier:" + expr.getName());
         }
-        expr.setName(fullPath + SEPARATOR + name());
+        expr.setName(expr.getName().replaceFirst(path(), fullPath));
     }
 
     private void useFullPathAsTag(Scope scope) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/Identifier.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/Identifier.java
@@ -53,8 +53,8 @@ class Identifier extends SQLClause<SQLIdentifierExpr> {
 
     /**
      * return the path of the expr name. e.g.
-     * if (expr.name = p.name), return p
-     * if (expr.name = p), return p
+     * expecting p returned as path in both WHERE p.name = 'A' and WHERE p IS NULL cases,
+     * in which expr.name = p.name and p separately
      */
     String path() {
         return separatorIndex() == -1 ? expr.getName() : expr.getName().substring(0, separatorIndex());

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/SQLClause.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/SQLClause.java
@@ -99,10 +99,7 @@ abstract class SQLClause<T> {
     String pathFromIdentifier(SQLExpr identifier) {
         String field = Util.extendedToString(identifier);
         int lastDot = field.lastIndexOf(".");
-        if (lastDot == -1) {
-            throw new IllegalStateException("pathFromIdentifier() is being invoked on the wrong field [" + field + "]");
-        }
-        return field.substring(0, lastDot);
+        return lastDot == -1 ? field :field.substring(0, lastDot);
     }
 
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
@@ -359,11 +359,11 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void testNestedIsNotNull() throws IOException {
+    public void testNestedIsNotNullExplain() throws IOException {
         String explain = explainQuery(
                 "SELECT e.name " +
-                        "FROM elasticsearch-sql_test_index_employee_nested as e, e.projects as p " +
-                        "WHERE p IS NOT NULL"
+                         "FROM elasticsearch-sql_test_index_employee_nested as e, e.projects as p " +
+                         "WHERE p IS NOT NULL"
         );
 
         assertThat(explain, containsString("\"exists\":{\"field\":\"projects\""));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
@@ -359,6 +359,18 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
     }
 
     @Test
+    public void testNestedIsNotNull() throws IOException {
+        String explain = explainQuery(
+                "SELECT e.name " +
+                        "FROM elasticsearch-sql_test_index_employee_nested as e, e.projects as p " +
+                        "WHERE p IS NOT NULL"
+        );
+
+        assertThat(explain, containsString("\"exists\":{\"field\":\"projects\""));
+        assertThat(explain, containsString("\"path\":\"projects\""));
+    }
+
+    @Test
     @Ignore // TODO: enable when subqueries are fixed
     public void testMultiQuery() throws IOException {
         String expectedOutput = TestUtils.fileToString("src/test/resources/expectedOutput/term_union_where", true);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/NestedFieldRewriterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/NestedFieldRewriterTest.java
@@ -249,6 +249,30 @@ public class NestedFieldRewriterTest {
         );
     }
 
+    @Test
+    public void isNotNull() {
+        same(
+                query("SELECT e.name FROM employee as e, e.projects as p WHERE p IS NOT NULL"),
+                query("SELECT name FROM employee WHERE nested(projects, 'projects') IS NOT NULL")
+        );
+    }
+
+    @Test
+    public void isNotNullAndCondition() {
+        same(
+                query("SELECT e.name FROM employee as e, e.projects as p WHERE p IS NOT NULL AND p.name LIKE 'security'"),
+                query("SELECT name FROM employee WHERE nested('projects', projects IS NOT NULL AND projects.name LIKE 'security')")
+        );
+    }
+
+    @Test
+    public void multiCondition() {
+        same(
+                query("SELECT e.name FROM employee as e, e.projects as p WHERE p.year = 2016 and p.name LIKE 'security'"),
+                query("SELECT name FROM employee WHERE nested('projects', projects.year = 2016 AND projects.name LIKE 'security')")
+        );
+    }
+
     private void noImpact(String sql) {
         same(parse(sql), rewrite(parse(sql)));
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Support using aliases in the where condition for nested query. Which is aligned with https://partiql.org/ specification.

For example,
p is the aliases of the employee_nested's projects attributes.
```
GET /_opendistro/_sql/?
{
  "query":"""
    SELECT e.name FROM employee_nested as e, e.projects as p WHERE p IS NOT NULL
  """
}
```
The result is 
```
    "hits" : [
      {
        "_index" : "employee_nested",
        "_type" : "_doc",
        "_id" : "1",
        "_score" : 0.0,
        "_source" : {
          "name" : "Bob Smith"
        }
      },
      {
        "_index" : "employee_nested",
        "_type" : "_doc",
        "_id" : "3",
        "_score" : 0.0,
        "_source" : {
          "name" : "Jane Smith"
        }
      }
    ]
```
The explained query in DSL is
```
{"from":0,"size":200,"query":{"bool":{"filter":[{"bool":{"must":[{"nested":{"query":{"bool":{"must_not":[{"bool":{"must_not":[{"exists":{"field":"projects","boost":1.0}}],"adjust_pure_negative":true,"boost":1.0}}],"adjust_pure_negative":true,"boost":1.0}},"path":"projects","ignore_unmapped":false,"score_mode":"none","boost":1.0}}],"adjust_pure_negative":true,"boost":1.0}}],"adjust_pure_negative":true,"boost":1.0}},"_source":{"includes":["name"],"excludes":[]}}
```

The test data is
```
{"id":3,"name":"Bob Smith","title":null,"projects":[{"name":"AWS Redshift Spectrum querying","started_year":1990,"address":[{"city":"Seattle","state":"WA"},{"city":"Boston","state":"MA"}]},{"name":"AWS Redshift security","started_year":1999,"address":[{"city":"Chicago","state":"IL"}]},{"name":"AWS Aurora security","started_year":2015}],"comments":[{"date":"2018-06-23","message":"I love New york","likes":56},{"date":"2017-10-25","message":"Today is good weather","likes":22}]}
{"id":4,"name":"Susan Smith","title":"Dev Mgr","projects":[],"comments":[{"date":"2018-06-23","message":"comment_2_1","likes":56},{"date":"2017-10-25","message":"comment_2_2","likes":22}]}
{"id":6,"name":"Jane Smith","title":"Software Eng 2","projects":[{"name":"AWS Redshift security","started_year":1998},{"name":"AWS Hello security","started_year":2015,"address":[{"city":"Dallas","state":"TX"}]}],"comments":[{"date":"2018-06-23","message":"comment_3_1","likes":24},{"date":"2017-10-25","message":"comment_3_2","likes":42}]}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
