### PR TITLE
Support datetime functions: MONTH, DAYOFMONTH, DATE, MONTHNAME, TIMESTAMP, MAKETIME, NOW, CURDATE

### DIFF
--- a/src/main/antlr/OpenDistroSqlParser.g4
+++ b/src/main/antlr/OpenDistroSqlParser.g4
@@ -413,6 +413,8 @@ functionNameBase
     | E | EXP | EXPM1 | FLOOR | LOG | LOG10 | LOG2 | LOWER
     | PI | POW | RADIANS | RANDOM | RINT | ROUND
     | SIN | SINH | SQRT | SUBSTRING | TAN | TRIM | UPPER | YEAR
+    | MONTH | DAYOFMONTH | DATE | MONTHNAME | TIMESTAMP
+    | MAKETIME | NOW | CURDATE
     ;
 
 esFunctionNameBase

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -17,8 +17,8 @@ package com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.function;
 
 import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.Type;
 import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.TypeExpression;
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType;
 
-import static com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType.DATE;
 import static com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType.DOUBLE;
 import static com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType.INTEGER;
 import static com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType.NUMBER;
@@ -43,8 +43,8 @@ public enum ScalarFunction implements TypeExpression {
     COSH(func(T(NUMBER)).to(T)),
     COT(func(T(NUMBER)).to(T)),
     DATE_FORMAT(
-        func(DATE, STRING).to(STRING),
-        func(DATE, STRING, STRING).to(STRING)
+        func(ESDataType.DATE, STRING).to(STRING),
+        func(ESDataType.DATE, STRING, STRING).to(STRING)
     ),
     DEGREES(func(T(NUMBER)).to(T)),
     E(func().to(DOUBLE)),
@@ -91,7 +91,15 @@ public enum ScalarFunction implements TypeExpression {
         func(T(STRING)).to(T),
         func(T(STRING), STRING).to(T)
     ),
-    YEAR(func(DATE).to(INTEGER));
+    YEAR(func(ESDataType.DATE).to(INTEGER)),
+    MONTH(func(ESDataType.DATE).to(INTEGER)),
+    MONTHNAME(func(ESDataType.DATE).to(STRING)),
+    DAYOFMONTH(func(ESDataType.DATE).to(INTEGER)),
+    DATE(func(ESDataType.DATE).to(ESDataType.DATE)),
+    TIMESTAMP(func(ESDataType.DATE).to(ESDataType.DATE)),
+    MAKETIME(func(INTEGER, INTEGER, INTEGER).to(ESDataType.DATE)),
+    NOW(),
+    CURDATE();
 
     private final TypeExpressionSpec[] specifications;
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -98,8 +98,8 @@ public enum ScalarFunction implements TypeExpression {
     DATE(func(ESDataType.DATE).to(ESDataType.DATE)),
     TIMESTAMP(func(ESDataType.DATE).to(ESDataType.DATE)),
     MAKETIME(func(INTEGER, INTEGER, INTEGER).to(ESDataType.DATE)),
-    NOW(),
-    CURDATE();
+    NOW(func().to(ESDataType.DATE)),
+    CURDATE(func().to(ESDataType.DATE));
 
     private final TypeExpressionSpec[] specifications;
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -67,7 +67,8 @@ public class SQLFunctions {
 
     private static final Set<String> dateFunctions = Sets.newHashSet(
             "date_format", "year", "month_of_year", "week_of_year", "day_of_year", "day_of_month",
-            "day_of_week", "hour_of_day", "minute_of_day", "minute_of_hour", "second_of_minute"
+            "day_of_week", "hour_of_day", "minute_of_day", "minute_of_hour", "second_of_minute", "month", "dayofmonth",
+            "date", "monthname", "timestamp", "maketime", "now", "curdate"
     );
 
     private static final Set<String> utilityFunctions = Sets.newHashSet("field", "assign");
@@ -157,7 +158,11 @@ public class SQLFunctions {
                 functionStr = dateFunctionTemplate("year", (SQLExpr) paramers.get(0).value);
                 break;
             case "month_of_year":
+            case "month":
                 functionStr = dateFunctionTemplate("monthOfYear", (SQLExpr) paramers.get(0).value);
+                break;
+            case "monthname":
+                functionStr = dateFunctionTemplate("month", (SQLExpr) paramers.get(0).value);
                 break;
             case "week_of_year":
                 functionStr = dateFunctionTemplate("weekOfWeekyear", (SQLExpr) paramers.get(0).value);
@@ -166,10 +171,14 @@ public class SQLFunctions {
                 functionStr = dateFunctionTemplate("dayOfYear", (SQLExpr) paramers.get(0).value);
                 break;
             case "day_of_month":
+            case "dayofmonth":
                 functionStr = dateFunctionTemplate("dayOfMonth", (SQLExpr) paramers.get(0).value);
                 break;
             case "day_of_week":
                 functionStr = dateFunctionTemplate("dayOfWeek", (SQLExpr) paramers.get(0).value);
+                break;
+            case "date":
+                functionStr = date((SQLExpr) paramers.get(0).value);
                 break;
             case "hour_of_day":
                 functionStr = dateFunctionTemplate("hourOfDay", (SQLExpr) paramers.get(0).value);
@@ -182,6 +191,19 @@ public class SQLFunctions {
                 break;
             case "second_of_minute":
                 functionStr = dateFunctionTemplate("secondOfMinute", (SQLExpr) paramers.get(0).value);
+                break;
+            case "timestamp":
+                functionStr = timestamp((SQLExpr) paramers.get(0).value);
+                break;
+            case "maketime":
+                functionStr = maketime((SQLExpr) paramers.get(0).value, (SQLExpr) paramers.get(1).value,
+                        (SQLExpr) paramers.get(2).value);
+                break;
+            case "now":
+                functionStr = now();
+                break;
+            case "curdate":
+                functionStr = curdate();
                 break;
 
             case "e":
@@ -708,6 +730,38 @@ public class SQLFunctions {
     private Tuple<String, String> ascii(SQLExpr field) {
         String name = nextId("ascii");
         return new Tuple<>(name, def(name, "(int) " + getPropertyOrStringValue(field) + ".charAt(0)"));
+    }
+
+    private Tuple<String, String> date(SQLExpr field) {
+        String name = nextId("date");
+        return new Tuple<>(name, def(name,
+                "LocalDate.parse(" + getPropertyOrStringValue(field) + ".toString(),"
+                        + "DateTimeFormatter.ISO_DATE_TIME)"));
+    }
+
+    private Tuple<String, String> timestamp(SQLExpr field) {
+        String name = nextId("timestamp");
+        return new Tuple<>(name, def(name,
+                "DateTimeFormatter.ofPattern('yyyy-MM-dd HH:mm:ss').format("
+                        + "DateTimeFormatter.ISO_DATE_TIME.parse("
+                        + getPropertyOrStringValue(field) + ".toString()))"));
+    }
+
+    private Tuple<String, String> maketime(SQLExpr hr, SQLExpr min, SQLExpr sec) {
+        String name = nextId("maketime");
+        return new Tuple<>(name, def(name, StringUtils.format(
+                "LocalTime.of(%s, %s, %s).format(DateTimeFormatter.ofPattern('HH:mm:ss'))",
+                hr.toString(), min.toString(), sec.toString())));
+    }
+
+    private Tuple<String, String> now() {
+        String name = nextId("now");
+        return new Tuple<>(name, def(name, "new SimpleDateFormat('HH:mm:ss').format(System.currentTimeMillis())"));
+    }
+
+    private Tuple<String, String> curdate() {
+        String name = nextId("curdate");
+        return new Tuple<>(name, def(name, "new SimpleDateFormat('yyyy-MM-dd').format(System.currentTimeMillis())"));
     }
 
     /**

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerScalarFunctionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerScalarFunctionTest.java
@@ -25,8 +25,8 @@ public class SemanticAnalyzerScalarFunctionTest extends SemanticAnalyzerTestBase
     @Test
     public void unsupportedScalarFunctionCallInSelectClauseShouldFail() {
         expectValidationFailWithErrorMessages(
-            "SELECT NOW() FROM semantics",
-            "Function [NOW] cannot be found or used here."
+            "SELECT DAY() FROM semantics",
+            "Function [DAY] cannot be found or used here."
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFunctionsIT.java
@@ -34,6 +34,7 @@ import java.time.Month;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.matchesPattern;
 
 public class DateFunctionsIT extends SQLIntegTestCase {
 
@@ -273,6 +274,20 @@ public class DateFunctionsIT extends SQLIntegTestCase {
         SearchHit[] hits = query("SELECT MAKETIME(13, 1, 1) AS maketime");
         String maketime = (String) getField(hits[0], "maketime");
         assertThat(maketime, equalTo("13:01:01"));
+    }
+
+    @Test
+    public void now() throws IOException {
+        SearchHit[] hits = query("SELECT NOW() AS now");
+        String now = (String) getField(hits[0], "now");
+        assertThat(now, matchesPattern("[0-9]{2}:[0-9]{2}:[0-9]{2}"));
+    }
+
+    @Test
+    public void curdate() throws IOException {
+        SearchHit[] hits = query("SELECT CURDATE() AS curdate");
+        String curdate = (String) getField(hits[0], "curdate");
+        assertThat(curdate, matchesPattern("[0-9]{4}-[0-9]{2}-[0-9]{2}"));
     }
 
     private SearchHit[] query(String select, String... statements) throws IOException {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/DateFunctionsIT.java
@@ -29,6 +29,7 @@ import org.json.JSONObject;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Month;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -205,6 +206,73 @@ public class DateFunctionsIT extends SQLIntegTestCase {
             DateTime insertTime = getDateFromSource(hit, "insert_time");
             assertThat(secondOfMinute, equalTo(insertTime.secondOfMinute().get()));
         }
+    }
+
+    @Test
+    public void month() throws IOException {
+        SearchHit[] hits = query(
+                "SELECT MONTH(insert_time) AS month", "LIMIT 500"
+        );
+        for (SearchHit hit: hits) {
+            int month = (int) getField(hit, "month");
+            DateTime dateTime = getDateFromSource(hit, "insert_time");
+            assertThat(month, equalTo(dateTime.monthOfYear().get()));
+        }
+    }
+
+    @Test
+    public void dayofmonth() throws IOException {
+        SearchHit[] hits = query(
+                "SELECT DAYOFMONTH(insert_time) AS dayofmonth", "LIMIT 500"
+        );
+        for (SearchHit hit: hits) {
+            int dayofmonth = (int) getField(hit, "dayofmonth");
+            DateTime dateTime = getDateFromSource(hit, "insert_time");
+            assertThat(dayofmonth, equalTo(dateTime.dayOfMonth().get()));
+        }
+    }
+
+    @Test
+    public void date() throws IOException {
+        SearchHit[] hits = query(
+                "SELECT DATE(insert_time) AS date", "LIMIT 500"
+        );
+        for (SearchHit hit: hits) {
+            String date = (String) getField(hit, "date");
+            DateTime dateTime = getDateFromSource(hit, "insert_time");
+            assertThat(date, equalTo(dateTime.toString("yyyy-MM-dd")));
+        }
+    }
+
+    @Test
+    public void monthname() throws IOException {
+        SearchHit[] hits = query(
+                "SELECT MONTHNAME(insert_time) AS monthname", "LIMIT 500"
+        );
+        for (SearchHit hit: hits) {
+            String monthname = (String) getField(hit, "monthname");
+            DateTime dateTime = getDateFromSource(hit, "insert_time");
+            assertThat(Month.valueOf(monthname), equalTo(Month.of(dateTime.getMonthOfYear())));
+        }
+    }
+
+    @Test
+    public void timestamp() throws IOException {
+        SearchHit[] hits = query(
+                "SELECT TIMESTAMP(insert_time) AS timestamp", "LIMIT 500"
+        );
+        for (SearchHit hit: hits) {
+            String timastamp = (String) getField(hit, "timestamp");
+            DateTime dateTime = getDateFromSource(hit, "insert_time");
+            assertThat(timastamp, equalTo(dateTime.toString("yyyy-MM-dd HH:mm:ss")));
+        }
+    }
+
+    @Test
+    public void maketime() throws IOException {
+        SearchHit[] hits = query("SELECT MAKETIME(13, 1, 1) AS maketime");
+        String maketime = (String) getField(hits[0], "maketime");
+        assertThat(maketime, equalTo("13:01:01"));
     }
 
     private SearchHit[] query(String select, String... statements) throws IOException {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFunctionsTest.java
@@ -127,4 +127,91 @@ public class DateFunctionsTest {
                         "doc['creationDate'].value.secondOfMinute"));
     }
 
+    @Test
+    public void month() {
+        String query = "SELECT MONTH(creationDate) " +
+                "FROM dates";
+        ScriptField scriptField = getScriptFieldFromQuery(query);
+        assertTrue(
+                scriptContainsString(
+                        scriptField,
+                        "doc['creationDate'].value.monthOfYear"));
+    }
+
+    @Test
+    public void dayofmonth() {
+        String query = "SELECT DAY_OF_MONTH(creationDate) " +
+                "FROM dates";
+        ScriptField scriptField = getScriptFieldFromQuery(query);
+        assertTrue(
+                scriptContainsString(
+                        scriptField,
+                        "doc['creationDate'].value.dayOfMonth"));
+    }
+
+    @Test
+    public void date() {
+        String query = "SELECT DATE(creationDate) " +
+                "FROM dates";
+        ScriptField scriptField = getScriptFieldFromQuery(query);
+        assertTrue(
+                scriptContainsString(
+                        scriptField,
+                        "LocalDate.parse(doc['creationDate'].value.toString(),DateTimeFormatter.ISO_DATE_TIME)"));
+    }
+
+    @Test
+    public void monthname() {
+        String query = "SELECT MONTHNAME(creationDate) " +
+                "FROM dates";
+        ScriptField scriptField = getScriptFieldFromQuery(query);
+        assertTrue(
+                scriptContainsString(
+                        scriptField,
+                        "doc['creationDate'].value.month"));
+    }
+
+    @Test
+    public void timestamp() {
+        String query = "SELECT TIMESTAMP(creationDate) " +
+                "FROM dates";
+        ScriptField scriptField = getScriptFieldFromQuery(query);
+        assertTrue(
+                scriptContainsString(
+                        scriptField,
+                        "DateTimeFormatter.ofPattern('yyyy-MM-dd HH:mm:ss')"));
+    }
+
+    @Test
+    public void maketime() {
+        String query = "SELECT MAKETIME(1, 1, 1) " +
+                "FROM dates";
+        ScriptField scriptField = getScriptFieldFromQuery(query);
+        assertTrue(
+                scriptContainsString(
+                        scriptField,
+                        "LocalTime.of(1, 1, 1).format(DateTimeFormatter.ofPattern('HH:mm:ss'))"));
+    }
+
+    @Test
+    public void now() {
+        String query = "SELECT NOW() " +
+                "FROM dates";
+        ScriptField scriptField = getScriptFieldFromQuery(query);
+        assertTrue(
+                scriptContainsString(
+                        scriptField,
+                        "System.currentTimeMillis()"));
+    }
+
+    @Test
+    public void curdate() {
+        String query = "SELECT CURDATE() " +
+                "FROM dates";
+        ScriptField scriptField = getScriptFieldFromQuery(query);
+        assertTrue(
+                scriptContainsString(
+                        scriptField,
+                        "System.currentTimeMillis()"));
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/DateFunctionsTest.java
@@ -129,8 +129,7 @@ public class DateFunctionsTest {
 
     @Test
     public void month() {
-        String query = "SELECT MONTH(creationDate) " +
-                "FROM dates";
+        String query = "SELECT MONTH(creationDate) FROM dates";
         ScriptField scriptField = getScriptFieldFromQuery(query);
         assertTrue(
                 scriptContainsString(
@@ -140,8 +139,7 @@ public class DateFunctionsTest {
 
     @Test
     public void dayofmonth() {
-        String query = "SELECT DAY_OF_MONTH(creationDate) " +
-                "FROM dates";
+        String query = "SELECT DAY_OF_MONTH(creationDate) FROM dates";
         ScriptField scriptField = getScriptFieldFromQuery(query);
         assertTrue(
                 scriptContainsString(
@@ -151,8 +149,7 @@ public class DateFunctionsTest {
 
     @Test
     public void date() {
-        String query = "SELECT DATE(creationDate) " +
-                "FROM dates";
+        String query = "SELECT DATE(creationDate) FROM dates";
         ScriptField scriptField = getScriptFieldFromQuery(query);
         assertTrue(
                 scriptContainsString(
@@ -162,8 +159,7 @@ public class DateFunctionsTest {
 
     @Test
     public void monthname() {
-        String query = "SELECT MONTHNAME(creationDate) " +
-                "FROM dates";
+        String query = "SELECT MONTHNAME(creationDate) FROM dates";
         ScriptField scriptField = getScriptFieldFromQuery(query);
         assertTrue(
                 scriptContainsString(
@@ -173,8 +169,7 @@ public class DateFunctionsTest {
 
     @Test
     public void timestamp() {
-        String query = "SELECT TIMESTAMP(creationDate) " +
-                "FROM dates";
+        String query = "SELECT TIMESTAMP(creationDate) FROM dates";
         ScriptField scriptField = getScriptFieldFromQuery(query);
         assertTrue(
                 scriptContainsString(
@@ -184,8 +179,7 @@ public class DateFunctionsTest {
 
     @Test
     public void maketime() {
-        String query = "SELECT MAKETIME(1, 1, 1) " +
-                "FROM dates";
+        String query = "SELECT MAKETIME(1, 1, 1) FROM dates";
         ScriptField scriptField = getScriptFieldFromQuery(query);
         assertTrue(
                 scriptContainsString(
@@ -195,8 +189,7 @@ public class DateFunctionsTest {
 
     @Test
     public void now() {
-        String query = "SELECT NOW() " +
-                "FROM dates";
+        String query = "SELECT NOW() FROM dates";
         ScriptField scriptField = getScriptFieldFromQuery(query);
         assertTrue(
                 scriptContainsString(
@@ -206,8 +199,7 @@ public class DateFunctionsTest {
 
     @Test
     public void curdate() {
-        String query = "SELECT CURDATE() " +
-                "FROM dates";
+        String query = "SELECT CURDATE() FROM dates";
         ScriptField scriptField = getScriptFieldFromQuery(query);
         assertTrue(
                 scriptContainsString(


### PR DESCRIPTION
*Issue #, if available:*

* [**Issue #235 Unable to recognize certain function names**](https://github.com/opendistro-for-elasticsearch/sql/issues/235)

*Description of changes:*

* Implemented datetime functions: MONTH, DAYOFMONTH, DATE, MONTHNAME, TIMESTAMP, MAKETIME, NOW, CURDATE.
* Added UT and IT.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
