### PR TITLE
Add parent for SQLExpr in AST if missing

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
@@ -44,6 +44,7 @@ import com.amazon.opendistroforelasticsearch.sql.rewriter.RewriteRuleExecutor;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.matchtoterm.TermFieldRewriter;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.matchtoterm.TermFieldRewriter.TermRewriterFilter;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.nestedfield.NestedFieldRewriter;
+import com.amazon.opendistroforelasticsearch.sql.rewriter.parent.SQLExprParentSetterRule;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.subquery.SubqueryRewriteRule;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.search.SearchHit;
@@ -73,11 +74,13 @@ public class ESActionFactory {
         switch (getFirstWord(sql)) {
             case "SELECT":
                 SQLQueryExpr sqlExpr = (SQLQueryExpr) toSqlExpr(sql);
-                sqlExpr.accept(new NestedFieldRewriter());
+
                 RewriteRuleExecutor<SQLQueryExpr> ruleExecutor = RewriteRuleExecutor.<SQLQueryExpr>builder()
+                        .withRule(new SQLExprParentSetterRule())
                         .withRule(new SubqueryRewriteRule())
                         .build();
                 ruleExecutor.executeOn(sqlExpr);
+                sqlExpr.accept(new NestedFieldRewriter());
 
                 if (isMulti(sqlExpr)) {
                     sqlExpr.accept(new TermFieldRewriter(client, TermRewriterFilter.MULTI_QUERY));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/NestedFieldRewriter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/nestedfield/NestedFieldRewriter.java
@@ -17,7 +17,6 @@ package com.amazon.opendistroforelasticsearch.sql.rewriter.nestedfield;
 
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
 import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
-import com.alibaba.druid.sql.ast.expr.SQLInSubQueryExpr;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitorAdapter;
 
@@ -82,15 +81,6 @@ public class NestedFieldRewriter extends MySqlASTVisitorAdapter {
         if (curScope().isAnyNestedField() && isNotGroupBy(query)) {
             new Select(query.getSelectList()).rewrite(curScope());
         }
-        return true;
-    }
-
-    /**
-     * Fix null parent problem which is required by SQLIdentifier.visit()
-     */
-    @Override
-    public boolean visit(SQLInSubQueryExpr subQuery) {
-        subQuery.getExpr().setParent(subQuery);
         return true;
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/parent/SQLExprParentSetter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/parent/SQLExprParentSetter.java
@@ -1,0 +1,35 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.rewriter.parent;
+
+import com.alibaba.druid.sql.ast.expr.SQLInSubQueryExpr;
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitorAdapter;
+
+/**
+ * Add the parent for the node in {@link SQLQueryExpr} if it is missing.
+ */
+public class SQLExprParentSetter extends MySqlASTVisitorAdapter {
+
+    /**
+     * Fix null parent problem which is required by SQLIdentifier.visit()
+     */
+    @Override
+    public boolean visit(SQLInSubQueryExpr subQuery) {
+        subQuery.getExpr().setParent(subQuery);
+        return true;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/parent/SQLExprParentSetterRule.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/parent/SQLExprParentSetterRule.java
@@ -1,0 +1,35 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.rewriter.parent;
+
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.amazon.opendistroforelasticsearch.sql.rewriter.RewriteRule;
+
+/**
+ * The {@link RewriteRule} which will apply {@link SQLExprParentSetter} for {@link SQLQueryExpr}
+ */
+public class SQLExprParentSetterRule implements RewriteRule<SQLQueryExpr> {
+
+    @Override
+    public boolean match(SQLQueryExpr expr) {
+        return true;
+    }
+
+    @Override
+    public void rewrite(SQLQueryExpr expr) {
+        expr.accept(new SQLExprParentSetter());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/NestedFieldRewriterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/NestedFieldRewriterTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static com.amazon.opendistroforelasticsearch.sql.util.SqlParserUtils.parse;
 import static java.util.stream.IntStream.range;
 import static org.junit.Assert.assertEquals;
 
@@ -397,15 +398,6 @@ public class NestedFieldRewriterTest {
             return expr;
         }
         return rewrite(expr);
-    }
-
-    private SQLQueryExpr parse(String sql) {
-        ElasticSqlExprParser parser = new ElasticSqlExprParser(sql);
-        SQLExpr expr = parser.expr();
-        if (parser.getLexer().token() != Token.EOF) {
-            throw new ParserException("Illegal sql: " + sql);
-        }
-        return (SQLQueryExpr) expr;
     }
 
     private SQLQueryExpr rewrite(SQLQueryExpr expr) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/parent/SQLExprParentSetterRuleTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/parent/SQLExprParentSetterRuleTest.java
@@ -1,0 +1,39 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.rewriter.parent;
+
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.amazon.opendistroforelasticsearch.sql.rewriter.parent.SQLExprParentSetterRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SQLExprParentSetterRuleTest {
+
+    @Mock
+    SQLQueryExpr queryExpr;
+
+    SQLExprParentSetterRule rule = new SQLExprParentSetterRule();
+
+    @Test
+    public void match() {
+        assertTrue(rule.match(queryExpr));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/parent/SQLExprParentSetterRuleTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/parent/SQLExprParentSetterRuleTest.java
@@ -28,9 +28,9 @@ import static org.junit.Assert.assertTrue;
 public class SQLExprParentSetterRuleTest {
 
     @Mock
-    SQLQueryExpr queryExpr;
+    private SQLQueryExpr queryExpr;
 
-    SQLExprParentSetterRule rule = new SQLExprParentSetterRule();
+    private SQLExprParentSetterRule rule = new SQLExprParentSetterRule();
 
     @Test
     public void match() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/parent/SQLExprParentSetterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/parent/SQLExprParentSetterTest.java
@@ -1,0 +1,45 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.rewriter.parent;
+
+import com.alibaba.druid.sql.ast.expr.SQLInSubQueryExpr;
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitorAdapter;
+import com.amazon.opendistroforelasticsearch.sql.util.SqlParserUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class SQLExprParentSetterTest {
+
+    @Test
+    public void testSQLInSubQueryExprHasParent() {
+        String sql =
+                "SELECT * FROM TbA " +
+                "WHERE a in (SELECT b FROM TbB)";
+        SQLQueryExpr expr = SqlParserUtils.parse(sql);
+        expr.accept(new SQLExprParentExistsValidator());
+    }
+
+    static class SQLExprParentExistsValidator extends MySqlASTVisitorAdapter {
+        @Override
+        public boolean visit(SQLInSubQueryExpr expr) {
+            assertNotNull(expr.getExpr().getParent());
+            return true;
+        }
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/SqlParserUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/SqlParserUtils.java
@@ -20,7 +20,7 @@ import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
 import com.alibaba.druid.sql.parser.ParserException;
 import com.alibaba.druid.sql.parser.Token;
 import com.amazon.opendistroforelasticsearch.sql.parser.ElasticSqlExprParser;
-import com.amazon.opendistroforelasticsearch.sql.rewriter.nestedfield.NestedFieldRewriter;
+import com.amazon.opendistroforelasticsearch.sql.rewriter.parent.SQLExprParentSetter;
 
 /**
  * Test utils class include all SQLExpr related method.
@@ -38,7 +38,8 @@ public class SqlParserUtils {
         if (parser.getLexer().token() != Token.EOF) {
             throw new ParserException("Illegal sql: " + sql);
         }
-        expr.accept(new NestedFieldRewriter());
+        SQLQueryExpr queryExpr = (SQLQueryExpr) expr;
+        queryExpr.accept(new SQLExprParentSetter());
         return (SQLQueryExpr) expr;
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add parent for SQLExpr in AST if missing. In current implementation, this logic is in NestedFiledRewriter, this CR trying to seperate this logic out of it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
