### PR TITLE
Opendistro 0.10: add missing buildDeb

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,4 +209,9 @@ afterEvaluate {
         archiveName "${packageName}-${version}.deb"
         dependsOn 'assemble'
     }
+
+    task buildPackages(type: GradleBuild) {
+         tasks = ['build', 'buildRpm', 'buildDeb']
+    }
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,6 @@ afterEvaluate {
         dirMode 0755
 
         requires('elasticsearch-oss', versions.elasticsearch, EQUAL)
-        arch = 'NOARCH'
         packager = 'Amazon'
         vendor = 'Amazon'
         os = 'LINUX'
@@ -200,7 +199,14 @@ afterEvaluate {
     }
 
     buildRpm {
+        arch = 'NOARCH'
         archiveName "${packageName}-${version}.rpm"
+        dependsOn 'assemble'
+    }
+
+    buildDeb {
+        arch = 'amd64'
+        archiveName "${packageName}-${version}.deb"
         dependsOn 'assemble'
     }
 }


### PR DESCRIPTION
Fix Issue #211: opendistro-sql v0.10.0.0 not available in Repositories.

Cherry-picked 16d399c and ed6c046 which added the missing buildDeb function.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.