### PR TITLE
Support ordinal aliases in GROUP and ORDER BY clauses

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
@@ -45,6 +45,7 @@ import com.amazon.opendistroforelasticsearch.sql.rewriter.alias.TableAliasPrefix
 import com.amazon.opendistroforelasticsearch.sql.rewriter.matchtoterm.TermFieldRewriter;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.matchtoterm.TermFieldRewriter.TermRewriterFilter;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.nestedfield.NestedFieldRewriter;
+import com.amazon.opendistroforelasticsearch.sql.rewriter.ordinal.OrdinalRewriterRule;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.parent.SQLExprParentSetterRule;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.subquery.SubQueryRewriteRule;
 import org.elasticsearch.client.Client;
@@ -80,6 +81,7 @@ public class ESActionFactory {
                         .withRule(new SQLExprParentSetterRule())
                         .withRule(new TableAliasPrefixRemoveRule())
                         .withRule(new SubQueryRewriteRule())
+                        .withRule(new OrdinalRewriterRule(sql))
                         .build();
                 ruleExecutor.executeOn(sqlExpr);
                 sqlExpr.accept(new NestedFieldRewriter());
@@ -173,9 +175,8 @@ public class ESActionFactory {
         SQLExpr expr = parser.expr();
 
         if (parser.getLexer().token() != Token.EOF) {
-            throw new ParserException("illegal sql expr : " + sql);
+            throw new ParserException("Illegal SQL expression : " + sql);
         }
-
         return expr;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
@@ -80,10 +80,10 @@ public class ESActionFactory {
 
                 RewriteRuleExecutor<SQLQueryExpr> ruleExecutor = RewriteRuleExecutor.builder()
                         .withRule(new SQLExprParentSetterRule())
+                        .withRule(new OrdinalRewriterRule(sql))
                         .withRule(new UnquoteIdentifierRule())
                         .withRule(new TableAliasPrefixRemoveRule())
                         .withRule(new SubQueryRewriteRule())
-                        .withRule(new OrdinalRewriterRule(sql))
                         .build();
                 ruleExecutor.executeOn(sqlExpr);
                 sqlExpr.accept(new NestedFieldRewriter());

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/ordinal/OrdinalRewriterRule.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/ordinal/OrdinalRewriterRule.java
@@ -26,9 +26,7 @@ import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
 import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlSelectGroupByExpr;
 import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
 import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitorAdapter;
-import com.alibaba.druid.sql.parser.ParserException;
 import com.alibaba.druid.sql.parser.SQLExprParser;
-import com.alibaba.druid.sql.parser.Token;
 import com.amazon.opendistroforelasticsearch.sql.parser.ElasticSqlExprParser;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.RewriteRule;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.RewriteRuleExecutor;
@@ -57,7 +55,7 @@ public class OrdinalRewriterRule implements RewriteRule<SQLQueryExpr> {
     }
 
     @Override
-    public boolean match(SQLQueryExpr root) throws SQLFeatureNotSupportedException {
+    public boolean match(SQLQueryExpr root) {
         SQLSelectQuery sqlSelectQuery = root.getSubQuery().getQuery();
          if (!(sqlSelectQuery instanceof MySqlSelectQueryBlock)) {
              // it could be SQLUnionQuery
@@ -70,12 +68,18 @@ public class OrdinalRewriterRule implements RewriteRule<SQLQueryExpr> {
             return false;
         }
 
-        // we cannot clone SQLSelectItem, so we need similar objects to assign to GroupBy and OrderBy items
-        sqlExprGroupCopy = generateAST();
-        sqlExprOrderCopy = generateAST();
+        return true;
+    }
 
-        collectOrdinalAliases(sqlExprGroupCopy, groupOrdinalToExpr);
-        collectOrdinalAliases(sqlExprOrderCopy, orderOrdinalToExpr);
+    @Override
+    public void rewrite(SQLQueryExpr root) throws SQLFeatureNotSupportedException {
+
+        // we cannot clone SQLSelectItem, so we need similar objects to assign to GroupBy and OrderBy items
+        sqlExprGroupCopy = toSqlExpr();
+        sqlExprOrderCopy = toSqlExpr();
+
+        mapOrdinalIndexesToSelectItems(sqlExprGroupCopy, groupOrdinalToExpr);
+        mapOrdinalIndexesToSelectItems(sqlExprOrderCopy, orderOrdinalToExpr);
 
         if (groupOrdinalToExpr.isEmpty()) {
             // orderOrdinalToExpr and groupOrdinalToExpr should be identical
@@ -91,53 +95,9 @@ public class OrdinalRewriterRule implements RewriteRule<SQLQueryExpr> {
             .build();
 
         ruleExecutor.executeOn(sqlExprGroupCopy);
-        ruleExecutor.executeOn(sqlExprGroupCopy);
-        return true;
-    }
+        ruleExecutor.executeOn(sqlExprOrderCopy);
 
-    @Override
-    public void rewrite(SQLQueryExpr root) {
         changeOrdinalAliasInGroupAndOrderBy(root);
-    }
-
-    private boolean hasGroupByWithOrdinals(MySqlSelectQueryBlock query) {
-        if (query.getGroupBy() == null) {
-            return false;
-        } else if (query.getGroupBy().getItems().isEmpty()){
-            return false;
-        }
-
-        return query.getGroupBy().getItems().stream().anyMatch(x ->
-            x instanceof MySqlSelectGroupByExpr && ((MySqlSelectGroupByExpr) x).getExpr() instanceof SQLIntegerExpr
-        );
-    }
-
-    private boolean hasOrderByWithOrdinals(MySqlSelectQueryBlock query) {
-        if (query.getOrderBy() == null) {
-            return false;
-        } else if (query.getOrderBy().getItems().isEmpty()){
-            return false;
-        }
-
-        return query.getOrderBy().getItems().stream().anyMatch(x ->
-            x.getExpr() instanceof SQLIntegerExpr
-            || (
-                x.getExpr() instanceof SQLBinaryOpExpr
-                && ((SQLBinaryOpExpr) x.getExpr()).getLeft() instanceof SQLIntegerExpr
-            )
-        );
-    }
-
-    private void collectOrdinalAliases(SQLQueryExpr root, Map<Integer, SQLExpr> map) {
-        root.accept(new MySqlASTVisitorAdapter() {
-            private Integer count = 0;
-
-            @Override
-            public boolean visit(SQLSelectItem select) {
-                map.put(++count, select.getExpr());
-                return false;
-            }
-        });
     }
 
     private void changeOrdinalAliasInGroupAndOrderBy(SQLQueryExpr root) {
@@ -170,8 +130,8 @@ public class OrdinalRewriterRule implements RewriteRule<SQLQueryExpr> {
                     checkInvalidOrdinal(newExpr, ordinalValue, orderException);
                     orderByItem.setExpr(newExpr);
                     newExpr.setParent(orderByItem);
-                }else if (expr instanceof SQLBinaryOpExpr
-                          && ((SQLBinaryOpExpr) expr).getLeft() instanceof SQLIntegerExpr) {
+                } else if (expr instanceof SQLBinaryOpExpr
+                    && ((SQLBinaryOpExpr) expr).getLeft() instanceof SQLIntegerExpr) {
                     // support ORDER BY IS NULL/NOT NULL
                     SQLBinaryOpExpr binaryOpExpr = (SQLBinaryOpExpr) expr;
                     SQLIntegerExpr integerExpr = (SQLIntegerExpr) binaryOpExpr.getLeft();
@@ -188,18 +148,59 @@ public class OrdinalRewriterRule implements RewriteRule<SQLQueryExpr> {
         });
     }
 
-    private SQLQueryExpr generateAST() {
-        return (SQLQueryExpr) toSqlExpr(sql);
+    private void mapOrdinalIndexesToSelectItems(SQLQueryExpr root, Map<Integer, SQLExpr> map) {
+        root.accept(new MySqlASTVisitorAdapter() {
+            private Integer count = 0;
+
+            @Override
+            public boolean visit(SQLSelectItem select) {
+                map.put(++count, select.getExpr());
+                return false;
+            }
+        });
     }
 
-    private static SQLExpr toSqlExpr(String sql) {
+    private boolean hasGroupByWithOrdinals(MySqlSelectQueryBlock query) {
+        if (query.getGroupBy() == null) {
+            return false;
+        } else if (query.getGroupBy().getItems().isEmpty()){
+            return false;
+        }
+
+        return query.getGroupBy().getItems().stream().anyMatch(x ->
+            x instanceof MySqlSelectGroupByExpr && ((MySqlSelectGroupByExpr) x).getExpr() instanceof SQLIntegerExpr
+        );
+    }
+
+    private boolean hasOrderByWithOrdinals(MySqlSelectQueryBlock query) {
+        if (query.getOrderBy() == null) {
+            return false;
+        } else if (query.getOrderBy().getItems().isEmpty()){
+            return false;
+        }
+
+        /**
+         * The second condition checks valid AST that meets ORDER BY IS NULL/NOT NULL condition
+         *
+         *            SQLSelectOrderByItem
+         *                      |
+         *             SQLBinaryOpExpr (Is || IsNot)
+         *                    /  \
+         *    SQLIdentifierExpr  SQLNullExpr
+         */
+        return query.getOrderBy().getItems().stream().anyMatch(x ->
+            x.getExpr() instanceof SQLIntegerExpr
+            || (
+                x.getExpr() instanceof SQLBinaryOpExpr
+                && ((SQLBinaryOpExpr) x.getExpr()).getLeft() instanceof SQLIntegerExpr
+            )
+        );
+    }
+
+    private SQLQueryExpr toSqlExpr() {
         SQLExprParser parser = new ElasticSqlExprParser(sql);
         SQLExpr expr = parser.expr();
-
-        if (parser.getLexer().token() != Token.EOF) {
-            throw new ParserException("Illegal SQL expression : " + sql);
-        }
-        return expr;
+        return (SQLQueryExpr) expr;
     }
 
     private void checkInvalidOrdinal(SQLExpr expr, Integer ordinal, String exception){

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/ordinal/OrdinalRewriterRule.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/ordinal/OrdinalRewriterRule.java
@@ -33,6 +33,7 @@ import com.amazon.opendistroforelasticsearch.sql.parser.ElasticSqlExprParser;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.RewriteRule;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.RewriteRuleExecutor;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.alias.TableAliasPrefixRemoveRule;
+import com.amazon.opendistroforelasticsearch.sql.rewriter.identifier.UnquoteIdentifierRule;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.matchtoterm.VerificationException;
 
 import java.sql.SQLFeatureNotSupportedException;
@@ -85,6 +86,7 @@ public class OrdinalRewriterRule implements RewriteRule<SQLQueryExpr> {
 
         // we need to rewrite the generated syntax tree to match the original syntax tree Select clause
         ruleExecutor = RewriteRuleExecutor.builder()
+            .withRule(new UnquoteIdentifierRule())
             .withRule(new TableAliasPrefixRemoveRule())
             .build();
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/ordinal/OrdinalRewriterRule.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/ordinal/OrdinalRewriterRule.java
@@ -1,0 +1,196 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+
+package com.amazon.opendistroforelasticsearch.sql.rewriter.ordinal;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
+import com.alibaba.druid.sql.ast.statement.SQLSelectOrderByItem;
+import com.alibaba.druid.sql.ast.statement.SQLSelectQuery;
+import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlSelectGroupByExpr;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitorAdapter;
+import com.alibaba.druid.sql.parser.ParserException;
+import com.alibaba.druid.sql.parser.SQLExprParser;
+import com.alibaba.druid.sql.parser.Token;
+import com.amazon.opendistroforelasticsearch.sql.parser.ElasticSqlExprParser;
+import com.amazon.opendistroforelasticsearch.sql.rewriter.RewriteRule;
+import com.amazon.opendistroforelasticsearch.sql.rewriter.RewriteRuleExecutor;
+import com.amazon.opendistroforelasticsearch.sql.rewriter.alias.TableAliasPrefixRemoveRule;
+
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Rewrite rule for changing ordinal alias in order by and group by to actual select field.
+ */
+public class OrdinalRewriterRule implements RewriteRule<SQLQueryExpr> {
+
+    private SQLQueryExpr sqlExprGroupCopy;
+    private SQLQueryExpr sqlExprOrderCopy;
+    private final String sql;
+    private final Map<Integer, SQLExpr> groupOrdinalToExpr = new HashMap<>();
+    private final Map<Integer, SQLExpr> orderOrdinalToExpr = new HashMap<>();
+    private RewriteRuleExecutor<SQLQueryExpr> ruleExecutor;
+
+    public OrdinalRewriterRule(String sql) {
+        this.sql = sql;
+    }
+
+    @Override
+    public boolean match(SQLQueryExpr root) throws SQLFeatureNotSupportedException {
+        SQLSelectQuery sqlSelectQuery = root.getSubQuery().getQuery();
+         if (!(sqlSelectQuery instanceof MySqlSelectQueryBlock)) {
+             // it could be SQLUnionQuery
+             return false;
+         }
+
+        MySqlSelectQueryBlock query = (MySqlSelectQueryBlock) sqlSelectQuery;
+
+        if (!hasGroupBy(query) && !hasOrderBy(query)) {
+            return false;
+        }
+
+        // we cannot clone SQLSelectItem, so we need similar objects to assign to GroupBy and OrderBy items
+        sqlExprGroupCopy = generateAST();
+        sqlExprOrderCopy = generateAST();
+
+        collectOrdinalAliases(sqlExprGroupCopy, groupOrdinalToExpr);
+        collectOrdinalAliases(sqlExprOrderCopy, orderOrdinalToExpr);
+
+        if (groupOrdinalToExpr.isEmpty()) {
+            // orderOrdinalToExpr and groupOrdinalToExpr should be identical
+            // because they are generated from similar syntax trees
+            // checking for groupOrdinalToExpr or orderOrdinalToExpr is enough
+            return false;
+        }
+
+        // we need to rewrite the generated syntax tree to match the original syntax tree Select clause
+        ruleExecutor = RewriteRuleExecutor.builder()
+            .withRule(new TableAliasPrefixRemoveRule())
+            .build();
+
+        ruleExecutor.executeOn(sqlExprGroupCopy);
+        ruleExecutor.executeOn(sqlExprGroupCopy);
+        return true;
+    }
+
+    @Override
+    public void rewrite(SQLQueryExpr root) {
+        changeOrdinalAliasInGroupAndOrderBy(root);
+    }
+
+    private boolean hasGroupBy(MySqlSelectQueryBlock query) {
+        if (query.getGroupBy() == null) {
+            return false;
+        } else if (query.getGroupBy().getItems().isEmpty()){
+            return false;
+        }
+
+        return query.getGroupBy().getItems().stream().anyMatch(x ->
+            x instanceof MySqlSelectGroupByExpr && ((MySqlSelectGroupByExpr) x).getExpr() instanceof SQLIntegerExpr
+        );
+    }
+
+    private boolean hasOrderBy(MySqlSelectQueryBlock query) {
+        if (query.getOrderBy() == null) {
+            return false;
+        } else if (query.getOrderBy().getItems().isEmpty()){
+            return false;
+        }
+
+        return query.getOrderBy().getItems().stream().anyMatch(x ->
+            x.getExpr() instanceof SQLIntegerExpr
+            || (
+                x.getExpr() instanceof SQLBinaryOpExpr
+                && ((SQLBinaryOpExpr) x.getExpr()).getLeft() instanceof SQLIntegerExpr
+            )
+        );
+    }
+
+    private void collectOrdinalAliases(SQLQueryExpr root, Map<Integer, SQLExpr> map) {
+        root.accept(new MySqlASTVisitorAdapter() {
+            private Integer count = 0;
+
+            @Override
+            public boolean visit(SQLSelectItem select) {
+                map.put(++count, select.getExpr());
+                return false;
+            }
+        });
+    }
+
+    private void changeOrdinalAliasInGroupAndOrderBy(SQLQueryExpr root) {
+        root.accept(new MySqlASTVisitorAdapter() {
+
+            @Override
+            public boolean visit(MySqlSelectGroupByExpr groupByExpr) {
+                SQLExpr expr = groupByExpr.getExpr();
+                if (expr instanceof SQLIntegerExpr) {
+                    Integer ordinalValue = ((SQLIntegerExpr) expr).getNumber().intValue();
+                    SQLExpr newExpr = groupOrdinalToExpr.get(ordinalValue);
+                    groupByExpr.setExpr(newExpr);
+                    newExpr.setParent(groupByExpr);
+                }
+                return false;
+            }
+
+            @Override
+            public boolean visit(SQLSelectOrderByItem orderByItem) {
+                SQLExpr expr = orderByItem.getExpr();
+                Integer ordinalValue;
+
+                if (expr instanceof SQLIntegerExpr) {
+                    ordinalValue = ((SQLIntegerExpr) expr).getNumber().intValue();
+                    SQLExpr newExpr = orderOrdinalToExpr.get(ordinalValue);
+
+                    orderByItem.setExpr(newExpr);
+                    newExpr.setParent(orderByItem);
+                }else if (expr instanceof SQLBinaryOpExpr
+                          && ((SQLBinaryOpExpr) expr).getLeft() instanceof SQLIntegerExpr) {
+                    // support ORDER BY IS NULL/NOT NULL
+                    SQLBinaryOpExpr binaryOpExpr = (SQLBinaryOpExpr) expr;
+                    SQLIntegerExpr integerExpr = (SQLIntegerExpr) binaryOpExpr.getLeft();
+
+                    ordinalValue = integerExpr.getNumber().intValue();
+                    SQLExpr newExpr = orderOrdinalToExpr.get(ordinalValue);
+                    binaryOpExpr.setLeft(newExpr);
+                    newExpr.setParent(binaryOpExpr);
+                }
+
+                return false;
+            }
+        });
+    }
+
+    private SQLQueryExpr generateAST() {
+        return (SQLQueryExpr) toSqlExpr(sql);
+    }
+
+    private static SQLExpr toSqlExpr(String sql) {
+        SQLExprParser parser = new ElasticSqlExprParser(sql);
+        SQLExpr expr = parser.expr();
+
+        if (parser.getLexer().token() != Token.EOF) {
+            throw new ParserException("Illegal SQL expression : " + sql);
+        }
+        return expr;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/ordinal/OrdinalRewriterRule.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/ordinal/OrdinalRewriterRule.java
@@ -34,7 +34,14 @@ import java.util.List;
 
 /**
  * Rewrite rule for changing ordinal alias in order by and group by to actual select field.
+ * Since we cannot clone or deepcopy the Druid SQL objects, we need to generate the
+ * two syntax tree from the  original query to map Group By and Order By fields with ordinal alias
+ * to Select fields in newly generated syntax tree.
+ *
+ * This rewriter assumes that all the backticks have been removed from identifiers.
+ * It also assumes that table alias have been removed from SELECT, WHERE, GROUP BY, ORDER BY fields.
  */
+
 public class OrdinalRewriterRule implements RewriteRule<SQLQueryExpr> {
 
     private final String sql;
@@ -52,7 +59,6 @@ public class OrdinalRewriterRule implements RewriteRule<SQLQueryExpr> {
          }
 
         MySqlSelectQueryBlock query = (MySqlSelectQueryBlock) sqlSelectQuery;
-
         if (!hasGroupByWithOrdinals(query) && !hasOrderByWithOrdinals(query)) {
             return false;
         }
@@ -61,7 +67,6 @@ public class OrdinalRewriterRule implements RewriteRule<SQLQueryExpr> {
 
     @Override
     public void rewrite(SQLQueryExpr root) {
-
         // we cannot clone SQLSelectItem, so we need similar objects to assign to GroupBy and OrderBy items
         SQLQueryExpr sqlExprGroupCopy = toSqlExpr();
         SQLQueryExpr sqlExprOrderCopy = toSqlExpr();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/OrdinalAliasRewriterIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/OrdinalAliasRewriterIT.java
@@ -50,13 +50,6 @@ public class OrdinalAliasRewriterIT extends SQLIntegTestCase {
         assertThat(actual, equalTo(expected));
     }
 
-
-    @Test
-    public void sometest() {
-        String expected = executeQuery(StringUtils.format(
-            "SELECT `lastname` FROM %s AS b GROUP BY `lastname` LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
-    }
-
     @Test
     public void selectFieldiWithBacticksGroupByOrdinal() {
         String expected = executeQuery(StringUtils.format(

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/OrdinalAliasRewriterIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/OrdinalAliasRewriterIT.java
@@ -1,0 +1,167 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.esintgtest;
+
+import com.amazon.opendistroforelasticsearch.sql.utils.StringUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class OrdinalAliasRewriterIT extends SQLIntegTestCase {
+
+    @Override
+    protected void init() throws Exception {
+        loadIndex(Index.ACCOUNT);
+    }
+
+    // tests query results with jdbc output
+    @Test
+    public void simpleGroupByOrdinal() {
+        String expected = executeQuery(StringUtils.format(
+            "SELECT lastname FROM %s AS b GROUP BY lastname LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        String actual = executeQuery(StringUtils.format(
+            "SELECT lastname FROM %s AS b GROUP BY 1 LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void multipleGroupByOrdinal() {
+        String expected = executeQuery(StringUtils.format(
+            "SELECT lastname, firstname, age FROM %s AS b GROUP BY firstname, age, lastname LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        String actual = executeQuery(StringUtils.format(
+            "SELECT lastname, firstname, age FROM %s AS b GROUP BY 2, 3, 1 LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        assertThat(actual, equalTo(expected));
+    }
+
+
+    @Test
+    public void sometest() {
+        String expected = executeQuery(StringUtils.format(
+            "SELECT `lastname` FROM %s AS b GROUP BY `lastname` LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+    }
+
+    @Test
+    public void selectFieldiWithBacticksGroupByOrdinal() {
+        String expected = executeQuery(StringUtils.format(
+            "SELECT `lastname` FROM %s AS b GROUP BY `lastname` LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        String actual = executeQuery(StringUtils.format(
+            "SELECT `lastname` FROM %s AS b GROUP BY 1 LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void selectFieldiWithBacticksAndTableAliasGroupByOrdinal() {
+        String expected = executeQuery(StringUtils.format(
+            "SELECT `b`.`lastname`, `age`, firstname FROM %s AS b GROUP BY `age`, `b`.`lastname` , firstname LIMIT 10",
+            TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        String actual = executeQuery(StringUtils.format(
+            "SELECT `b`.`lastname`, `age`, firstname  FROM %s AS b GROUP BY 2, 1, 3 LIMIT 10",
+            TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void simpleOrderByOrdinal() {
+        String expected = executeQuery(StringUtils.format(
+            "SELECT lastname FROM %s AS b ORDER BY lastname LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        String actual = executeQuery(StringUtils.format(
+            "SELECT lastname FROM %s AS b ORDER BY 1 LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void multipleOrderByOrdinal() {
+        String expected = executeQuery(StringUtils.format(
+            "SELECT lastname, firstname, age FROM %s AS b ORDER BY firstname, age, lastname LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        String actual = executeQuery(StringUtils.format(
+            "SELECT lastname, firstname, age FROM %s AS b ORDER BY 2, 3, 1 LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void selectFieldiWithBacticksOrderByOrdinal() {
+        String expected = executeQuery(StringUtils.format(
+            "SELECT `lastname` FROM %s AS b ORDER BY `lastname` LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        String actual = executeQuery(StringUtils.format(
+            "SELECT `lastname` FROM %s AS b ORDER BY 1 LIMIT 3", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void selectFieldiWithBacticksAndTableAliasOrderByOrdinal() {
+        String expected = executeQuery(StringUtils.format(
+            "SELECT `b`.`lastname` FROM %s AS b ORDER BY `b`.`lastname` LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        String actual = executeQuery(StringUtils.format(
+            "SELECT `b`.`lastname` FROM %s AS b ORDER BY 1 LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        assertThat(actual, equalTo(expected));
+    }
+
+    // ORDER BY IS NULL/NOT NULL
+    @Test
+    public void selectFieldiWithBacticksAndTableAliasOrderByOrdinalAndNull() {
+        String expected = executeQuery(StringUtils.format(
+            "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY `b`.`lastname` IS NOT NULL DESC, age is NULL LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        String actual = executeQuery(StringUtils.format(
+            "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY 1 IS NOT NULL DESC, 2 IS NULL LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT), "jdbc");
+        assertThat(actual, equalTo(expected));
+    }
+
+
+    // explain
+    @Test
+    public void explainSelectFieldiWithBacticksAndTableAliasGroupByOrdinal() throws IOException {
+        String expected = explainQuery(StringUtils.format(
+            "SELECT `b`.`lastname` FROM %s AS b GROUP BY `b`.`lastname` LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT));
+        String actual = explainQuery(StringUtils.format(
+            "SELECT `b`.`lastname` FROM %s AS b GROUP BY 1 LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT));
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void explainSelectFieldiWithBacticksAndTableAliasOrderByOrdinal() throws IOException {
+        String expected = explainQuery(StringUtils.format(
+            "SELECT `b`.`lastname` FROM %s AS b ORDER BY `b`.`lastname` LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT));
+        String actual = explainQuery(StringUtils.format(
+            "SELECT `b`.`lastname` FROM %s AS b ORDER BY 1 LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT));
+        assertThat(actual, equalTo(expected));
+    }
+
+    // explain ORDER BY IS NULL/NOT NULL
+    @Test
+    public void explainSelectFieldiWithBacticksAndTableAliasOrderByOrdinalAndNull()  throws IOException {
+        String expected = explainQuery(StringUtils.format(
+            "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY `b`.`lastname` IS NOT NULL DESC, age is NULL LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT));
+        String actual = explainQuery(StringUtils.format(
+            "SELECT `b`.`lastname`, age FROM %s AS b ORDER BY 1 IS NOT NULL DESC, 2 IS NULL LIMIT 3",
+            TestsConstants.TEST_INDEX_ACCOUNT));
+        assertThat(actual, equalTo(expected));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/ordinal/OrdinalRewriterRuleTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/ordinal/OrdinalRewriterRuleTest.java
@@ -76,13 +76,17 @@ public class OrdinalRewriterRuleTest {
     public void multipleGroupByOrdinal() throws SQLFeatureNotSupportedException {
         query("SELECT lastname, age FROM bank GROUP BY 1, 2 "
         ).shouldBeAfterRewrite("SELECT lastname, age FROM bank GROUP BY lastname, age");
-    }
 
-    @Test
-    public void multipleGroupByOrdinalDifferentorder() throws SQLFeatureNotSupportedException {
         query("SELECT lastname, age FROM bank GROUP BY 2, 1"
         ).shouldBeAfterRewrite("SELECT lastname, age FROM bank GROUP BY age, lastname");
+
+        query("SELECT lastname, age, firstname FROM bank GROUP BY 2, firstname, 1"
+        ).shouldBeAfterRewrite("SELECT lastname, age, firstname FROM bank GROUP BY age, firstname, lastname");
+
+        query("SELECT lastname, age, firstname FROM bank GROUP BY 2, something, 1"
+        ).shouldBeAfterRewrite("SELECT lastname, age, firstname FROM bank GROUP BY age, something, lastname");
     }
+
 
     @Test
     public void simpleOrderByOrdinal() throws SQLFeatureNotSupportedException {
@@ -94,14 +98,17 @@ public class OrdinalRewriterRuleTest {
     public void multipleOrderByOrdinal() throws SQLFeatureNotSupportedException {
         query("SELECT lastname, age FROM bank ORDER BY 1, 2 "
         ).shouldBeAfterRewrite("SELECT lastname, age FROM bank ORDER BY lastname, age");
-    }
 
-    @Test
-    public void multipleOrderByOrdinalDifferentorder() throws SQLFeatureNotSupportedException {
         query("SELECT lastname, age FROM bank ORDER BY 2, 1"
         ).shouldBeAfterRewrite("SELECT lastname, age FROM bank ORDER BY age, lastname");
+
+        query("SELECT lastname, age, firstname FROM bank ORDER BY 2, firstname, 1"
+        ).shouldBeAfterRewrite("SELECT lastname, age, firstname FROM bank ORDER BY age, firstname, lastname");
+
+        query("SELECT lastname, age, firstname FROM bank ORDER BY 2, department, 1"
+        ).shouldBeAfterRewrite("SELECT lastname, age, firstname FROM bank ORDER BY age, department, lastname");
     }
-    
+
 
     // TODO: Some more Tests
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/ordinal/OrdinalRewriterRuleTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/ordinal/OrdinalRewriterRuleTest.java
@@ -25,8 +25,6 @@ import com.amazon.opendistroforelasticsearch.sql.util.SqlParserUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.sql.SQLFeatureNotSupportedException;
-
 import static org.hamcrest.Matchers.containsString;
 
 /**
@@ -36,44 +34,44 @@ import static org.hamcrest.Matchers.containsString;
 public class OrdinalRewriterRuleTest {
 
     @Test
-    public void ordinalInGroupByShouldMatch() throws SQLFeatureNotSupportedException {
+    public void ordinalInGroupByShouldMatch() {
         query("SELECT lastname FROM bank GROUP BY 1").shouldMatchRule();
     }
 
     @Test
-    public void ordinalInOrderByShouldMatch() throws SQLFeatureNotSupportedException {
+    public void ordinalInOrderByShouldMatch() {
         query("SELECT lastname FROM bank ORDER BY 1").shouldMatchRule();
     }
 
 
     @Test
-    public void ordinalInGroupAndOrderByShouldMatch() throws SQLFeatureNotSupportedException {
+    public void ordinalInGroupAndOrderByShouldMatch() {
         query("SELECT lastname, age FROM bank GROUP BY 2, 1 ORDER BY 1").shouldMatchRule();
     }
 
     @Test
-    public void noOrdinalInGroupByShouldNotMatch() throws SQLFeatureNotSupportedException {
+    public void noOrdinalInGroupByShouldNotMatch() {
         query("SELECT lastname FROM bank GROUP BY lastname").shouldNotMatchRule();
     }
 
     @Test
-    public void noOrdinalInOrderByShouldNotMatch() throws SQLFeatureNotSupportedException {
+    public void noOrdinalInOrderByShouldNotMatch() {
         query("SELECT lastname, age FROM bank ORDER BY age").shouldNotMatchRule();
     }
 
     @Test
-    public void noOrdinalInGroupAndOrderByShouldNotMatch() throws SQLFeatureNotSupportedException {
+    public void noOrdinalInGroupAndOrderByShouldNotMatch() {
         query("SELECT lastname, age FROM bank GROUP BY lastname, age ORDER BY age").shouldNotMatchRule();
     }
 
     @Test
-    public void simpleGroupByOrdinal() throws SQLFeatureNotSupportedException {
+    public void simpleGroupByOrdinal() {
         query("SELECT lastname FROM bank GROUP BY 1"
         ).shouldBeAfterRewrite("SELECT lastname FROM bank GROUP BY lastname");
     }
 
     @Test
-    public void multipleGroupByOrdinal() throws SQLFeatureNotSupportedException {
+    public void multipleGroupByOrdinal() {
         query("SELECT lastname, age FROM bank GROUP BY 1, 2 "
         ).shouldBeAfterRewrite("SELECT lastname, age FROM bank GROUP BY lastname, age");
 
@@ -89,13 +87,13 @@ public class OrdinalRewriterRuleTest {
 
 
     @Test
-    public void simpleOrderByOrdinal() throws SQLFeatureNotSupportedException {
+    public void simpleOrderByOrdinal() {
         query("SELECT lastname FROM bank ORDER BY 1"
         ).shouldBeAfterRewrite("SELECT lastname FROM bank ORDER BY lastname");
     }
 
     @Test
-    public void multipleOrderByOrdinal() throws SQLFeatureNotSupportedException {
+    public void multipleOrderByOrdinal() {
         query("SELECT lastname, age FROM bank ORDER BY 1, 2 "
         ).shouldBeAfterRewrite("SELECT lastname, age FROM bank ORDER BY lastname, age");
 
@@ -125,7 +123,7 @@ public class OrdinalRewriterRuleTest {
             this.rule = new OrdinalRewriterRule(sql);
         }
 
-        void shouldBeAfterRewrite(String expected) throws SQLFeatureNotSupportedException {
+        void shouldBeAfterRewrite(String expected) {
             shouldMatchRule();
             rule.rewrite(expr);
             Assert.assertEquals(
@@ -134,15 +132,15 @@ public class OrdinalRewriterRuleTest {
             );
         }
 
-        void shouldMatchRule() throws SQLFeatureNotSupportedException {
+        void shouldMatchRule() {
             Assert.assertTrue(match());
         }
 
-        void shouldNotMatchRule() throws SQLFeatureNotSupportedException {
+        void shouldNotMatchRule() {
             Assert.assertFalse(match());
         }
 
-        void shouldThrowException(int ordinal) throws SQLFeatureNotSupportedException {
+        void shouldThrowException(int ordinal) {
             try {
                 shouldMatchRule();
                 rule.rewrite(expr);
@@ -152,7 +150,7 @@ public class OrdinalRewriterRuleTest {
             }
         }
 
-        private boolean match() throws SQLFeatureNotSupportedException {
+        private boolean match() {
             return rule.match(expr);
         }
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/ordinal/OrdinalRewriterRuleTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/ordinal/OrdinalRewriterRuleTest.java
@@ -18,12 +18,16 @@ package com.amazon.opendistroforelasticsearch.sql.unittest.rewriter.ordinal;
 import com.alibaba.druid.sql.SQLUtils;
 import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
 
+import com.amazon.opendistroforelasticsearch.sql.rewriter.matchtoterm.VerificationException;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.ordinal.OrdinalRewriterRule;
 import com.amazon.opendistroforelasticsearch.sql.util.SqlParserUtils;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.SQLFeatureNotSupportedException;
+
+import static org.hamcrest.Matchers.containsString;
 
 /**
  * Test cases for ordinal aliases in GROUP BY and ORDER BY
@@ -97,23 +101,9 @@ public class OrdinalRewriterRuleTest {
         query("SELECT lastname, age FROM bank ORDER BY 2, 1"
         ).shouldBeAfterRewrite("SELECT lastname, age FROM bank ORDER BY age, lastname");
     }
+    
 
-
-    //Tests with table aliases
-
-
-
-
-    //Tests with quoted identifiers
-
-
-
-    //Tests with invalid ordinals
-
-
-
-    // Some more Tests
-
+    // TODO: Some more Tests
 
     private QueryAssertion query(String sql) {
         return new QueryAssertion(sql);
@@ -143,6 +133,16 @@ public class OrdinalRewriterRuleTest {
 
         void shouldNotMatchRule() throws SQLFeatureNotSupportedException {
             Assert.assertFalse(match());
+        }
+
+        void shouldThrowException(int ordinal) throws SQLFeatureNotSupportedException {
+            try {
+                shouldMatchRule();
+                rule.rewrite(expr);
+                Assert.fail("Expected VerificationException, but none was thrown");
+            } catch (VerificationException e) {
+                Assert.assertThat(e.getMessage(), containsString("Invalid ordinal ["+ ordinal +"] specified in"));
+            }
         }
 
         private boolean match() throws SQLFeatureNotSupportedException {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/ordinal/OrdinalRewriterRuleTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/rewriter/ordinal/OrdinalRewriterRuleTest.java
@@ -1,0 +1,152 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.rewriter.ordinal;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+
+import com.amazon.opendistroforelasticsearch.sql.rewriter.ordinal.OrdinalRewriterRule;
+import com.amazon.opendistroforelasticsearch.sql.util.SqlParserUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.SQLFeatureNotSupportedException;
+
+/**
+ * Test cases for ordinal aliases in GROUP BY and ORDER BY
+ */
+
+public class OrdinalRewriterRuleTest {
+
+    @Test
+    public void ordinalInGroupByShouldMatch() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname FROM bank GROUP BY 1").shouldMatchRule();
+    }
+
+    @Test
+    public void ordinalInOrderByShouldMatch() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname FROM bank ORDER BY 1").shouldMatchRule();
+    }
+
+
+    @Test
+    public void ordinalInGroupAndOrderByShouldMatch() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname, age FROM bank GROUP BY 2, 1 ORDER BY 1").shouldMatchRule();
+    }
+
+    @Test
+    public void noOrdinalInGroupByShouldNotMatch() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname FROM bank GROUP BY lastname").shouldNotMatchRule();
+    }
+
+    @Test
+    public void noOrdinalInOrderByShouldNotMatch() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname, age FROM bank ORDER BY age").shouldNotMatchRule();
+    }
+
+    @Test
+    public void noOrdinalInGroupAndOrderByShouldNotMatch() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname, age FROM bank GROUP BY lastname, age ORDER BY age").shouldNotMatchRule();
+    }
+
+    @Test
+    public void simpleGroupByOrdinal() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname FROM bank GROUP BY 1"
+        ).shouldBeAfterRewrite("SELECT lastname FROM bank GROUP BY lastname");
+    }
+
+    @Test
+    public void multipleGroupByOrdinal() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname, age FROM bank GROUP BY 1, 2 "
+        ).shouldBeAfterRewrite("SELECT lastname, age FROM bank GROUP BY lastname, age");
+    }
+
+    @Test
+    public void multipleGroupByOrdinalDifferentorder() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname, age FROM bank GROUP BY 2, 1"
+        ).shouldBeAfterRewrite("SELECT lastname, age FROM bank GROUP BY age, lastname");
+    }
+
+    @Test
+    public void simpleOrderByOrdinal() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname FROM bank ORDER BY 1"
+        ).shouldBeAfterRewrite("SELECT lastname FROM bank ORDER BY lastname");
+    }
+
+    @Test
+    public void multipleOrderByOrdinal() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname, age FROM bank ORDER BY 1, 2 "
+        ).shouldBeAfterRewrite("SELECT lastname, age FROM bank ORDER BY lastname, age");
+    }
+
+    @Test
+    public void multipleOrderByOrdinalDifferentorder() throws SQLFeatureNotSupportedException {
+        query("SELECT lastname, age FROM bank ORDER BY 2, 1"
+        ).shouldBeAfterRewrite("SELECT lastname, age FROM bank ORDER BY age, lastname");
+    }
+
+
+    //Tests with table aliases
+
+
+
+
+    //Tests with quoted identifiers
+
+
+
+    //Tests with invalid ordinals
+
+
+
+    // Some more Tests
+
+
+    private QueryAssertion query(String sql) {
+        return new QueryAssertion(sql);
+    }
+    private static class QueryAssertion {
+
+        private OrdinalRewriterRule rule;
+        private SQLQueryExpr expr;
+
+        QueryAssertion(String sql) {
+            this.expr = SqlParserUtils.parse(sql);
+            this.rule = new OrdinalRewriterRule(sql);
+        }
+
+        void shouldBeAfterRewrite(String expected) throws SQLFeatureNotSupportedException {
+            shouldMatchRule();
+            rule.rewrite(expr);
+            Assert.assertEquals(
+                SQLUtils.toMySqlString(SqlParserUtils.parse(expected)),
+                SQLUtils.toMySqlString(expr)
+            );
+        }
+
+        void shouldMatchRule() throws SQLFeatureNotSupportedException {
+            Assert.assertTrue(match());
+        }
+
+        void shouldNotMatchRule() throws SQLFeatureNotSupportedException {
+            Assert.assertFalse(match());
+        }
+
+        private boolean match() throws SQLFeatureNotSupportedException {
+            return rule.match(expr);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #215*

*Description of changes:*
- Added a new Rewriter to map GROUP BY and ORDER By aliases to SELECT column fields



*Testing*
- Passing Gradle build with existing unit and integration tests
- Added new unit tests and integration tests




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
