### PR TITLE
Support SELECT <number_literal>

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -634,7 +634,8 @@ public class SQLFunctions {
         }
 
         if (mathConstants.contains(functionName) || numberOperators.contains(functionName)
-                || trigFunctions.contains(functionName) || binaryOperators.contains(functionName)) {
+                || trigFunctions.contains(functionName) || binaryOperators.contains(functionName)
+                || utilityFunctions.contains(functionName)) {
             return Schema.Type.DOUBLE;
         }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.esintgtest;
 
+import com.amazon.opendistroforelasticsearch.sql.utils.StringUtils;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -193,6 +194,19 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
             hits(
                 hasValueForFields("Bradshaw", "firstname", "lastname")
             )
+        );
+    }
+
+    @Test
+    public void numberLiteralInSelectField() {
+        assertTrue(
+                executeQuery(StringUtils.format("SELECT 2 AS number from %s", TEST_INDEX_ACCOUNT), "jdbc")
+                .contains("\"type\": \"double\"")
+        );
+
+        assertTrue(
+                executeQuery(StringUtils.format("SELECT 2.1 AS number FROM %s", TEST_INDEX_ACCOUNT), "jdbc")
+                .contains("\"type\": \"double\"")
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryFunctionsIT.java
@@ -200,13 +200,13 @@ public class QueryFunctionsIT extends SQLIntegTestCase {
     @Test
     public void numberLiteralInSelectField() {
         assertTrue(
-                executeQuery(StringUtils.format("SELECT 2 AS number from %s", TEST_INDEX_ACCOUNT), "jdbc")
-                .contains("\"type\": \"double\"")
+                executeQuery(StringUtils.format("SELECT 234234 AS number from %s", TEST_INDEX_ACCOUNT), "jdbc")
+                .contains("234234")
         );
 
         assertTrue(
-                executeQuery(StringUtils.format("SELECT 2.1 AS number FROM %s", TEST_INDEX_ACCOUNT), "jdbc")
-                .contains("\"type\": \"double\"")
+                executeQuery(StringUtils.format("SELECT 2.34234 AS number FROM %s", TEST_INDEX_ACCOUNT), "jdbc")
+                .contains("2.34234")
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/QueryFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/QueryFunctionsTest.java
@@ -26,6 +26,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.MultiMatchQueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -41,6 +42,7 @@ import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.elasticsearch.index.query.QueryBuilders.wildcardQuery;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertTrue;
 
 public class QueryFunctionsTest {
 
@@ -198,6 +200,18 @@ public class QueryFunctionsTest {
         );
     }
 
+    @Test
+    public void numberLiteralInSelectField() {
+        String query = "SELECT 2 AS number FROM bank WHERE age > 20";
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                     scriptField,
+                     "def assign"
+                )
+        );
+    }
+
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void emptyQueryShouldThrowSQLFeatureNotSupportedException() throws SQLFeatureNotSupportedException, SqlParseException {
         ESActionFactory.create(Mockito.mock(Client.class), "");
@@ -225,6 +239,10 @@ public class QueryFunctionsTest {
 
     private String query(String from, String... statements) {
         return explain(SELECT_ALL + " " + from + " " + String.join(" ", statements));
+    }
+
+    private String query(String sql) {
+        return explain(sql);
     }
 
     private String explain(String sql) {


### PR DESCRIPTION
*Issue #, if available:*

* **[Issue #254 Support SELECT <literal>](https://github.com/opendistro-for-elasticsearch/sql/issues/254)** 

*Description of changes:*

* Supported number literal in SELECT field as utility function "ASSIGN" to pass the jdbc formatter.
* Added IT and UT.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
