### PR TITLE
Remove table alias from WHERE clause fields

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SqlParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SqlParser.java
@@ -95,6 +95,10 @@ public class SqlParser {
 
         select.setWhere(whereParser.findWhere());
 
+        if (select.getWhere() != null) {
+            removeAliasPrefix(select.getWhere(), query.getFrom().getAlias());
+        }
+
         select.fillSubQueries();
 
         select.getHints().addAll(parseHints(query.getHints()));
@@ -320,7 +324,6 @@ public class SqlParser {
         // check that operator IS or IS NOT
         SQLBinaryOperator operator = binaryExpr.getOperator();
         return operator == SQLBinaryOperator.Is || operator == SQLBinaryOperator.IsNot;
-
     }
 
     private void findLimit(MySqlSelectQueryBlock.Limit limit, Select select) {
@@ -562,7 +565,9 @@ public class SqlParser {
         if (where instanceof Condition) {
             Condition cond = (Condition) where;
             String aliasPrefix = alias + ".";
-            cond.setName(cond.getName().replaceFirst(aliasPrefix, ""));
+            if (cond.getName() != null) {
+                cond.setName(cond.getName().replaceFirst(aliasPrefix, ""));
+            }
             return;
         }
         for (Where innerWhere : where.getWheres()) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/WhereParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/WhereParser.java
@@ -118,7 +118,7 @@ public class WhereParser {
             parseWhere(((SQLNotExpr) expr).getExpr(), where);
             negateWhere(where);
         } else {
-            explanCond("AND", expr, where);
+            explainCond("AND", expr, where);
         }
     }
 
@@ -150,7 +150,7 @@ public class WhereParser {
                             + " " + operator + " " + Util.expr2Object(bExpr.getRight(), "'"))
             );
 
-            explanCond("AND", sqlMethodInvokeExpr, where);
+            explainCond("AND", sqlMethodInvokeExpr, where);
             return true;
         }
         return false;
@@ -185,7 +185,7 @@ public class WhereParser {
             sqlMethodInvokeExpr.addParameter(new SQLCharExpr(
                     "doc['" + leftProperty + "'].value " + operator + " doc['" + rightProperty + "'].value"));
 
-            explanCond("AND", sqlMethodInvokeExpr, where);
+            explainCond("AND", sqlMethodInvokeExpr, where);
             return true;
         }
         return false;
@@ -226,11 +226,11 @@ public class WhereParser {
             parseWhere(((SQLNotExpr) sub).getExpr(), subWhere);
             negateWhere(subWhere);
         } else {
-            explanCond(bExpr.getOperator().name, sub, where);
+            explainCond(bExpr.getOperator().name, sub, where);
         }
     }
 
-    private void explanCond(String opear, SQLExpr expr, Where where) throws SqlParseException {
+    private void explainCond(String opear, SQLExpr expr, Where where) throws SqlParseException {
         if (expr instanceof SQLBinaryOpExpr) {
             SQLBinaryOpExpr soExpr = (SQLBinaryOpExpr) expr;
             boolean methodAsOpear = false;
@@ -506,7 +506,7 @@ public class WhereParser {
 
             where.addWhere(condition);
         } else {
-            throw new SqlParseException("err find condition " + expr.getClass());
+            throw new SqlParseException("error parsing condition for " + expr.getClass());
         }
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ExplainIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ExplainIT.java
@@ -202,6 +202,17 @@ public class ExplainIT extends SQLIntegTestCase {
         Assert.assertThat(result.replaceAll("\\s+", ""), equalTo(expectedOutput.replaceAll("\\s+", "")));
     }
 
+    @Test
+    public void columnAliasInWhere() throws IOException {
+        String query = "SELECT a.email, a.age " +
+                       "FROM elasticsearch-sql_test_index_account a " +
+                       "WHERE a.age > 33 OR a.lastname LIKE 'Nels%'";
+        String result = explainQuery(query);
+        assertThat(result, containsString("range\":{\"age"));
+        assertThat(result, containsString("wildcard\":{\"lastname\":{\"wildcard\":\"Nels*"));
+        assertThat(result, containsString("\"includes\":[\"email\",\"age\"]"));
+    }
+
     public void testContentTypeOfExplainRequestShouldBeJson() throws IOException {
         String query = makeRequest("SELECT firstname FROM elasticsearch-sql_test_index_account");
         Request request = getSqlRequest(query, true);


### PR DESCRIPTION
Issue #99

*Description of changes:*
This changes fixes the table alias problem, where the table alias is still attached to field name in Elasticsearch DSL query. Also includes some refactoring.

The following query 
```
POST _opendistro/_sql/_explain
{
  "query": "SELECT a.age FROM accounts a WHERE a.age = 10 or a.name LIKE 'Abb%'"
}

```

should produce this

```
{
  "term": {
    "age": {
      "value": 10,
      "boost": 1
    }
  }
},
{
  "wildcard": {
    "name": {
      "wildcard": "Abb*",
      "boost": 1
    }
  }
}
```
instead of this , leading to incorrect results.

```
{
  "term": {
    "a.age": { <----
      "value": 10,
      "boost": 1
    }
  }
},
{
  "wildcard": {
    "a.name": { <-----
      "wildcard": "Abb*",
      "boost": 1
    }
  }
}
```


*Testing:*
- Passes Gradle build
- Passes existing integration and unit tests
- Added new integration test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
