### PR TITLE
Fix issue that IP type cannot pass JDBC formatter

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/Schema.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/Schema.java
@@ -99,13 +99,12 @@ public class Schema implements Iterable<Schema.Column> {
 
     // Only core ES datatypes currently supported
     public enum Type {
-        TEXT, KEYWORD, // String types
+        TEXT, KEYWORD, IP, // String types
         LONG, INTEGER, SHORT, BYTE, DOUBLE, FLOAT, HALF_FLOAT, SCALED_FLOAT, // Numeric types
         DATE, // Date types
         BOOLEAN, // Boolean types
         BINARY, // Binary types
-        INTEGER_RANGE, FLOAT_RANGE, LONG_RANGE, DOUBLE_RANGE, DATE_RANGE, // Range types
-        IP;
+        INTEGER_RANGE, FLOAT_RANGE, LONG_RANGE, DOUBLE_RANGE, DATE_RANGE; // Range types
 
         public String nameLowerCase() {
             return name().toLowerCase();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/Schema.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/Schema.java
@@ -104,7 +104,8 @@ public class Schema implements Iterable<Schema.Column> {
         DATE, // Date types
         BOOLEAN, // Boolean types
         BINARY, // Binary types
-        INTEGER_RANGE, FLOAT_RANGE, LONG_RANGE, DOUBLE_RANGE, DATE_RANGE; // Range types
+        INTEGER_RANGE, FLOAT_RANGE, LONG_RANGE, DOUBLE_RANGE, DATE_RANGE, // Range types
+        IP;
 
         public String nameLowerCase() {
             return name().toLowerCase();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.sql.esintgtest;
 import org.json.JSONObject;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class JdbcTestIT extends SQLIntegTestCase {
@@ -27,6 +28,7 @@ public class JdbcTestIT extends SQLIntegTestCase {
         loadIndex(Index.ONLINE);
         loadIndex(Index.PEOPLE);
         loadIndex(Index.ACCOUNT);
+        loadIndex(Index.WEBLOG);
     }
 
     public void testPercentilesQuery() {
@@ -124,6 +126,14 @@ public class JdbcTestIT extends SQLIntegTestCase {
                         "WHERE date_format(insert_time, 'yyyy-MM-dd', 'UTC') > '2014-01-01' " +
                         "GROUP BY date_format(insert_time, 'yyyy-MM-dd', 'UTC') " +
                         "ORDER BY date_format(insert_time, 'yyyy-MM-dd', 'UTC')", "jdbc")
+        );
+    }
+
+    @Test
+    public void ipTypeShouldPassJdbcFormatter() {
+        assertThat(
+                executeQuery("SELECT host FROM " + TestsConstants.TEST_INDEX_WEBLOG, "jdbc"),
+                containsString("\"type\": \"ip\"")
         );
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -132,7 +132,8 @@ public class JdbcTestIT extends SQLIntegTestCase {
     @Test
     public void ipTypeShouldPassJdbcFormatter() {
         assertThat(
-                executeQuery("SELECT host FROM " + TestsConstants.TEST_INDEX_WEBLOG, "jdbc"),
+                executeQuery("SELECT host AS hostIP FROM " + TestsConstants.TEST_INDEX_WEBLOG
+                        + " ORDER BY hostIP", "jdbc"),
                 containsString("\"type\": \"ip\"")
         );
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
@@ -331,7 +331,11 @@ public abstract class SQLIntegTestCase extends ESIntegTestCase {
         ORDER(TestsConstants.TEST_INDEX_ORDER,
                 "_doc",
                  TestUtils.getOrderIndexMapping(),
-                "src/test/resources/order.json");
+                "src/test/resources/order.json"),
+        WEBLOG(TestsConstants.TEST_INDEX_WEBLOG,
+                "weblog",
+                TestUtils.getWeblogsIndexMapping(),
+                "src/test/resources/weblogs.json");
 
         private final String name;
         private final String type;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -494,6 +494,30 @@ public class TestUtils {
             "}";
     }
 
+    public static String getWeblogsIndexMapping() {
+        return "{\n" +
+                "  \"weblog\": {\n" +
+                "    \"properties\": {\n" +
+                "      \"host\": {\n" +
+                "        \"type\": \"ip\"\n" +
+                "      },\n" +
+                "      \"method\": {\n" +
+                "        \"type\": \"text\"\n" +
+                "      },\n" +
+                "      \"url\": {\n" +
+                "        \"type\": \"text\"\n" +
+                "      },\n" +
+                "      \"response\": {\n" +
+                "        \"type\": \"text\"\n" +
+                "      },\n" +
+                "      \"bytes\": {\n" +
+                "        \"type\": \"text\"\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+    }
+
     public static void loadBulk(Client client, String jsonPath, String defaultIndex) throws Exception {
         System.out.println(String.format("Loading file %s into elasticsearch cluster", jsonPath));
         String absJsonPath = getResourceFilePath(jsonPath);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestsConstants.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestsConstants.java
@@ -43,6 +43,7 @@ public class TestsConstants {
     public final static String TEST_INDEX_BANK = TEST_INDEX + "_bank";
     public final static String TEST_INDEX_BANK_TWO = TEST_INDEX_BANK + "_two";
     public final static String TEST_INDEX_ORDER = TEST_INDEX + "_order";
+    public final static String TEST_INDEX_WEBLOG = TEST_INDEX + "_weblog";
 
     public final static String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     public final static String TS_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";

--- a/src/test/resources/weblogs.json
+++ b/src/test/resources/weblogs.json
@@ -1,0 +1,6 @@
+{"index":{"_type": "weblog"}}
+{"host": "199.72.81.55", "method": "GET", "url": "/history/apollo/", "response": "200", "bytes": "6245"}
+{"index":{"_type": "weblog"}}
+{"host": "199.120.110.21", "method": "GET", "url": "/shuttle/missions/sts-73/mission-sts-73.html", "response": "200", "bytes": "4085"}
+{"index":{"_type": "weblog"}}
+{"host": "205.212.115.106", "method": "GET", "url": "/shuttle/countdown/countdown.html", "response": "200", "bytes": "3985"}


### PR DESCRIPTION
*Issue #, if available:*

* [**Issue #272 IP field types are currently not supported.**](https://github.com/opendistro-for-elasticsearch/sql/issues/272)

*Description of changes:*

* Fixed the JDBC formatter for the IP type.
* Appended dataset with field of IP type.
* Added and passed the integration test, manually sanity tested on Kibana.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
