### PR TITLE
Support to parse index name with dot/period at start (issue#121)

### DIFF
--- a/src/main/antlr/OpenDistroSqlParser.g4
+++ b/src/main/antlr/OpenDistroSqlParser.g4
@@ -230,6 +230,7 @@ uid
 
 simpleId
     : ID
+    | DOT_ID
     | STRING_LITERAL
     | keywordsCanBeId
     | functionNameBase

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/ElasticSqlExprParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/ElasticSqlExprParser.java
@@ -296,6 +296,9 @@ public class ElasticSqlExprParser extends SQLExprParser {
             case GROUP:
                 lexer.nextToken();
                 return primaryRest(new SQLIdentifierExpr(lexer.stringVal()));
+            case DOT:
+                lexer.nextToken();
+                return primaryRest(new SQLIdentifierExpr("." + lexer.stringVal()));
             default:
                 return super.primary();
         }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/SyntaxAnalysisTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/SyntaxAnalysisTest.java
@@ -104,13 +104,9 @@ public class SyntaxAnalysisTest {
         );
     }
 
-    /** This is not supported for now */
     @Test
-    public void systemIndexNameShouldThrowException() {
-        expectValidationFailWithErrorMessage(
-            "SELECT * FROM .kibana",
-            "offending symbol [.kibana]"
-        );
+    public void systemIndexNameShouldPass() {
+        validate("SELECT * FROM .kibana");
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SqlParserTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SqlParserTest.java
@@ -546,6 +546,14 @@ public class SqlParserTest {
     }
 
     @Test
+    public void systemIndexNameTest() throws SqlParseException {
+        String query = "SELECT * FROM .kibana";
+        SQLExpr sqlExpr = queryToExpr(query);
+        Select select = parser.parseSelect((SQLQueryExpr) sqlExpr);
+        Assert.assertEquals(".kibana", select.getFrom().get(0).getIndex());
+    }
+
+    @Test
     public void indexWithSemiColons() throws SqlParseException {
         String query = "select * from some;index";
         SQLExpr sqlExpr = queryToExpr(query);


### PR DESCRIPTION
*Issue #, if available:*

* [#121 Dot/period at start of index name fails to parse](https://github.com/opendistro-for-elasticsearch/sql/issues/121)

*Description of changes:*

* Support to parse index name with dot/period at start.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
