### PR TITLE
Support string operators: ASCII, RTRIM, LTRIM, LOCATE, LENGTH, REPLACE

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -49,6 +49,7 @@ public enum ScalarFunction implements TypeExpression {
     E(func().to(DOUBLE)),
     EXP(func(T(NUMBER)).to(T)),
     EXPM1(func(T(NUMBER)).to(T)),
+    LENGTH(func(T(STRING)).to(INTEGER)),
     FLOOR(func(T(NUMBER)).to(T)),
     LOG(
         func(T(NUMBER)).to(T),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -68,6 +68,7 @@ public enum ScalarFunction implements TypeExpression {
     ),
     RADIANS(func(T(NUMBER)).to(T)),
     RANDOM(func(T(NUMBER)).to(T)),
+    REPLACE(func(STRING, STRING, STRING).to(STRING)),
     RINT(func(T(NUMBER)).to(T)),
     ROUND(func(T(NUMBER)).to(T)),
     SIGN(func(T(NUMBER)).to(T)),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -51,11 +51,11 @@ public enum ScalarFunction implements TypeExpression {
     EXP(func(T(NUMBER)).to(T)),
     EXPM1(func(T(NUMBER)).to(T)),
     FLOOR(func(T(NUMBER)).to(T)),
-    LENGTH(func(T(STRING)).to(INTEGER)
+    LENGTH(func(STRING).to(INTEGER)
 ),
     LOCATE(
-            func(STRING, T(STRING), INTEGER).to(INTEGER),
-            func(STRING, T(STRING)).to(INTEGER)
+            func(STRING, STRING, INTEGER).to(INTEGER),
+            func(STRING, STRING).to(INTEGER)
     ),
     LOG(
         func(T(NUMBER)).to(T),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -49,8 +49,14 @@ public enum ScalarFunction implements TypeExpression {
     E(func().to(DOUBLE)),
     EXP(func(T(NUMBER)).to(T)),
     EXPM1(func(T(NUMBER)).to(T)),
-    LENGTH(func(T(STRING)).to(INTEGER)),
     FLOOR(func(T(NUMBER)).to(T)),
+//    LEFT(func(T(STRING), INTEGER).to(T)),
+    LENGTH(func(T(STRING)).to(INTEGER)
+),
+    LOCATE(
+            func(STRING, T(STRING), INTEGER).to(INTEGER),
+            func(STRING, T(STRING)).to(INTEGER)
+    ),
     LOG(
         func(T(NUMBER)).to(T),
         func(T(NUMBER), NUMBER).to(T)
@@ -68,7 +74,7 @@ public enum ScalarFunction implements TypeExpression {
     ),
     RADIANS(func(T(NUMBER)).to(T)),
     RANDOM(func(T(NUMBER)).to(T)),
-    REPLACE(func(STRING, STRING, STRING).to(STRING)),
+    REPLACE(func(T(STRING), STRING, STRING).to(T)),
     RINT(func(T(NUMBER)).to(T)),
     ROUND(func(T(NUMBER)).to(T)),
     SIGN(func(T(NUMBER)).to(T)),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -67,6 +67,7 @@ public enum ScalarFunction implements TypeExpression {
         func(T(STRING)).to(T),
         func(T(STRING), STRING).to(T)
     ),
+    LTRIM(func(T(STRING)).to(T)),
     PI(func().to(DOUBLE)),
     POW, POWER(
         func(T(NUMBER)).to(T),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -51,7 +51,6 @@ public enum ScalarFunction implements TypeExpression {
     EXP(func(T(NUMBER)).to(T)),
     EXPM1(func(T(NUMBER)).to(T)),
     FLOOR(func(T(NUMBER)).to(T)),
-//    LEFT(func(T(STRING), INTEGER).to(T)),
     LENGTH(func(T(STRING)).to(INTEGER)
 ),
     LOCATE(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -31,6 +31,7 @@ import static com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.spe
 public enum ScalarFunction implements TypeExpression {
 
     ABS(func(T(NUMBER)).to(T)), // translate to Java: <T extends Number> T ABS(T)
+    ASCII(func(T(STRING)).to(T)),
     ASIN(func(T(NUMBER)).to(T)),
     ATAN(func(T(NUMBER)).to(T)),
     ATAN2(func(T(NUMBER), NUMBER).to(T)),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -77,6 +77,7 @@ public enum ScalarFunction implements TypeExpression {
     REPLACE(func(T(STRING), STRING, STRING).to(T)),
     RINT(func(T(NUMBER)).to(T)),
     ROUND(func(T(NUMBER)).to(T)),
+    RTRIM(func(T(STRING)).to(T)),
     SIGN(func(T(NUMBER)).to(T)),
     SIGNUM(func(T(NUMBER)).to(T)),
     SIN(func(T(NUMBER)).to(T)),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -54,7 +54,7 @@ public class SQLFunctions {
     );
 
     private static final Set<String> stringOperators = Sets.newHashSet(
-            "split", "concat_ws", "substring", "trim", "lower", "upper", "ascii", "rtrim", "locate",
+            "split", "concat_ws", "substring", "trim", "lower", "upper", "ascii", "rtrim", "ltrim", "locate",
             "length", "replace", "left", "right"
     );
 
@@ -309,6 +309,10 @@ public class SQLFunctions {
                 break;
             case "rtrim":
                 functionStr = rtrim((SQLExpr) paramers.get(0).value);
+                break;
+            case "ltrim":
+                functionStr = ltrim((SQLExpr) paramers.get(0).value);
+                break;
             default:
 
         }
@@ -687,10 +691,20 @@ public class SQLFunctions {
         String fieldString = getPropertyOrStringValue(field);
         return new Tuple<>(name, StringUtils.format(
                 "int pos=%s.length();"
-                + "while(%s.substring(pos-1, pos) == ' ' && pos > 0) {pos --;} "
-                + def(name, "%s.substring(0, pos)")
-                ,
+                + "while(%s.substring(pos-1, pos)==' ' && pos > 0) {pos --;} "
+                + def(name, "%s.substring(0, pos)"),
                 fieldString, fieldString, fieldString
+        ));
+    }
+
+    private Tuple<String, String> ltrim(SQLExpr field) {
+        String name = nextId("ltrim");
+        String fieldString = getPropertyOrStringValue(field);
+        return new Tuple<>(name, StringUtils.format(
+                "int pos=0;"
+                + "while(%s.substring(pos, pos+1)==' ' && pos < %s.length()) {pos ++;} "
+                + def(name, "%s.substring(pos, %s.length())"),
+                fieldString, fieldString, fieldString, fieldString
         ));
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -295,9 +295,9 @@ public class SQLFunctions {
             case "length":
                 functionStr = length((SQLExpr) paramers.get(0).value);
                 break;
-//            case "replace":
-//                functionStr = replace((SQLExpr) paramers.get(0).value, (CharSequence) paramers.get(1),
-//                        (CharSequence) paramers.get(1).value);
+            case "replace":
+                functionStr = replace(paramers.get(0).value.toString(), paramers.get(1).value.toString(),
+                        paramers.get(2).value.toString());
                 break;
             default:
 
@@ -633,10 +633,10 @@ public class SQLFunctions {
         return new Tuple<>(name, def(name, doc(field) + ".value" + ".length()"));
     }
 
-    private Tuple<String, String> replace(SQLExpr field, CharSequence original, CharSequence replacement) {
+    private Tuple<String, String> replace(String original, String target, String replacement) {
         String  name = nextId("replace");
         return new Tuple<>(name, def(name,
-                doc(field) + ".value" + ".replace(" + original + ", " + replacement + ")"));
+                original + ".replace(" + target + ", " + replacement + ")"));
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -638,17 +638,22 @@ public class SQLFunctions {
 
     // query: substring(Column expr, int pos, int len)
     // painless script: substring(int begin, int end)
+    // es behavior: 1-index, supports out-of-bound index
     public Tuple<String, String> substring(SQLExpr field, int pos, int len, String valueName) {
         String name = nextId("substring");
+
+        // start and end are 0-indexes
+        int start = pos < 1 ? 0 : pos - 1;
+        int end = Math.min(start + len, getPropertyOrValue(field).length());
         if (valueName == null) {
             return new Tuple<>(name, def(name, getPropertyOrStringValue(field) + "."
                     + func("substring", false,
-                    Integer.toString(pos), Integer.toString(pos + len))));
+                    Integer.toString(start), Integer.toString(end))));
         } else {
             return new Tuple<>(name, getPropertyOrStringValue(field) + "; "
                     + def(name, valueName + "."
                     + func("substring", false,
-                    Integer.toString(pos), Integer.toString(pos + len))));
+                    Integer.toString(start), Integer.toString(end))));
         }
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -299,11 +299,11 @@ public class SQLFunctions {
                 functionStr = assign((SQLExpr) paramers.get(0).value);
                 break;
             case "length":
-                functionStr = length((SQLExpr) paramers.get(0).value, name);
+                functionStr = length((SQLExpr) paramers.get(0).value);
                 break;
             case "replace":
                 functionStr = replace((SQLExpr) paramers.get(0).value, paramers.get(1).value.toString(),
-                        paramers.get(2).value.toString(), name);
+                        paramers.get(2).value.toString());
                 break;
             case "locate":
                 int start = 0;
@@ -665,24 +665,15 @@ public class SQLFunctions {
         return property + ".toUpperCase(Locale.forLanguageTag(\"" + culture + "\"))";
     }
 
-    private Tuple<String, String> length(SQLExpr field, String valueName) {
+    private Tuple<String, String> length(SQLExpr field) {
         String name = nextId("length");
-        if (Strings.isNullOrEmpty(valueName)) {
-            return new Tuple<>(name, def(name, getPropertyOrStringValue(field) + ".length()"));
-        } else {
-            return new Tuple<>(name, getPropertyOrValue(field) + ";" + def(name, valueName + ".length()"));
-        }
+        return new Tuple<>(name, def(name, getPropertyOrStringValue(field) + ".length()"));
     }
 
-    private Tuple<String, String> replace(SQLExpr field, String target, String replacement, String valueName) {
+    private Tuple<String, String> replace(SQLExpr field, String target, String replacement) {
         String name = nextId("replace");
-        if (Strings.isNullOrEmpty(valueName)) {
-            return new Tuple<>(name, def(name, getPropertyOrStringValue(field)
-                    + ".replace(" + target + "," + replacement + ")"));
-        } else {
-            return new Tuple<>(name, getPropertyOrStringValue(field) + ";"
-                    + def(name, valueName + ".replace(\" + target + \",\" + replacement + \")"));
-        }
+        return new Tuple<>(name, def(name, getPropertyOrStringValue(field)
+                + ".replace(" + target + "," + replacement + ")"));
     }
 
     // es behavior: both 'start' and return value are 1-index; return 0 if pattern does not exist;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -685,15 +685,18 @@ public class SQLFunctions {
         }
     }
 
+    // es behavior: both 'start' and return value are 1-index; return 0 if pattern does not exist;
+    // support out-of-bound index
     private Tuple<String, String> locate(String pattern, SQLExpr source, int start) {
         String name = nextId("locate");
         String docSource = getPropertyOrStringValue(source);
+        start = start < 1 ? 0 : start - 1;
         return new Tuple<>(name, StringUtils.format(
                 "int count=%d;int res=-1;" + "while(count< %s.length() - %s.length()) {"
                         + "if (%s == %s.substring(count, count+%s.length())) {"
                         + "res = count;break;} "
                         + "else {count++;}}"
-                        + def(name, "res"),
+                        + def(name, "res+1"),
                 start, docSource, pattern, pattern, docSource, pattern)
                 );
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -625,8 +625,8 @@ public class SQLFunctions {
 
     }
 
-    //substring(Column expr, int pos, int len)
-    //in painless language: substring(int begin, int end)
+    // query: substring(Column expr, int pos, int len)
+    // painless script: substring(int begin, int end)
     public Tuple<String, String> substring(SQLExpr field, int pos, int len, String valueName) {
         String name = nextId("substring");
         if (valueName == null) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -54,7 +54,7 @@ public class SQLFunctions {
     );
 
     private static final Set<String> stringOperators = Sets.newHashSet(
-            "split", "concat_ws", "substring", "trim", "lower", "upper",  "rtrim", "ltrim", "replace",
+            "split", "concat_ws", "substring", "trim", "lower", "upper", "rtrim", "ltrim", "replace",
             "left", "right"
     );
 
@@ -675,7 +675,7 @@ public class SQLFunctions {
     }
 
     private Tuple<String, String> replace(SQLExpr field, String target, String replacement, String valueName) {
-        String  name = nextId("replace");
+        String name = nextId("replace");
         if (Strings.isNullOrEmpty(valueName)) {
             return new Tuple<>(name, def(name, getPropertyOrStringValue(field)
                     + ".replace(" + target + "," + replacement + ")"));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -294,6 +294,11 @@ public class SQLFunctions {
                 break;
             case "length":
                 functionStr = length((SQLExpr) paramers.get(0).value);
+                break;
+//            case "replace":
+//                functionStr = replace((SQLExpr) paramers.get(0).value, (CharSequence) paramers.get(1),
+//                        (CharSequence) paramers.get(1).value);
+                break;
             default:
 
         }
@@ -626,6 +631,12 @@ public class SQLFunctions {
     private Tuple<String, String> length(SQLExpr field) {
         String name = nextId("length");
         return new Tuple<>(name, def(name, doc(field) + ".value" + ".length()"));
+    }
+
+    private Tuple<String, String> replace(SQLExpr field, CharSequence original, CharSequence replacement) {
+        String  name = nextId("replace");
+        return new Tuple<>(name, def(name,
+                doc(field) + ".value" + ".replace(" + original + ", " + replacement + ")"));
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -313,6 +313,8 @@ public class SQLFunctions {
             case "ltrim":
                 functionStr = ltrim((SQLExpr) paramers.get(0).value);
                 break;
+            case "ascii":
+                functionStr = ascii((SQLExpr) paramers.get(0).value);
             default:
 
         }
@@ -706,6 +708,11 @@ public class SQLFunctions {
                 + def(name, "%s.substring(pos, %s.length())"),
                 fieldString, fieldString, fieldString, fieldString
         ));
+    }
+
+    private Tuple<String, String> ascii(SQLExpr field) {
+        String name = nextId("ascii");
+        return new Tuple<>(name, def(name, "(int) " + getPropertyOrStringValue(field) + ".charAt(0)"));
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -53,7 +53,8 @@ public class SQLFunctions {
     );
 
     private static final Set<String> stringOperators = Sets.newHashSet(
-            "split", "concat_ws", "substring", "trim", "lower", "upper"
+            "split", "concat_ws", "substring", "trim", "lower", "upper", "ascii", "rtrim", "locate",
+            "length", "replace", "left", "right"
     );
 
     private static final Set<String> binaryOperators = Sets.newHashSet(
@@ -291,6 +292,8 @@ public class SQLFunctions {
             case "assign":
                 functionStr = assign((SQLExpr) paramers.get(0).value);
                 break;
+            case "length":
+                functionStr = length((SQLExpr) paramers.get(0).value);
             default:
 
         }
@@ -618,6 +621,11 @@ public class SQLFunctions {
 
     private String upper(String property, String culture) {
         return property + ".toUpperCase(Locale.forLanguageTag(\"" + culture + "\"))";
+    }
+
+    private Tuple<String, String> length(SQLExpr field) {
+        String name = nextId("length");
+        return new Tuple<>(name, def(name, doc(field) + ".value" + ".length()"));
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -54,8 +54,12 @@ public class SQLFunctions {
     );
 
     private static final Set<String> stringOperators = Sets.newHashSet(
-            "split", "concat_ws", "substring", "trim", "lower", "upper", "ascii", "rtrim", "ltrim", "locate",
-            "length", "replace", "left", "right"
+            "split", "concat_ws", "substring", "trim", "lower", "upper",  "rtrim", "ltrim", "replace",
+            "left", "right"
+    );
+
+    private static final Set<String> stringFunctions = Sets.newHashSet(
+            "length", "locate", "ascii"
     );
 
     private static final Set<String> binaryOperators = Sets.newHashSet(
@@ -74,6 +78,7 @@ public class SQLFunctions {
             mathConstants,
             trigFunctions,
             stringOperators,
+            stringFunctions,
             binaryOperators,
             dateFunctions,
             utilityFunctions)
@@ -731,6 +736,10 @@ public class SQLFunctions {
         if (mathConstants.contains(functionName) || numberOperators.contains(functionName)
                 || trigFunctions.contains(functionName) || binaryOperators.contains(functionName)) {
             return Schema.Type.DOUBLE;
+        }
+
+        if (stringFunctions.contains(functionName)) {
+            return Schema.Type.INTEGER;
         }
 
         throw new UnsupportedOperationException(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -300,15 +300,15 @@ public class SQLFunctions {
                 functionStr = replace((SQLExpr) paramers.get(0).value, paramers.get(1).value.toString(),
                         paramers.get(2).value.toString(), name);
                 break;
-//            case "left":
-//                functionStr = substring((SQLExpr) paramers.get(0).value, 0,
-//                        Integer.parseInt(paramers.get(1).value.toString()), null);
             case "locate":
                 int start = 0;
                 if (paramers.size() > 2) {
                     start = Integer.parseInt(paramers.get(2).value.toString());
                 }
                 functionStr = locate(paramers.get(0).value.toString(), (SQLExpr) paramers.get(1).value, start);
+                break;
+            case "rtrim":
+                functionStr = rtrim((SQLExpr) paramers.get(0).value);
             default:
 
         }
@@ -680,6 +680,18 @@ public class SQLFunctions {
                         + def(name, "res"),
                 start, docSource, pattern, pattern, docSource, pattern)
                 );
+    }
+
+    private Tuple<String, String> rtrim(SQLExpr field) {
+        String name = nextId("rtrim");
+        String fieldString = getPropertyOrStringValue(field);
+        return new Tuple<>(name, StringUtils.format(
+                "int pos=%s.length();"
+                + "while(%s.substring(pos-1, pos) == ' ' && pos > 0) {pos --;} "
+                + def(name, "%s.substring(0, pos)")
+                ,
+                fieldString, fieldString, fieldString
+        ));
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -691,23 +691,16 @@ public class SQLFunctions {
         String name = nextId("locate");
         String docSource = getPropertyOrStringValue(source);
         start = start < 1 ? 0 : start - 1;
-        return new Tuple<>(name, StringUtils.format(
-                "int count=%d;int res=-1;" + "while(count< %s.length() - %s.length()) {"
-                        + "if (%s == %s.substring(count, count+%s.length())) {"
-                        + "res = count;break;} "
-                        + "else {count++;}}"
-                        + def(name, "res+1"),
-                start, docSource, pattern, pattern, docSource, pattern)
-                );
+        return new Tuple<>(name, def(name, StringUtils.format("%s.indexOf(%s,%d)+1", docSource, pattern, start)));
     }
 
     private Tuple<String, String> rtrim(SQLExpr field) {
         String name = nextId("rtrim");
         String fieldString = getPropertyOrStringValue(field);
         return new Tuple<>(name, StringUtils.format(
-                "int pos=%s.length();"
-                + "while(%s.substring(pos-1, pos)==' ' && pos > 0) {pos --;} "
-                + def(name, "%s.substring(0, pos)"),
+                "int pos=%s.length()-1;"
+                + "while(pos >= 0 && Character.isWhitespace(%s.charAt(pos))) {pos --;} "
+                + def(name, "%s.substring(0, pos+1)"),
                 fieldString, fieldString, fieldString
         ));
     }
@@ -717,7 +710,7 @@ public class SQLFunctions {
         String fieldString = getPropertyOrStringValue(field);
         return new Tuple<>(name, StringUtils.format(
                 "int pos=0;"
-                + "while(%s.substring(pos, pos+1)==' ' && pos < %s.length()) {pos ++;} "
+                + "while(pos < %s.length() && Character.isWhitespace(%s.charAt(pos))) {pos ++;} "
                 + def(name, "%s.substring(pos, %s.length())"),
                 fieldString, fieldString, fieldString, fieldString
         ));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -24,7 +24,6 @@ import com.alibaba.druid.sql.ast.expr.SQLVariantRefExpr;
 import com.amazon.opendistroforelasticsearch.sql.domain.KVValue;
 import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema;
 import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.elasticsearch.common.collect.Tuple;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -15,8 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.sql.esintgtest;
 
-
-import com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -25,21 +23,18 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
-import org.hamcrest.Matcher;
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.IntStream;
 
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.hitAny;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kvDouble;
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kvInt;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kvString;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.both;
@@ -48,7 +43,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasValue;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
@@ -243,14 +237,76 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
     }
 
     @Test
-//    public void operatorLength() throws Exception {
-//        String query = "SELECT LENGTH(lastname) AS length, age FROM " + TEST_INDEX_ACCOUNT
-//                + "WHERE lastname IS NOT NULL GRUOP BY age ORDER BY age";
-//        assertThat(
-//                executeQuery(query, "jdbc"),
-//                contains()
-//        );
-//    }
+    public void operatorLength() throws IOException {
+        assertThat(
+                executeQuery("SELECT LENGTH(lastname) FROM " + TEST_INDEX_ACCOUNT
+                                + " WHERE lastname IS NOT NULL GROUP BY LENGTH(lastname) ORDER BY LENGTH(lastname)", "jdbc"),
+                containsString("\"type\": \"integer\"")
+        );
+
+        assertThat(
+                executeQuery("SELECT LENGTH('sampleName') AS length FROM " + TEST_INDEX_ACCOUNT),
+                hitAny(kvInt("/fields/length/0", equalTo(10)))
+        );
+
+    }
+
+    @Test
+    public void operatorReplace() {
+        String query = "SELECT REPLACE('elastic', 'el', 'fant') FROM " + TEST_INDEX_ACCOUNT;
+        assertThat(
+                executeQuery(query, "jdbc"),
+                containsString("fantastic")
+        );
+    }
+
+    @Test
+    public void operatorLocate() throws IOException {
+        String query = "SELECT LOCATE('a', lastname, 0) FROM " + TEST_INDEX_ACCOUNT
+                + " WHERE lastname IS NOT NULL GROUP BY LOCATE('a', lastname, 0) ORDER BY LOCATE('a', lastname, 0)";
+        assertThat(
+                executeQuery(query, "jdbc"), containsString("\"type\": \"integer\"")
+        );
+
+        assertThat(
+                executeQuery("SELECT LOCATE('a', 'sampleName', 2) AS locate FROM " + TEST_INDEX_ACCOUNT),
+                hitAny(kvInt("/fields/locate/0", equalTo(7)))
+        );
+        assertThat(
+                executeQuery("SELECT LOCATE('a', 'sampleName') AS locate FROM " + TEST_INDEX_ACCOUNT),
+                hitAny(kvInt("/fields/locate/0", equalTo(1)))
+        );
+    }
+
+    @Test
+    public void rtrim() {
+        assertThat(
+                executeQuery("SELECT RTRIM(' sampleName  ') FROM " + TEST_INDEX_ACCOUNT, "jdbc"),
+                containsString(" sampleName")
+        );
+    }
+
+    @Test
+    public void ltrim() {
+        assertThat(
+                executeQuery("SELECT LTRIM(' sampleName  ') FROM " + TEST_INDEX_ACCOUNT, "jdbc"),
+                containsString("sampleName  ")
+        );
+    }
+
+    @Test
+    public void ascii() throws IOException {
+        assertThat(
+                executeQuery("SELECT ASCII(lastname) FROM " + TEST_INDEX_ACCOUNT
+                        + " WHERE lastname IS NOT NULL GROUP BY ASCII(lastname) ORDER BY ASCII(lastname) LIMIT 5",
+                        "jdbc"),
+                containsString("\"type\": \"integer\"")
+        );
+        assertThat(
+                executeQuery("SELECT ASCII('sampleName') AS ascii FROM " + TEST_INDEX_ACCOUNT),
+                hitAny(kvInt("/fields/ascii/0", equalTo(115)))
+        );
+    }
 
     /**
      * Ignore this test case because painless doesn't whitelist String.split function.

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -242,6 +242,16 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
         );
     }
 
+    @Test
+//    public void operatorLength() throws Exception {
+//        String query = "SELECT LENGTH(lastname) AS length, age FROM " + TEST_INDEX_ACCOUNT
+//                + "WHERE lastname IS NOT NULL GRUOP BY age ORDER BY age";
+//        assertThat(
+//                executeQuery(query, "jdbc"),
+//                contains()
+//        );
+//    }
+
     /**
      * Ignore this test case because painless doesn't whitelist String.split function.
      * @see <a href="https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html">https://www.elastic.co/guide/en/elasticsearch/painless/7.0/painless-api-reference.html</a>

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -269,7 +269,7 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
         String query = "SELECT REPLACE('elastic', 'el', 'fant') FROM " + TEST_INDEX_ACCOUNT;
         assertThat(
                 executeQuery(query, "jdbc"),
-                containsString("fantastic")
+                equalTo("fantastic")
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -237,17 +237,15 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void operatorSubstring() {
+    public void operatorSubstring() throws IOException {
         assertThat(
-                executeQuery("SELECT substring('sampleName', 1, 4) FROM " + TEST_INDEX_ACCOUNT,
-                        "jdbc"),
-                containsString("samp")
+                executeQuery("SELECT substring('sampleName', 1, 4) AS substring FROM " + TEST_INDEX_ACCOUNT),
+                hitAny(kvString("/fields/substring/0", equalTo("samp")))
         );
 
         assertThat(
-                executeQuery("SELECT substring('sampleName', 0, 20) FROM " + TEST_INDEX_ACCOUNT,
-                        "jdbc"),
-                containsString("sampleName")
+                executeQuery("SELECT substring('sampleName', 0, 20) AS substring FROM " + TEST_INDEX_ACCOUNT),
+                hitAny(kvString("/fields/substring/0", equalTo("sampleName")))
         );
     }
 
@@ -294,18 +292,18 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void rtrim() {
+    public void rtrim() throws IOException {
         assertThat(
-                executeQuery("SELECT RTRIM(' sampleName  ') FROM " + TEST_INDEX_ACCOUNT, "jdbc"),
-                containsString(" sampleName")
+                executeQuery("SELECT RTRIM(' sampleName  ') AS rtrim FROM " + TEST_INDEX_ACCOUNT),
+                hitAny(kvString("/fields/rtrim/0", equalTo(" sampleName")))
         );
     }
 
     @Test
-    public void ltrim() {
+    public void ltrim() throws IOException {
         assertThat(
-                executeQuery("SELECT LTRIM(' sampleName  ') FROM " + TEST_INDEX_ACCOUNT, "jdbc"),
-                containsString("sampleName  ")
+                executeQuery("SELECT LTRIM(' sampleName  ') AS ltrim FROM " + TEST_INDEX_ACCOUNT),
+                hitAny(kvString("/fields/ltrim/0",equalTo( "sampleName  ")))
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -237,6 +237,21 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
     }
 
     @Test
+    public void operatorSubstring() {
+        assertThat(
+                executeQuery("SELECT substring('sampleName', 1, 4) FROM " + TEST_INDEX_ACCOUNT,
+                        "jdbc"),
+                containsString("samp")
+        );
+
+        assertThat(
+                executeQuery("SELECT substring('sampleName', 0, 20) FROM " + TEST_INDEX_ACCOUNT,
+                        "jdbc"),
+                containsString("sampleName")
+        );
+    }
+
+    @Test
     public void operatorLength() throws IOException {
         assertThat(
                 executeQuery("SELECT LENGTH(lastname) FROM " + TEST_INDEX_ACCOUNT
@@ -269,12 +284,12 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
         );
 
         assertThat(
-                executeQuery("SELECT LOCATE('a', 'sampleName', 2) AS locate FROM " + TEST_INDEX_ACCOUNT),
-                hitAny(kvInt("/fields/locate/0", equalTo(7)))
+                executeQuery("SELECT LOCATE('a', 'sampleName', 3) AS locate FROM " + TEST_INDEX_ACCOUNT),
+                hitAny(kvInt("/fields/locate/0", equalTo(8)))
         );
         assertThat(
                 executeQuery("SELECT LOCATE('a', 'sampleName') AS locate FROM " + TEST_INDEX_ACCOUNT),
-                hitAny(kvInt("/fields/locate/0", equalTo(1)))
+                hitAny(kvInt("/fields/locate/0", equalTo(2)))
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/StringOperatorsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/StringOperatorsTest.java
@@ -1,3 +1,18 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
 package com.amazon.opendistroforelasticsearch.sql.unittest;
 
 import com.amazon.opendistroforelasticsearch.sql.parser.ScriptFilter;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/StringOperatorsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/StringOperatorsTest.java
@@ -1,0 +1,182 @@
+package com.amazon.opendistroforelasticsearch.sql.unittest;
+
+import com.amazon.opendistroforelasticsearch.sql.parser.ScriptFilter;
+import com.amazon.opendistroforelasticsearch.sql.parser.SqlParser;
+import com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents;
+import org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class StringOperatorsTest {
+
+    private static SqlParser parser;
+
+    @BeforeClass
+    public static void init() { parser = new SqlParser(); }
+
+    @Test
+    public void substringTest() {
+        String query = "SELECT substring(lastname, 2, 1) FROM accounts WHERE substring(lastname, 2, 1) = 'a' " +
+                "GROUP BY substring(lastname, 2, 1) ORDER BY substring(lastname, 2, 1)";
+
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptField,
+                        "doc['lastname'].value.substring(1, 2)"));
+
+        ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptFilter,
+                        "doc['lastname'].value.substring(1, 2)"
+                )
+        );
+    }
+
+    @Test
+    public void substringIndexOutOfBoundTest() {
+        String query = "SELECT substring('sampleName', 0, 20) FROM accounts";
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptField,
+                        "'sampleName'.substring(0, 10)"
+                )
+        );
+    }
+
+    @Test
+    public void lengthTest() {
+        String query = "SELECT length(lastname) FROM accounts WHERE length(lastname) = 5 " +
+                "GROUP BY length(lastname) ORDER BY length(lastname)";
+
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptField,
+                        "doc['lastname'].value.length()"
+                )
+        );
+
+        ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptFilter,
+                        "doc['lastname'].value.length()"
+                )
+        );
+    }
+
+    @Test
+    public void replaceTest() {
+        String query = "SELECT replace(lastname, 'a', 'A') FROM accounts WHERE replace(lastname, 'a', 'A') = 'aba' " +
+                "GROUP BY replace(lastname, 'a', 'A') ORDER BY replace(lastname, 'a', 'A')";
+
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptField,
+                        "doc['lastname'].value.replace('a','A')"
+                )
+        );
+
+        ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptFilter,
+                        "doc['lastname'].value.replace('a','A')"
+                )
+        );
+    }
+
+    @Test
+    public void locateTest() {
+        String query = "SELECT locate('a', lastname, 1) FROM accounts WHERE locate('a', lastname, 1) = 4 " +
+                "GROUP BY locate('a', lastname, 1) ORDER BY locate('a', lastname, 1)";
+
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptField,
+                        "if ('a' == doc['lastname'].value.substring("
+                )
+        );
+
+        ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptFilter,
+                        "if ('a' == doc['lastname'].value.substring("
+                )
+        );
+    }
+
+    @Test
+    public void ltrimTest() {
+        String query = "SELECT ltrim(lastname) FROM accounts WHERE ltrim(lastname) = 'abc' " +
+                "GROUP BY ltrim(lastname) ORDER BY ltrim(lastname)";
+
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptField,
+                        "doc['lastname'].value.substring(pos, doc['lastname'].value.length())"
+                )
+        );
+
+        ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptFilter,
+                        "doc['lastname'].value.substring(pos, doc['lastname'].value.length())"
+                )
+        );
+    }
+
+    @Test
+    public void rtrimTest() {
+        String query = "SELECT rtrim(lastname) FROM accounts WHERE rtrim(lastname) = 'cba' " +
+                "GROUP BY rtrim(lastname) ORDER BY rtrim(lastname)";
+
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptField,
+                        "doc['lastname'].value.substring(0, pos)"
+                )
+        );
+
+        ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptFilter,
+                        "doc['lastname'].value.substring(0, pos)"
+                )
+        );
+    }
+
+    @Test
+    public void asciiTest() {
+        String query = "SELECT ascii(lastname) FROM accounts WHERE ascii(lastname) = 108 " +
+                "GROUP BY ascii(lastname) ORDER BY ascii(lastname)";
+
+        ScriptField scriptField = CheckScriptContents.getScriptFieldFromQuery(query);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptField,
+                        "(int) doc['lastname'].value.charAt(0)"
+                )
+        );
+
+        ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
+        assertTrue(
+                CheckScriptContents.scriptContainsString(
+                        scriptFilter,
+                        "(int) doc['lastname'].value.charAt(0)"
+                )
+        );
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/StringOperatorsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/StringOperatorsTest.java
@@ -116,7 +116,7 @@ public class StringOperatorsTest {
         assertTrue(
                 CheckScriptContents.scriptContainsString(
                         scriptField,
-                        "if ('a' == doc['lastname'].value.substring("
+                        "doc['lastname'].value.indexOf('a',0)+1"
                 )
         );
 
@@ -124,7 +124,7 @@ public class StringOperatorsTest {
         assertTrue(
                 CheckScriptContents.scriptContainsString(
                         scriptFilter,
-                        "if ('a' == doc['lastname'].value.substring("
+                        "doc['lastname'].value.indexOf('a',0)+1"
                 )
         );
     }
@@ -138,7 +138,7 @@ public class StringOperatorsTest {
         assertTrue(
                 CheckScriptContents.scriptContainsString(
                         scriptField,
-                        "doc['lastname'].value.substring(pos, doc['lastname'].value.length())"
+                        "Character.isWhitespace(doc['lastname'].value.charAt(pos))"
                 )
         );
 
@@ -146,7 +146,7 @@ public class StringOperatorsTest {
         assertTrue(
                 CheckScriptContents.scriptContainsString(
                         scriptFilter,
-                        "doc['lastname'].value.substring(pos, doc['lastname'].value.length())"
+                        "Character.isWhitespace(doc['lastname'].value.charAt(pos))"
                 )
         );
     }
@@ -160,7 +160,7 @@ public class StringOperatorsTest {
         assertTrue(
                 CheckScriptContents.scriptContainsString(
                         scriptField,
-                        "doc['lastname'].value.substring(0, pos)"
+                        "Character.isWhitespace(doc['lastname'].value.charAt(pos))"
                 )
         );
 
@@ -168,7 +168,7 @@ public class StringOperatorsTest {
         assertTrue(
                 CheckScriptContents.scriptContainsString(
                         scriptFilter,
-                        "doc['lastname'].value.substring(0, pos)"
+                        "Character.isWhitespace(doc['lastname'].value.charAt(pos))"
                 )
         );
     }


### PR DESCRIPTION
*Issue #, if available:*

* [**Issue #224 Support for extra functions required by BI tools**](https://github.com/opendistro-for-elasticsearch/sql/issues/224)
* [**Issue #235 Unable to recognize certain function names**](https://github.com/opendistro-for-elasticsearch/sql/issues/235)
* [**Issue #226 SUBSTRING() function is 0-indexed**](https://github.com/opendistro-for-elasticsearch/sql/issues/226)

*Description of changes:*

* Implemented string operators: ASCII, RTRIM, LTRIM, LOCATE, LENGTH, REPLACE
* Modified SUBSTRING: 1) SUBSTRING(source, start, end) --> SUBSTRING(source, start, length), 2) 0-index --> 1-index
* Added IT and UT

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
