### PR TITLE
Support subquery in from with parent only has select

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/visitor/AntlrSqlParseTreeVisitor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/visitor/AntlrSqlParseTreeVisitor.java
@@ -19,6 +19,7 @@ import com.amazon.opendistroforelasticsearch.sql.antlr.parser.OpenDistroSqlParse
 import com.amazon.opendistroforelasticsearch.sql.antlr.parser.OpenDistroSqlParser.InnerJoinContext;
 import com.amazon.opendistroforelasticsearch.sql.antlr.parser.OpenDistroSqlParser.QuerySpecificationContext;
 import com.amazon.opendistroforelasticsearch.sql.antlr.parser.OpenDistroSqlParser.SelectColumnElementContext;
+import com.amazon.opendistroforelasticsearch.sql.antlr.parser.OpenDistroSqlParser.SubqueryTableItemContext;
 import com.amazon.opendistroforelasticsearch.sql.antlr.parser.OpenDistroSqlParser.TableNamePatternContext;
 import com.amazon.opendistroforelasticsearch.sql.antlr.parser.OpenDistroSqlParserBaseVisitor;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -172,6 +173,11 @@ public class AntlrSqlParseTreeVisitor<T extends Reducible> extends OpenDistroSql
 
         visitor.endVisitQuery();
         return result;
+    }
+
+    @Override
+    public T visitSubqueryTableItem(SubqueryTableItemContext ctx) {
+        throw new EarlyExitAnalysisException("Exit when meeting subquery in from");
     }
 
     /** Visit here instead of tableName because we need alias */

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Having.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/Having.java
@@ -72,6 +72,10 @@ public class Having {
         conditions = parseHavingExprToConditions(havingExpr, havingParser);
     }
 
+    public List<Where> getConditions() {
+        return conditions;
+    }
+
     /**
      * Construct by GROUP BY expression with null check
      *

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SqlParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SqlParser.java
@@ -74,10 +74,13 @@ public class SqlParser {
     }
 
     public Select parseSelect(SQLQueryExpr mySqlExpr) throws SqlParseException {
-
         MySqlSelectQueryBlock query = (MySqlSelectQueryBlock) mySqlExpr.getSubQuery().getQuery();
-
-        return parseSelect(query);
+        SubQueryParser subQueryParser = new SubQueryParser(this);
+        if (subQueryParser.containSubqueryInFrom(query)) {
+            return subQueryParser.parseSubQueryInFrom(query);
+        } else {
+            return parseSelect(query);
+        }
     }
 
     public Select parseSelect(MySqlSelectQueryBlock query) throws SqlParseException {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SubQueryParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SubQueryParser.java
@@ -1,0 +1,114 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.parser;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
+import com.alibaba.druid.sql.ast.statement.SQLSubqueryTableSource;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
+import com.amazon.opendistroforelasticsearch.sql.domain.Condition;
+import com.amazon.opendistroforelasticsearch.sql.domain.Field;
+import com.amazon.opendistroforelasticsearch.sql.domain.Order;
+import com.amazon.opendistroforelasticsearch.sql.domain.Select;
+import com.amazon.opendistroforelasticsearch.sql.domain.Where;
+import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
+import com.google.common.base.Strings;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Definition of SubQuery Parser
+ */
+public class SubQueryParser {
+    private final SqlParser sqlParser;
+
+    public SubQueryParser(SqlParser sqlParser) {
+        this.sqlParser = sqlParser;
+    }
+
+    public boolean containSubqueryInFrom(MySqlSelectQueryBlock query) {
+        return query.getFrom() instanceof SQLSubqueryTableSource;
+    }
+
+    public Select parseSubQueryInFrom(MySqlSelectQueryBlock query) throws SqlParseException {
+        assert query.getFrom() instanceof SQLSubqueryTableSource;
+
+        Select select = sqlParser.parseSelect(
+                (MySqlSelectQueryBlock) ((SQLSubqueryTableSource) query.getFrom()).getSelect()
+                .getQuery());
+        String subQueryAlias = query.getFrom().getAlias();
+        return pushSelect(query.getSelectList(), select, subQueryAlias);
+    }
+
+    private Select pushSelect(List<SQLSelectItem> selectItems, Select subquerySelect, String subQueryAlias) {
+        Map<String, Function<String, String>> fieldAliasRewriter = prepareFieldAliasRewriter(
+                selectItems,
+                subQueryAlias);
+
+        //1. rewrite field in select list
+        for (Field field : subquerySelect.getFields()) {
+            /*
+             * return true if the subquerySelectItem in the final select list.
+             * for example, subquerySelectItem is "SUM(emp.empno) as TEMP",
+             * and final select list is TEMP. then return true.
+             */
+            if (fieldAliasRewriter.containsKey(field.getAlias())) {
+                field.setAlias(fieldAliasRewriter.get(field.getAlias()).apply(field.getAlias()));
+            }
+        }
+
+        //2. rewrite field in order by
+        for (Order orderBy : subquerySelect.getOrderBys()) {
+            if (fieldAliasRewriter.containsKey(orderBy.getName())) {
+                String replaceOrderName = fieldAliasRewriter.get(orderBy.getName()).apply(orderBy.getName());
+                orderBy.setName(replaceOrderName);
+                orderBy.getSortField().setName(replaceOrderName);
+            }
+        }
+
+        // 3. rewrite field in having
+        if (subquerySelect.getHaving() != null) {
+            for (Where condition : subquerySelect.getHaving().getConditions()) {
+                Condition cond = (Condition) condition;
+                if (fieldAliasRewriter.containsKey(cond.getName())) {
+                    String replaceOrderName = fieldAliasRewriter.get(cond.getName()).apply(cond.getName());
+                    cond.setName(replaceOrderName);
+                }
+            }
+        }
+        return subquerySelect;
+    }
+
+    private Map<String, Function<String, String>> prepareFieldAliasRewriter(List<SQLSelectItem> selectItems,
+                                                                          String owner) {
+        HashMap<String, Function<String, String>> selectMap = new HashMap<>();
+        for (SQLSelectItem item : selectItems) {
+            if (Strings.isNullOrEmpty(item.getAlias())) {
+                selectMap.put(getFieldName(item.getExpr(), owner), s -> s);
+            } else {
+                selectMap.put(getFieldName(item.getExpr(), owner), s -> item.getAlias());
+            }
+        }
+        return selectMap;
+    }
+
+    private String getFieldName(SQLExpr expr, String owner) {
+        return expr.toString().replace(String.format("%s.", owner), "");
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SubQueryParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/SubQueryParser.java
@@ -28,6 +28,7 @@ import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.google.common.base.Strings;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -62,7 +63,9 @@ public class SubQueryParser {
                 subQueryAlias);
 
         //1. rewrite field in select list
-        for (Field field : subquerySelect.getFields()) {
+        Iterator<Field> fieldIterator = subquerySelect.getFields().iterator();
+        while (fieldIterator.hasNext()) {
+            Field field = fieldIterator.next();
             /*
              * return true if the subquerySelectItem in the final select list.
              * for example, subquerySelectItem is "SUM(emp.empno) as TEMP",
@@ -70,6 +73,8 @@ public class SubQueryParser {
              */
             if (fieldAliasRewriter.containsKey(field.getAlias())) {
                 field.setAlias(fieldAliasRewriter.get(field.getAlias()).apply(field.getAlias()));
+            } else {
+                fieldIterator.remove();
             }
         }
 
@@ -100,7 +105,7 @@ public class SubQueryParser {
         HashMap<String, Function<String, String>> selectMap = new HashMap<>();
         for (SQLSelectItem item : selectItems) {
             if (Strings.isNullOrEmpty(item.getAlias())) {
-                selectMap.put(getFieldName(item.getExpr(), owner), s -> s);
+                selectMap.put(getFieldName(item.getExpr(), owner), Function.identity());
             } else {
                 selectMap.put(getFieldName(item.getExpr(), owner), s -> item.getAlias());
             }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerSubqueryTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerSubqueryTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.antlr.semantic;
 
+import com.amazon.opendistroforelasticsearch.sql.antlr.visitor.EarlyExitAnalysisException;
 import org.junit.Test;
 
 /**
@@ -105,4 +106,11 @@ public class SemanticAnalyzerSubqueryTest extends SemanticAnalyzerTestBase {
         validate("SELECT * FROM semantics s WHERE EXISTS (SELECT 1 FROM s.projects p)");
     }
 
+    /**
+     * Ignore the semantic analyzer by using {@link EarlyExitAnalysisException}
+     */
+    @Test
+    public void useSubqueryInFromClauseWithSelectConstantShouldPass() {
+        validate("SELECT t.TEMP as count FROM (SELECT COUNT(*) as TEMP FROM semantics) t");
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SubQueryParserTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SubQueryParserTest.java
@@ -1,0 +1,140 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.parser;
+
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.amazon.opendistroforelasticsearch.sql.domain.Condition;
+import com.amazon.opendistroforelasticsearch.sql.domain.Select;
+import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
+import com.amazon.opendistroforelasticsearch.sql.parser.ElasticSqlExprParser;
+import com.amazon.opendistroforelasticsearch.sql.parser.SqlParser;
+import com.amazon.opendistroforelasticsearch.sql.utils.StringUtils;
+import org.junit.Test;
+
+import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ACCOUNT;
+import static org.junit.Assert.assertEquals;
+
+public class SubQueryParserTest {
+
+    private static SqlParser parser = new SqlParser();
+
+    @Test
+    public void selectFromSubqueryShouldPass() throws SqlParseException {
+        Select select = parseSelect(
+                StringUtils.format(
+                        "SELECT t.T1 as age1, t.T2 as balance1 " +
+                        "FROM (SELECT age as T1, balance as T2 FROM %s/account) t",
+                        TEST_INDEX_ACCOUNT));
+
+        assertEquals(2, select.getFields().size());
+        assertEquals("age", select.getFields().get(0).getName());
+        assertEquals("age1", select.getFields().get(0).getAlias());
+        assertEquals("balance", select.getFields().get(1).getName());
+        assertEquals("balance1", select.getFields().get(1).getAlias());
+    }
+
+    @Test
+    public void selectFromSubqueryShouldIgnoreUnusedField() throws SqlParseException {
+        Select select = parseSelect(
+                StringUtils.format(
+                        "SELECT t.T1 as age1 " +
+                        "FROM (SELECT age as T1, balance as T2 FROM %s/account) t",
+                        TEST_INDEX_ACCOUNT));
+
+        assertEquals(1, select.getFields().size());
+        assertEquals("age", select.getFields().get(0).getName());
+        assertEquals("age1", select.getFields().get(0).getAlias());
+    }
+
+    @Test
+    public void selectFromSubqueryWithAggShouldPass() throws SqlParseException {
+        Select select = parseSelect(
+                StringUtils.format(
+                        "SELECT t.TEMP as count " +
+                        "FROM (SELECT COUNT(*) as TEMP FROM %s/account) t",
+                        TEST_INDEX_ACCOUNT));
+        assertEquals(1, select.getFields().size());
+        assertEquals("COUNT", select.getFields().get(0).getName());
+        assertEquals("count", select.getFields().get(0).getAlias());
+    }
+
+    @Test
+    public void selectFromSubqueryWithWhereAndCountShouldPass() throws SqlParseException {
+        Select select = parseSelect(
+                StringUtils.format(
+                        "SELECT t.TEMP as count " +
+                        "FROM (SELECT COUNT(*) as TEMP FROM %s/account WHERE age > 30) t",
+                        TEST_INDEX_ACCOUNT));
+
+        assertEquals(1, select.getFields().size());
+        assertEquals("COUNT", select.getFields().get(0).getName());
+        assertEquals("count", select.getFields().get(0).getAlias());
+    }
+
+    @Test
+    public void selectFromSubqueryWithCountAndGroupByAndOrderByShouldPass() throws SqlParseException {
+        Select select = parseSelect(
+                StringUtils.format(
+                        "SELECT t.TEMP as count " +
+                        "FROM (SELECT COUNT(*) as TEMP FROM %s/account GROUP BY age ORDER BY TEMP) t",
+                        TEST_INDEX_ACCOUNT));
+
+        assertEquals(1, select.getFields().size());
+        assertEquals("COUNT", select.getFields().get(0).getName());
+        assertEquals("count", select.getFields().get(0).getAlias());
+        assertEquals(1, select.getOrderBys().size());
+        assertEquals("count", select.getOrderBys().get(0).getName());
+        assertEquals("count", select.getOrderBys().get(0).getSortField().getName());
+    }
+
+    @Test
+    public void selectFromSubqueryWithCountAndGroupByAndHavingShouldPass() throws Exception {
+
+        Select select = parseSelect(
+                StringUtils.format("SELECT t.T1 as g, t.T2 as c " +
+                                   "FROM (SELECT gender as T1, COUNT(*) as T2 " +
+                                   "      FROM %s/account " +
+                                   "      GROUP BY gender " +
+                                   "      HAVING T2 > 500) t", TEST_INDEX_ACCOUNT));
+
+        assertEquals(2, select.getFields().size());
+        assertEquals("gender", select.getFields().get(0).getName());
+        assertEquals("g", select.getFields().get(0).getAlias());
+        assertEquals("COUNT", select.getFields().get(1).getName());
+        assertEquals("c", select.getFields().get(1).getAlias());
+        assertEquals(1, select.getHaving().getConditions().size());
+        assertEquals("c", ((Condition) select.getHaving().getConditions().get(0)).getName());
+    }
+
+    @Test
+    public void selectFromSubqueryCountAndSum() throws Exception {
+        Select select = parseSelect(
+                StringUtils.format(
+                        "SELECT t.TEMP1 as count, t.TEMP2 as balance " +
+                        "FROM (SELECT COUNT(*) as TEMP1, SUM(balance) as TEMP2 " +
+                        "      FROM %s/account) t",
+                        TEST_INDEX_ACCOUNT));
+        assertEquals(2, select.getFields().size());
+        assertEquals("COUNT", select.getFields().get(0).getName());
+        assertEquals("count", select.getFields().get(0).getAlias());
+        assertEquals("SUM", select.getFields().get(1).getName());
+        assertEquals("balance", select.getFields().get(1).getAlias());
+    }
+
+    private Select parseSelect(String query) throws SqlParseException {
+        return parser.parseSelect((SQLQueryExpr) new ElasticSqlExprParser(query).expr());
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #230 

*Description of changes:*
Support subquery in from with parent only has select. 

#### To reviewer
* The current solution bypass the failed semantic check failed when subquery in from. There is no good solution found to decide whether the context frame should be poped or keep. For example, the if the subquery in where clause, the frame context frame shoud be poped. But when subquery in from clause, the frame context should be keeped to make the expression in select could be resolved in the frame context.
*  The current solution push the select in the outer query to subquery in from clause and rewrite the field in the subquery.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
