### PR TITLE
Support extra number operators: POWER, ATAN2, COT, SIGN

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -33,7 +33,7 @@ public enum ScalarFunction implements TypeExpression {
     ABS(func(T(NUMBER)).to(T)), // translate to Java: <T extends Number> T ABS(T)
     ASIN(func(T(NUMBER)).to(T)),
     ATAN(func(T(NUMBER)).to(T)),
-    ATAN2(func(T(NUMBER), T(NUMBER)).to(T)),
+    ATAN2(func(T(NUMBER), NUMBER).to(T)),
     CBRT(func(T(NUMBER)).to(T)),
     CEIL(func(T(NUMBER)).to(T)),
     CONCAT(), // TODO: varargs support required

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -33,7 +33,7 @@ public enum ScalarFunction implements TypeExpression {
     ABS(func(T(NUMBER)).to(T)), // translate to Java: <T extends Number> T ABS(T)
     ASIN(func(T(NUMBER)).to(T)),
     ATAN(func(T(NUMBER)).to(T)),
-    ATAN2(func(T(NUMBER)).to(T)),
+    ATAN2(func(T(NUMBER), NUMBER).to(T)),
     CBRT(func(T(NUMBER)).to(T)),
     CEIL(func(T(NUMBER)).to(T)),
     CONCAT(), // TODO: varargs support required

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -33,7 +33,7 @@ public enum ScalarFunction implements TypeExpression {
     ABS(func(T(NUMBER)).to(T)), // translate to Java: <T extends Number> T ABS(T)
     ASIN(func(T(NUMBER)).to(T)),
     ATAN(func(T(NUMBER)).to(T)),
-    ATAN2(func(T(NUMBER), NUMBER).to(T)),
+    ATAN2(func(T(NUMBER), T(NUMBER)).to(T)),
     CBRT(func(T(NUMBER)).to(T)),
     CEIL(func(T(NUMBER)).to(T)),
     CONCAT(), // TODO: varargs support required

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -69,6 +69,8 @@ public enum ScalarFunction implements TypeExpression {
     RANDOM(func(T(NUMBER)).to(T)),
     RINT(func(T(NUMBER)).to(T)),
     ROUND(func(T(NUMBER)).to(T)),
+    SIGN(func(T(NUMBER)).to(T)),
+    SIGNUM(func(T(NUMBER)).to(T)),
     SIN(func(T(NUMBER)).to(T)),
     SINH(func(T(NUMBER)).to(T)),
     SQRT(func(T(NUMBER)).to(T)),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -40,6 +40,7 @@ public enum ScalarFunction implements TypeExpression {
     CONCAT_WS(),
     COS(func(T(NUMBER)).to(T)),
     COSH(func(T(NUMBER)).to(T)),
+    COT(func(T(NUMBER)).to(T)),
     DATE_FORMAT(
         func(DATE, STRING).to(STRING),
         func(DATE, STRING, STRING).to(STRING)

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -60,7 +60,7 @@ public enum ScalarFunction implements TypeExpression {
         func(T(STRING), STRING).to(T)
     ),
     PI(func().to(DOUBLE)),
-    POW(
+    POW, POWER(
         func(T(NUMBER)).to(T),
         func(T(NUMBER), NUMBER).to(T)
     ),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -42,7 +42,7 @@ import java.util.stream.Stream;
 public class SQLFunctions {
 
     private static final Set<String> numberOperators = Sets.newHashSet(
-            "exp", "expm1", "log", "log2", "log10", "sqrt", "cbrt", "ceil", "floor", "rint", "pow",
+            "exp", "expm1", "log", "log2", "log10", "sqrt", "cbrt", "ceil", "floor", "rint", "pow", "power",
             "round", "random", "abs"
     );
 
@@ -206,6 +206,8 @@ public class SQLFunctions {
                 break;
 
             case "pow":
+            case "power":
+                methodName = "pow";
                 functionStr = mathDoubleValueTemplate("Math." + methodName, methodName,
                         (SQLExpr) paramers.get(0).value, Util.expr2Object((SQLExpr) paramers.get(1).value).toString(),
                         name);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -49,7 +49,7 @@ public class SQLFunctions {
     private static final Set<String> mathConstants = Sets.newHashSet("e", "pi");
 
     private static final Set<String> trigFunctions = Sets.newHashSet(
-            "degrees", "radians", "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "sinh", "cosh"
+            "degrees", "radians", "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "sinh", "cosh", "cot"
     );
 
     private static final Set<String> stringOperators = Sets.newHashSet(
@@ -202,6 +202,12 @@ public class SQLFunctions {
             case "sinh":
             case "cosh":
                 functionStr = mathSingleValueTemplate("Math." + methodName, methodName,
+                        (SQLExpr) paramers.get(0).value, name);
+                break;
+
+            case "cot":
+                // ES does not support the function name cot
+                functionStr = mathSingleValueTemplate("1 / Math.tan", methodName,
                         (SQLExpr) paramers.get(0).value, name);
                 break;
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -49,7 +49,7 @@ public class SQLFunctions {
     private static final Set<String> mathConstants = Sets.newHashSet("e", "pi");
 
     private static final Set<String> trigFunctions = Sets.newHashSet(
-            "degrees", "radians", "sin", "cos", "tan", "asin", "acos", "atan", "sinh", "cosh"
+            "degrees", "radians", "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "sinh", "cosh"
     );
 
     private static final Set<String> stringOperators = Sets.newHashSet(
@@ -211,6 +211,11 @@ public class SQLFunctions {
                 functionStr = mathDoubleValueTemplate("Math." + methodName, methodName,
                         (SQLExpr) paramers.get(0).value, Util.expr2Object((SQLExpr) paramers.get(1).value).toString(),
                         name);
+                break;
+
+            case "atan2":
+                functionStr = mathDoubleValueTemplate("Math." + methodName, methodName,
+                        (SQLExpr) paramers.get(0).value, (SQLExpr) paramers.get(1).value);
                 break;
 
             case "substring":
@@ -544,6 +549,13 @@ public class SQLFunctions {
             return new Tuple<>(name, getPropertyOrValue(val1) + "; "
                     + def(name, func(methodName, false, valueName, val2)));
         }
+    }
+
+    private Tuple<String, String> mathDoubleValueTemplate(String methodName, String fieldName, SQLExpr val1,
+                                                          SQLExpr val2) {
+        String name = nextId(fieldName);
+        return new Tuple<>(name, def(name, func(methodName, false,
+                getPropertyOrValue(val1), getPropertyOrValue(val2))));
     }
 
     private Tuple<String, String> mathSingleValueTemplate(String methodName, String fieldName, SQLExpr field,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -43,7 +43,7 @@ public class SQLFunctions {
 
     private static final Set<String> numberOperators = Sets.newHashSet(
             "exp", "expm1", "log", "log2", "log10", "sqrt", "cbrt", "ceil", "floor", "rint", "pow", "power",
-            "round", "random", "abs"
+            "round", "random", "abs", "sign", "signum"
     );
 
     private static final Set<String> mathConstants = Sets.newHashSet("e", "pi");
@@ -208,6 +208,13 @@ public class SQLFunctions {
             case "cot":
                 // ES does not support the function name cot
                 functionStr = mathSingleValueTemplate("1 / Math.tan", methodName,
+                        (SQLExpr) paramers.get(0).value, name);
+                break;
+
+            case "sign":
+            case "signum":
+                methodName = "signum";
+                functionStr = mathSingleValueTemplate("Math." + methodName, methodName,
                         (SQLExpr) paramers.get(0).value, name);
                 break;
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerScalarFunctionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerScalarFunctionTest.java
@@ -139,7 +139,7 @@ public class SemanticAnalyzerScalarFunctionTest extends SemanticAnalyzerTestBase
             " ABS(age), " +
             " ASIN(age), " +
             " ATAN(age), " +
-            " ATAN2(age), " +
+            " ATAN2(age, age), " +
             " CBRT(age), " +
             " CEIL(age), " +
             " COS(age), " +
@@ -170,7 +170,7 @@ public class SemanticAnalyzerScalarFunctionTest extends SemanticAnalyzerTestBase
             " ABS(age) = 1 AND " +
             " ASIN(age) = 1 AND " +
             " ATAN(age) = 1 AND " +
-            " ATAN2(age) = 1 AND " +
+            " ATAN2(age, age) = 1 AND " +
             " CBRT(age) = 1 AND " +
             " CEIL(age) = 1 AND " +
             " COS(age) = 1 AND " +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MathFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MathFunctionsIT.java
@@ -142,16 +142,18 @@ public class MathFunctionsIT extends SQLIntegTestCase {
     @Test
     public void power() throws IOException {
         SearchHit[] hits = query(
-                "SELECT POWER(PI(), 2) AS power", "WHERE POWER(PI(), 2) > 0"
+                "SELECT POWER(age, 2) AS power",
+                "WHERE (age IS NOT NULL) AND (balance IS NOT NULL) and (POWER(balance, 3) > 0)"
         );
         double power = (double) getField(hits[0], "power");
-        assertThat(power, equalTo(Math.pow(Math.PI, 2)));
+        assertTrue(power >= 0);
     }
 
     @Test
     public void atan2() throws IOException {
         SearchHit[] hits = query(
-                "SELECT ATAN2(age, age) AS atan2", "WHERE age IS NOT NULL"
+                "SELECT ATAN2(age, age) AS atan2",
+                "WHERE (age IS NOT NULL) AND (ATAN2(age, age) > 0)"
         );
         double atan2 = (double) getField(hits[0], "atan2");
         assertThat(atan2, equalTo(Math.atan2(1, 1)));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MathFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MathFunctionsIT.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
@@ -141,7 +142,7 @@ public class MathFunctionsIT extends SQLIntegTestCase {
     @Test
     public void power() throws IOException {
         SearchHit[] hits = query(
-                "SELECT POWER(PI(), 2) AS power"
+                "SELECT POWER(PI(), 2) AS power", "WHERE POWER(PI(), 2) > 0"
         );
         double power = (double) getField(hits[0], "power");
         assertThat(power, equalTo(Math.pow(Math.PI, 2)));
@@ -162,7 +163,7 @@ public class MathFunctionsIT extends SQLIntegTestCase {
                 "SELECT COT(PI()) AS cot"
         );
         double cot = (double) getField(hits[0], "cot");
-        assertThat(cot, equalTo(1 / Math.tan(Math.PI)));
+        assertThat(cot, closeTo(1 / Math.tan(Math.PI), 0.001));
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MathFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MathFunctionsIT.java
@@ -138,6 +138,42 @@ public class MathFunctionsIT extends SQLIntegTestCase {
         assertThat(sinh, equalTo(Math.sinh(Math.PI)));
     }
 
+    @Test
+    public void power() throws IOException {
+        SearchHit[] hits = query(
+                "SELECT POWER(PI(), 2) AS power"
+        );
+        double power = (double) getField(hits[0], "power");
+        assertThat(power, equalTo(Math.pow(Math.PI, 2)));
+    }
+
+    @Test
+    public void atan2() throws IOException {
+        SearchHit[] hits = query(
+                "SELECT ATAN2(age, age) AS atan2", "WHERE age IS NOT NULL"
+        );
+        double atan2 = (double) getField(hits[0], "atan2");
+        assertThat(atan2, equalTo(Math.atan2(1, 1)));
+    }
+
+    @Test
+    public void cot() throws IOException {
+        SearchHit[] hits = query(
+                "SELECT COT(PI()) AS cot"
+        );
+        double cot = (double) getField(hits[0], "cot");
+        assertThat(cot, equalTo(1 / Math.tan(Math.PI)));
+    }
+
+    @Test
+    public void sign() throws IOException {
+        SearchHit[] hits = query(
+                "SELECT SIGN(E()) AS sign"
+        );
+        double sign = (double) getField(hits[0], "sign");
+        assertThat(sign, equalTo(Math.signum(Math.E)));
+    }
+
     private SearchHit[] query(String select, String... statements) throws IOException {
         final String response = executeQueryWithStringOutput(select + " " + FROM + " " + String.join(" ", statements));
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/MathFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/MathFunctionsTest.java
@@ -317,8 +317,7 @@ public class MathFunctionsTest {
 
     @Test
     public void powerWithPropertyArgument() {
-        String query = "SELECT POWER(age, 2) " +
-                "FROM bank";
+        String query = "SELECT POWER(age, 2) FROM bank WHERE POWER(age, 2) > 0";
         ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
         assertTrue(
                 CheckScriptContents.scriptContainsString(
@@ -328,8 +327,7 @@ public class MathFunctionsTest {
 
     @Test
     public void atan2WithValueArgument() {
-        String query = "SELECT ATAN2(2, 3) " +
-                "FROM bank";
+        String query = "SELECT ATAN2(2, 3) FROM bank";
         ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
         assertTrue(
                 CheckScriptContents.scriptContainsString(
@@ -339,8 +337,7 @@ public class MathFunctionsTest {
 
     @Test
     public void cotWithValueArgument() {
-        String query = "SELECT COT(0.5) " +
-                "FROM bank";
+        String query = "SELECT COT(0.5) FROM bank";
         ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
         assertTrue(CheckScriptContents.scriptContainsString(
                 scriptField,
@@ -349,8 +346,7 @@ public class MathFunctionsTest {
 
     @Test
     public void signWithFunctionPropertyArgument() {
-        String query = "SELECT SIGN(age) " +
-                "FROM bank WHERE age IS NOT NULL";
+        String query = "SELECT SIGN(age) FROM bank WHERE age IS NOT NULL";
         ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
         assertTrue(CheckScriptContents.scriptContainsString(
                 scriptField,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/MathFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/MathFunctionsTest.java
@@ -315,4 +315,46 @@ public class MathFunctionsTest {
                         "Math.cosh(0)"));
     }
 
+    @Test
+    public void powerWithPropertyArgument() {
+        String query = "SELECT POWER(age, 2) " +
+                "FROM bank";
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptField,
+                        "Math.pow(doc['age'].value, 2)"));
+    }
+
+    @Test
+    public void atan2WithValueArgument() {
+        String query = "SELECT ATAN2(2, 3) " +
+                "FROM bank";
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptField,
+                        "Math.atan2(2, 3)"));
+    }
+
+    @Test
+    public void cotWithValueArgument() {
+        String query = "SELECT COT(0.5) " +
+                "FROM bank";
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(CheckScriptContents.scriptContainsString(
+                scriptField,
+                "1 / Math.tan(0.5)"));
+    }
+
+    @Test
+    public void signWithFunctionPropertyArgument() {
+        String query = "SELECT SIGN(age) " +
+                "FROM bank WHERE age IS NOT NULL";
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(CheckScriptContents.scriptContainsString(
+                scriptField,
+                "Math.signum(doc['age'].value)"));
+    }
+
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/MathFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/MathFunctionsTest.java
@@ -23,8 +23,6 @@ import org.junit.Test;
 
 import static org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
 import static org.junit.Assert.assertTrue;
-import static com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents.scriptContainsString;
-import static com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents.scriptHasPattern;
 
 public class MathFunctionsTest {
 
@@ -317,40 +315,64 @@ public class MathFunctionsTest {
 
     @Test
     public void powerWithPropertyArgument() {
-        String query = "SELECT POWER(age, 2) FROM bank WHERE POWER(age, 2) > 0";
+        String query = "SELECT POWER(age, 2) FROM bank WHERE POWER(balance, 3) > 0";
         ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
         assertTrue(
                 CheckScriptContents.scriptContainsString(
                         scriptField,
                         "Math.pow(doc['age'].value, 2)"));
+
+        ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptFilter,
+                        "Math.pow(doc['balance'].value, 3)"));
     }
 
     @Test
-    public void atan2WithValueArgument() {
-        String query = "SELECT ATAN2(2, 3) FROM bank";
+    public void atan2WithPropertyArgument() {
+        String query = "SELECT ATAN2(age, 2) FROM bank WHERE ATAN2(balance, 3) > 0";
         ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
         assertTrue(
                 CheckScriptContents.scriptContainsString(
                         scriptField,
-                        "Math.atan2(2, 3)"));
+                        "Math.atan2(doc['age'].value, 2)"));
+
+        ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptFilter,
+                        "Math.atan2(doc['balance'].value, 3)"));
     }
 
     @Test
-    public void cotWithValueArgument() {
-        String query = "SELECT COT(0.5) FROM bank";
+    public void cotWithPropertyArgument() {
+        String query = "SELECT COT(age) FROM bank WHERE COT(balance) > 0";
         ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
-        assertTrue(CheckScriptContents.scriptContainsString(
-                scriptField,
-                "1 / Math.tan(0.5)"));
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptField,
+                        "1 / Math.tan(doc['age'].value)"));
+
+        ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptFilter,
+                        "1 / Math.tan(doc['balance'].value)"));
     }
 
     @Test
     public void signWithFunctionPropertyArgument() {
-        String query = "SELECT SIGN(age) FROM bank WHERE age IS NOT NULL";
+        String query = "SELECT SIGN(age) FROM bank WHERE SIGNUM(balance) = 1";
         ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
         assertTrue(CheckScriptContents.scriptContainsString(
                 scriptField,
                 "Math.signum(doc['age'].value)"));
-    }
 
+        ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptFilter,
+                        "Math.signum(doc['balance'].value)"));
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

* [**Issue #224 Support for extra functions required by BI tools**](https://github.com/opendistro-for-elasticsearch/sql/issues/224)

* [**Issue #235 Unable to recognize certain function names**](https://github.com/opendistro-for-elasticsearch/sql/issues/235)

*Description of changes:*

* Support number operators: POWER, ATAN2, COT, SIGN.
* Added IT and UT for the operators above respectively.

_Note: other types of operators/functions mentioned in the issues (string operators, date operators, logic functions etc.) will be submitted in other PRs respectively._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
