### PR TITLE
Support to parse backticks quoted identifiers for larger coverage

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/identifier/UnquoteIdentifierRule.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/identifier/UnquoteIdentifierRule.java
@@ -16,13 +16,11 @@
 package com.amazon.opendistroforelasticsearch.sql.rewriter.identifier;
 
 import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
-import com.alibaba.druid.sql.ast.expr.SQLPropertyExpr;
 import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
 import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
 import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
 import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitorAdapter;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.RewriteRule;
-import com.amazon.opendistroforelasticsearch.sql.utils.StringUtils;
 
 import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.unquoteFullColumn;
 import static com.amazon.opendistroforelasticsearch.sql.utils.StringUtils.unquoteSingleField;
@@ -55,32 +53,6 @@ public class UnquoteIdentifierRule extends MySqlASTVisitorAdapter implements Rew
         }
         selectItem.setAlias(unquoteSingleField(selectItem.getAlias(), "`"));
         return true;
-    }
-
-    /**
-     *
-     * This method is to adjust the AST in the cases where the alias of index is quoted
-     * (e.g. SELECT `b`.lastname FROM bank AS `b`).
-     *
-     * In this case, the druid parser constructs a SQLPropertyExpr for the field "`b`.lastname", with owner of a
-     * SQLIdentifierExpr "`b`" and name of "lastname".
-     *
-     * This method prevent the visitor from visitin the SQLPropertyExpr in this case,
-     * and corrects AST with a SQLSelectItem object to have SQLIdentifier of "b.lastname".
-     *
-     * Used in the case where alias of index and the field name are both quoted
-     * (e.g. SELECT `b`.`lastname` FROM bank AS `b`).
-     */
-    @Override
-    public boolean visit(SQLPropertyExpr propertyExpr) {
-        String fieldName = ((SQLIdentifierExpr) propertyExpr.getOwner()).getName();
-        if (!StringUtils.isQuoted(fieldName, "`")) {
-            return true;
-        }
-        String correctedIdentifier = unquoteSingleField(fieldName) + "." + unquoteSingleField(propertyExpr.getName());
-        SQLSelectItem selectItem = (SQLSelectItem) propertyExpr.getParent();
-        selectItem.setExpr(new SQLIdentifierExpr(correctedIdentifier));
-        return false;
     }
 
     @Override

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryIT.java
@@ -1686,6 +1686,16 @@ public class QueryIT extends SQLIntegTestCase {
                 executeQuery("SELECT lastname FROM bank", "jdbc"),
                 executeQuery("SELECT `bank`.`lastname` FROM `bank`", "jdbc")
         );
+
+        assertEquals(
+                executeQuery(
+                        "SELECT `b`.`age` AS `AGE`, AVG(`b`.`balance`) FROM `bank` AS `b` " +
+                                "WHERE ABS(`b`.`age`) > 20 GROUP BY `b`.`age` ORDER BY `b`.`age`",
+                        "jdbc"),
+                executeQuery("SELECT b.age AS AGE, AVG(balance) FROM bank AS b " +
+                                "WHERE ABS(age) > 20 GROUP BY b.age ORDER BY b.age",
+                        "jdbc")
+        );
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/identifier/UnquoteIdentifierRuleTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/identifier/UnquoteIdentifierRuleTest.java
@@ -61,6 +61,17 @@ public class UnquoteIdentifierRuleTest {
         ).shouldBeAfterRewrite("SELECT bank.lastname FROM bank");
     }
 
+    @Test
+    public void queryWithQuotedAggrAndFunc() {
+        query("" +
+                "SELECT `b`.`lastname` AS `name`, AVG(`b`.`balance`) FROM `bank` AS `b` " +
+                "WHERE ABS(`b`.`age`) > 20 GROUP BY `b`.`gender` ORDER BY `b`.`age`"
+        ).shouldBeAfterRewrite(
+                "SELECT b.lastname AS name, AVG(b.balance) FROM bank AS b " +
+                        "WHERE ABS(b.age) > 20 GROUP BY b.gender ORDER BY b.age"
+        );
+    }
+
     private QueryAssertion query(String sql) {
         return new QueryAssertion(sql);
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/identifier/UnquoteIdentifierRuleTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/identifier/UnquoteIdentifierRuleTest.java
@@ -65,10 +65,10 @@ public class UnquoteIdentifierRuleTest {
     public void queryWithQuotedAggrAndFunc() {
         query("" +
                 "SELECT `b`.`lastname` AS `name`, AVG(`b`.`balance`) FROM `bank` AS `b` " +
-                "WHERE ABS(`b`.`age`) > 20 GROUP BY `b`.`age` ORDER BY `b`.`age`"
+                "WHERE ABS(`b`.`age`) > 20 GROUP BY `b`.`lastname` ORDER BY `b`.`lastname`"
         ).shouldBeAfterRewrite(
                 "SELECT b.lastname AS name, AVG(b.balance) FROM bank AS b " +
-                        "WHERE ABS(b.age) > 20 GROUP BY b.age ORDER BY b.age"
+                        "WHERE ABS(b.age) > 20 GROUP BY b.lastname ORDER BY b.lastname"
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/identifier/UnquoteIdentifierRuleTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/identifier/UnquoteIdentifierRuleTest.java
@@ -65,10 +65,10 @@ public class UnquoteIdentifierRuleTest {
     public void queryWithQuotedAggrAndFunc() {
         query("" +
                 "SELECT `b`.`lastname` AS `name`, AVG(`b`.`balance`) FROM `bank` AS `b` " +
-                "WHERE ABS(`b`.`age`) > 20 GROUP BY `b`.`gender` ORDER BY `b`.`age`"
+                "WHERE ABS(`b`.`age`) > 20 GROUP BY `b`.`age` ORDER BY `b`.`age`"
         ).shouldBeAfterRewrite(
                 "SELECT b.lastname AS name, AVG(b.balance) FROM bank AS b " +
-                        "WHERE ABS(b.age) > 20 GROUP BY b.gender ORDER BY b.age"
+                        "WHERE ABS(b.age) > 20 GROUP BY b.age ORDER BY b.age"
         );
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Deleted the visit SQLPropertyExpr rewritten method from UnquoteIdentifierRule, and modified the ElasticSqlExprParser to support a larger coverage of parsing quoted identifier cases.

* Added UT and IT for these complex cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
