### PR TITLE
Fix the issue that function name is case sensitive in JDBC formatter

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -98,7 +98,7 @@ public class SQLFunctions {
     public Tuple<String, String> function(String methodName, List<KVValue> paramers, String name,
                                                  boolean returnValue) {
         Tuple<String, String> functionStr = null;
-        switch (methodName) {
+        switch (methodName.toLowerCase()) {
             case "lower": {
                 functionStr = lower(
                         (SQLExpr) paramers.get(0).value,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -600,7 +600,7 @@ public class SQLFunctions {
      * it might be safely treated as INTEGER.
      */
     public static Schema.Type getScriptFunctionReturnType(String functionName) {
-        if (dateFunctions.contains(functionName) || stringOperators.contains(functionName)) {
+        if (dateFunctions.contains(functionName) || stringOperators.contains(functionName.toLowerCase())) {
             return Schema.Type.TEXT;
         }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -600,7 +600,9 @@ public class SQLFunctions {
      * it might be safely treated as INTEGER.
      */
     public static Schema.Type getScriptFunctionReturnType(String functionName) {
-        if (dateFunctions.contains(functionName) || stringOperators.contains(functionName.toLowerCase())) {
+        functionName = functionName.toLowerCase();
+
+        if (dateFunctions.contains(functionName) || stringOperators.contains(functionName)) {
             return Schema.Type.TEXT;
         }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -127,9 +127,13 @@ public class JdbcTestIT extends SQLIntegTestCase {
     public void dateFunctionNameCaseInsensitiveTest() {
         assertEquals(
                 executeQuery("SELECT insert_time FROM elasticsearch-sql_test_index_online/online " +
-                        "WHERE date_FORMAT(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01'", "jdbc"),
+                        "WHERE date_FORMAT(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01' " +
+                        "group by DAte_format(insert_time, 'yyyy-MM-dd', 'UTC') " +
+                        "oRDEr By date_forMAT(insert_time, 'yyyy-MM-dd', 'UTC')", "jdbc"),
                 executeQuery("SELECT insert_time FROM elasticsearch-sql_test_index_online/online " +
-                        "WHERE date_format(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01'", "jdbc")
+                        "WHERE date_format(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01' " +
+                        "GROUP BY date_format(insert_time, 'yyyy-MM-dd', 'UTC') " +
+                        "ORDER BY date_format(insert_time, 'yyyy-MM-dd', 'UTC')", "jdbc")
         );
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -114,16 +114,6 @@ public class JdbcTestIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void binaryOperatorNameCaseInsensitiveTest() {
-        assertEquals(
-                executeQuery("SELECT lastname FROM elasticsearch-sql_test_index_account/account " +
-                        "WHERE (age IS NOT NULL) AND (gender = 'M') ORDER BY age LIMIT 5", "jdbc"),
-                executeQuery("SELECT lastname FROM elasticsearch-sql_test_index_account/account " +
-                        "WHERE (age IS NOT NULL) and (gender = 'M') ORDER by age LIMIT 5", "jdbc")
-        );
-    }
-
-    @Test
     public void dateFunctionNameCaseInsensitiveTest() {
         assertEquals(
                 executeQuery("SELECT insert_time FROM elasticsearch-sql_test_index_online/online " +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -116,11 +116,11 @@ public class JdbcTestIT extends SQLIntegTestCase {
     @Test
     public void dateFunctionNameCaseInsensitiveTest() {
         assertEquals(
-                executeQuery("SELECT insert_time FROM elasticsearch-sql_test_index_online/online " +
+                executeQuery("SELECT DATE_FORMAT(insert_time, 'yyyy-MM-dd', 'UTC') FROM elasticsearch-sql_test_index_online/online " +
                         "WHERE date_FORMAT(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01' " +
                         "GROUP BY DAte_format(insert_time, 'yyyy-MM-dd', 'UTC') " +
                         "ORDER BY date_forMAT(insert_time, 'yyyy-MM-dd', 'UTC')", "jdbc"),
-                executeQuery("SELECT insert_time FROM elasticsearch-sql_test_index_online/online " +
+                executeQuery("SELECT date_format(insert_time, 'yyyy-MM-dd', 'UTC') FROM elasticsearch-sql_test_index_online/online " +
                         "WHERE date_format(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01' " +
                         "GROUP BY date_format(insert_time, 'yyyy-MM-dd', 'UTC') " +
                         "ORDER BY date_format(insert_time, 'yyyy-MM-dd', 'UTC')", "jdbc")

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -128,8 +128,8 @@ public class JdbcTestIT extends SQLIntegTestCase {
         assertEquals(
                 executeQuery("SELECT insert_time FROM elasticsearch-sql_test_index_online/online " +
                         "WHERE date_FORMAT(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01' " +
-                        "group by DAte_format(insert_time, 'yyyy-MM-dd', 'UTC') " +
-                        "oRDEr By date_forMAT(insert_time, 'yyyy-MM-dd', 'UTC')", "jdbc"),
+                        "GROUP BY DAte_format(insert_time, 'yyyy-MM-dd', 'UTC') " +
+                        "ORDER BY date_forMAT(insert_time, 'yyyy-MM-dd', 'UTC')", "jdbc"),
                 executeQuery("SELECT insert_time FROM elasticsearch-sql_test_index_online/online " +
                         "WHERE date_format(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01' " +
                         "GROUP BY date_format(insert_time, 'yyyy-MM-dd', 'UTC') " +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.sql.esintgtest;
 
 import org.json.JSONObject;
+import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -25,6 +26,7 @@ public class JdbcTestIT extends SQLIntegTestCase {
     protected void init() throws Exception {
         loadIndex(Index.ONLINE);
         loadIndex(Index.PEOPLE);
+        loadIndex(Index.ACCOUNT);
     }
 
     public void testPercentilesQuery() {
@@ -77,5 +79,57 @@ public class JdbcTestIT extends SQLIntegTestCase {
 
     private JSONObject executeJdbcRequest(String query){
         return new JSONObject(executeQuery(query, "jdbc"));
+    }
+
+    @Test
+    public void numberOperatorNameCaseInsensitiveTest() {
+        assertEquals(
+                executeQuery("SELECT ABS(age) FROM elasticsearch-sql_test_index_account/account " +
+                                "WHERE age IS NOT NULL LIMIT 5", "jdbc"),
+                executeQuery("SELECT abs(age) FROM elasticsearch-sql_test_index_account/account " +
+                                "WHERE age IS NOT NULL LIMIT 5", "jdbc")
+        );
+    }
+
+    @Test
+    public void trigFunctionNameCaseInsensitiveTest() {
+        assertEquals(
+                executeQuery("SELECT Cos(age) FROM elasticsearch-sql_test_index_account/account " +
+                                "WHERE age is NOT NULL LIMIT 5", "jdbc"),
+                executeQuery("SELECT cos(age) FROM elasticsearch-sql_test_index_account/account " +
+                                "WHERE age is NOT NULL LIMIT 5", "jdbc")
+        );
+    }
+
+    @Test
+    public void stringOperatorNameCaseInsensitiveTest() {
+        assertEquals(
+                executeQuery(
+                        "SELECT SubStrinG(lastname, 0, 2) FROM elasticsearch-sql_test_index_account/account " +
+                                "ORDER BY age LIMIT 5", "jdbc"),
+                executeQuery(
+                        "SELECT substring(lastname, 0, 2) FROM elasticsearch-sql_test_index_account/account " +
+                                "ORDER BY age LIMIT 5", "jdbc")
+        );
+    }
+
+    @Test
+    public void binaryOperatorNameCaseInsensitiveTest() {
+        assertEquals(
+                executeQuery("SELECT lastname FROM elasticsearch-sql_test_index_account/account " +
+                        "WHERE (age IS NOT NULL) AND (gender = 'M') ORDER BY age LIMIT 5", "jdbc"),
+                executeQuery("SELECT lastname FROM elasticsearch-sql_test_index_account/account " +
+                        "WHERE (age IS NOT NULL) and (gender = 'M') ORDER by age LIMIT 5", "jdbc")
+        );
+    }
+
+    @Test
+    public void dateFunctionNameCaseInsensitiveTest() {
+        assertEquals(
+                executeQuery("SELECT insert_time FROM elasticsearch-sql_test_index_online/online " +
+                        "WHERE date_FORMAT(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01'", "jdbc"),
+                executeQuery("SELECT insert_time FROM elasticsearch-sql_test_index_online/online " +
+                        "WHERE date_format(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01'", "jdbc")
+        );
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_NESTED_TYPE;
+import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ONLINE;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_PHRASE;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.everyItem;
@@ -51,6 +52,7 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
     private static final String FROM_ACCOUNTS = "FROM " + TEST_INDEX_ACCOUNT + "/account";
     private static final String FROM_NESTED = "FROM " + TEST_INDEX_NESTED_TYPE + "/nestedType";
     private static final String FROM_PHRASE = "FROM " + TEST_INDEX_PHRASE + "/phrase";
+    private static final String FROM_ONLINE = "FROM " + TEST_INDEX_ONLINE;
 
     /**
      * TODO Looks like Math/Date Functions test all use the same query() and execute() functions
@@ -62,6 +64,7 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
         loadIndex(Index.ACCOUNT);
         loadIndex(Index.NESTED);
         loadIndex(Index.PHRASE);
+        loadIndex(Index.ONLINE);
     }
 
     @Test
@@ -193,6 +196,56 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
             hits(
                 hasValueForFields("Bradshaw", "firstname", "lastname")
             )
+        );
+    }
+
+    @Test
+    public void numberOperatorNumberCaseInsensitiveTest() {
+        assertEquals(
+                executeQuery("SELECT ABS(age) " + FROM_ACCOUNTS + " WHERE age IS NOT NULL LIMIT 5",
+                        "jdbc"),
+                executeQuery("SELECT abs(age) " + FROM_ACCOUNTS + " WHERE age IS NOT NULL LIMIT 5",
+                        "jdbc")
+        );
+    }
+
+    @Test
+    public void trigFunctionNameCaseInsensitiveTest() {
+        assertEquals(
+                executeQuery("SELECT Cos(age) " + FROM_ACCOUNTS + " WHERE age is NOT NULL LIMIT 5",
+                        "jdbc"),
+                executeQuery("SELECT cos(age) " + FROM_ACCOUNTS + " WHERE age is NOT NULL LIMIT 5",
+                        "jdbc")
+        );
+    }
+
+    @Test
+    public void stringOperatorNameCaseInsensitiveTest() {
+        assertEquals(
+                executeQuery("SELECT SubStrinG(lastname, 0, 2) " + FROM_ACCOUNTS + " ORDER BY age LIMIT 5",
+                        "jdbc"),
+                executeQuery("SELECT substring(lastname, 0, 2) " + FROM_ACCOUNTS + " ORDER BY age LIMIT 5",
+                        "jdbc")
+        );
+    }
+
+    @Test
+    public void binaryOperatorNameCaseInsensitiveTest() {
+        assertEquals(
+                executeQuery("SELECT lastname " + FROM_ACCOUNTS +
+                        " WHERE (age IS NOT NULL) AND (gender = 'M') ORDER BY age LIMIT 5", "jdbc"),
+                executeQuery("SELECT lastname " + FROM_ACCOUNTS +
+                        " WHERE (age IS NOT NULL) and (gender = 'M') ORDER by age LIMIT 5", "jdbc")
+        );
+    }
+
+    @Test
+    public void dateFunctionNameCaseInsensitiveTest() {
+        assertEquals(
+                executeQuery("SELECT insert_time " + FROM_ONLINE +
+                        " WHERE date_FORMAT(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01'", "jdbc"),
+                executeQuery("SELECT insert_time " + FROM_ONLINE +
+                        " WHERE date_format(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01'", "jdbc")
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
@@ -62,7 +62,6 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
         loadIndex(Index.ACCOUNT);
         loadIndex(Index.NESTED);
         loadIndex(Index.PHRASE);
-        loadIndex(Index.ONLINE);
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
@@ -39,7 +39,6 @@ import java.util.stream.Collectors;
 
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_NESTED_TYPE;
-import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ONLINE;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_PHRASE;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.everyItem;
@@ -52,7 +51,6 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
     private static final String FROM_ACCOUNTS = "FROM " + TEST_INDEX_ACCOUNT + "/account";
     private static final String FROM_NESTED = "FROM " + TEST_INDEX_NESTED_TYPE + "/nestedType";
     private static final String FROM_PHRASE = "FROM " + TEST_INDEX_PHRASE + "/phrase";
-    private static final String FROM_ONLINE = "FROM " + TEST_INDEX_ONLINE;
 
     /**
      * TODO Looks like Math/Date Functions test all use the same query() and execute() functions
@@ -196,56 +194,6 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
             hits(
                 hasValueForFields("Bradshaw", "firstname", "lastname")
             )
-        );
-    }
-
-    @Test
-    public void numberOperatorNameCaseInsensitiveTest() {
-        assertEquals(
-                executeQuery("SELECT ABS(age) " + FROM_ACCOUNTS + " WHERE age IS NOT NULL LIMIT 5",
-                        "jdbc"),
-                executeQuery("SELECT abs(age) " + FROM_ACCOUNTS + " WHERE age IS NOT NULL LIMIT 5",
-                        "jdbc")
-        );
-    }
-
-    @Test
-    public void trigFunctionNameCaseInsensitiveTest() {
-        assertEquals(
-                executeQuery("SELECT Cos(age) " + FROM_ACCOUNTS + " WHERE age is NOT NULL LIMIT 5",
-                        "jdbc"),
-                executeQuery("SELECT cos(age) " + FROM_ACCOUNTS + " WHERE age is NOT NULL LIMIT 5",
-                        "jdbc")
-        );
-    }
-
-    @Test
-    public void stringOperatorNameCaseInsensitiveTest() {
-        assertEquals(
-                executeQuery("SELECT SubStrinG(lastname, 0, 2) " + FROM_ACCOUNTS + " ORDER BY age LIMIT 5",
-                        "jdbc"),
-                executeQuery("SELECT substring(lastname, 0, 2) " + FROM_ACCOUNTS + " ORDER BY age LIMIT 5",
-                        "jdbc")
-        );
-    }
-
-    @Test
-    public void binaryOperatorNameCaseInsensitiveTest() {
-        assertEquals(
-                executeQuery("SELECT lastname " + FROM_ACCOUNTS +
-                        " WHERE (age IS NOT NULL) AND (gender = 'M') ORDER BY age LIMIT 5", "jdbc"),
-                executeQuery("SELECT lastname " + FROM_ACCOUNTS +
-                        " WHERE (age IS NOT NULL) and (gender = 'M') ORDER by age LIMIT 5", "jdbc")
-        );
-    }
-
-    @Test
-    public void dateFunctionNameCaseInsensitiveTest() {
-        assertEquals(
-                executeQuery("SELECT insert_time " + FROM_ONLINE +
-                        " WHERE date_FORMAT(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01'", "jdbc"),
-                executeQuery("SELECT insert_time " + FROM_ONLINE +
-                        " WHERE date_format(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01'", "jdbc")
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
@@ -200,7 +200,7 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void numberOperatorNumberCaseInsensitiveTest() {
+    public void numberOperatorNameCaseInsensitiveTest() {
         assertEquals(
                 executeQuery("SELECT ABS(age) " + FROM_ACCOUNTS + " WHERE age IS NOT NULL LIMIT 5",
                         "jdbc"),


### PR DESCRIPTION
*Issue #, if available:*

* **[Issue #233 Function names are case-sensitive](https://github.com/opendistro-for-elasticsearch/sql/issues/233)**

*Description of changes:*

* Fixed the bug that the function names are case sensitive when formatting the response to JDBC.
* Added IT.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
