### PR TITLE
Better error reporting for unsupported case like max(x)-min(y)

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
@@ -34,6 +34,7 @@ import com.amazon.opendistroforelasticsearch.sql.domain.KVValue;
 import com.amazon.opendistroforelasticsearch.sql.domain.MethodField;
 import com.amazon.opendistroforelasticsearch.sql.domain.ScriptMethodField;
 import com.amazon.opendistroforelasticsearch.sql.domain.Where;
+import com.amazon.opendistroforelasticsearch.sql.exception.SqlFeatureNotImplementedException;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.utils.SQLFunctions;
 import com.amazon.opendistroforelasticsearch.sql.utils.Util;
@@ -230,6 +231,7 @@ public class FieldMaker {
         SQLMethodInvokeExpr methodInvokeExpr = new SQLMethodInvokeExpr(operator, null);
         methodInvokeExpr.addParameter(expr.getLeft());
         methodInvokeExpr.addParameter(expr.getRight());
+        methodInvokeExpr.putAttribute("source", expr);
         return methodInvokeExpr;
     }
 
@@ -317,6 +319,10 @@ public class FieldMaker {
             } else if (object instanceof SQLCastExpr) {
                 String scriptCode = new CastParser((SQLCastExpr) object, alias, tableAlias).parse(false);
                 paramers.add(new KVValue("script", new SQLCharExpr(scriptCode)));
+            } else if (object instanceof SQLAggregateExpr) {
+                SQLExpr source = (SQLExpr) object.getParent().getAttribute("source");
+                throw new SqlFeatureNotImplementedException(
+                        "The complex aggregate expressions are not implemented yet: " + source);
             } else {
                 paramers.add(new KVValue(Util.removeTableAilasFromField(object, tableAlias)));
             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.sql.parser;
 
 import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLObject;
 import com.alibaba.druid.sql.ast.expr.SQLAggregateExpr;
 import com.alibaba.druid.sql.ast.expr.SQLAggregateOption;
 import com.alibaba.druid.sql.ast.expr.SQLAllColumnExpr;
@@ -320,7 +321,18 @@ public class FieldMaker {
                 String scriptCode = new CastParser((SQLCastExpr) object, alias, tableAlias).parse(false);
                 paramers.add(new KVValue("script", new SQLCharExpr(scriptCode)));
             } else if (object instanceof SQLAggregateExpr) {
-                SQLExpr source = (SQLExpr) object.getParent().getAttribute("source");
+                SQLObject parent = object.getParent();
+                SQLExpr source = (SQLExpr) parent.getAttribute("source");
+
+                if (parent instanceof SQLMethodInvokeExpr && source == null) {
+                    throw new SqlFeatureNotImplementedException(
+                            "Function calls of form '"
+                                    + ((SQLMethodInvokeExpr) parent).getMethodName()
+                                    + "("
+                                    + ((SQLAggregateExpr) object).getMethodName()
+                                    + "(...))' are not implemented yet");
+                }
+
                 throw new SqlFeatureNotImplementedException(
                         "The complex aggregate expressions are not implemented yet: " + source);
             } else {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SqlParserTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SqlParserTest.java
@@ -113,6 +113,22 @@ public class SqlParserTest {
     }
 
     @Test()
+    public void failingQueryTest2() throws SqlParseException {
+        thrown.expect(SqlFeatureNotImplementedException.class);
+        thrown.expectMessage(
+                "Function calls of form 'log(MAX(...))' are not implemented yet");
+
+        Select select =
+                parser.parseSelect((SQLQueryExpr) queryToExpr(
+                        "SELECT DestCountry, dayOfWeek, log(max(FlightDelayMin))" +
+                        "   FROM kibana_sample_data_flights\n" +
+                        "   GROUP BY DestCountry, dayOfWeek\n"));
+
+        AggregationQueryAction queryAction = new AggregationQueryAction(mock(Client.class), select);
+        String elasticDsl = queryAction.explain().explain();
+    }
+
+    @Test()
     public void failingQueryWithHavingTest() throws SqlParseException {
         thrown.expect(SqlFeatureNotImplementedException.class);
         thrown.expectMessage(

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SqlParserTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SqlParserTest.java
@@ -30,18 +30,20 @@ import com.amazon.opendistroforelasticsearch.sql.domain.Where;
 import com.amazon.opendistroforelasticsearch.sql.domain.hints.Hint;
 import com.amazon.opendistroforelasticsearch.sql.domain.hints.HintType;
 import com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants;
+import com.amazon.opendistroforelasticsearch.sql.exception.SqlFeatureNotImplementedException;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.parser.ElasticSqlExprParser;
 import com.amazon.opendistroforelasticsearch.sql.parser.ScriptFilter;
 import com.amazon.opendistroforelasticsearch.sql.parser.SqlParser;
+import com.amazon.opendistroforelasticsearch.sql.query.AggregationQueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.maker.QueryMaker;
 import com.amazon.opendistroforelasticsearch.sql.query.multi.MultiQuerySelect;
 import com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -56,15 +58,19 @@ import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstant
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_GAME_OF_THRONES;
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ODBC;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
 
 public class SqlParserTest {
 
-    private static SqlParser parser;
+    private SqlParser parser;
 
-    @BeforeClass
-    public static void init() {
+    @Before
+    public void init() {
         parser = new SqlParser();
     }
+
+    @Rule
+    public ExpectedException thrown= ExpectedException.none();
 
     @Test
     public void whereConditionLeftFunctionRightPropertyGreatTest() throws Exception {
@@ -84,6 +90,55 @@ public class SqlParserTest {
         Pattern pattern = Pattern.compile("floor_\\d+ > doc\\['b'].value");
         java.util.regex.Matcher matcher = pattern.matcher(scriptFilter.getScript());
         Assert.assertTrue(matcher.find());
+    }
+
+    @Test()
+    public void failingQueryTest() throws SqlParseException {
+        thrown.expect(SqlFeatureNotImplementedException.class);
+        thrown.expectMessage(
+                "The complex aggregate expressions are not implemented yet: MAX(FlightDelayMin) - MIN(FlightDelayMin)");
+
+        Select select =
+                parser.parseSelect((SQLQueryExpr) queryToExpr(
+                        "SELECT DestCountry, dayOfWeek, max(FlightDelayMin) - min(FlightDelayMin)" +
+                        "   FROM kibana_sample_data_flights\n" +
+                        "   GROUP BY DestCountry, dayOfWeek\n"));
+
+        AggregationQueryAction queryAction = new AggregationQueryAction(mock(Client.class), select);
+        String elasticDsl = queryAction.explain().explain();
+    }
+
+    @Test()
+    public void failingQueryWithHavingTest() throws SqlParseException {
+        thrown.expect(SqlFeatureNotImplementedException.class);
+        thrown.expectMessage(
+                "The complex aggregate expressions are not implemented yet: MAX(FlightDelayMin) - MIN(FlightDelayMin)");
+
+        Select select =
+                parser.parseSelect((SQLQueryExpr) queryToExpr(
+                        "SELECT DestCountry, dayOfWeek, max(FlightDelayMin) - min(FlightDelayMin) " +
+                        "   FROM kibana_sample_data_flights\n" +
+                        "   GROUP BY DestCountry, dayOfWeek\n" +
+                        "   HAVING max(FlightDelayMin) - min(FlightDelayMin)) * count(FlightDelayMin) + 14 > 100"));
+
+        AggregationQueryAction queryAction = new AggregationQueryAction(mock(Client.class), select);
+        String elasticDsl = queryAction.explain().explain();
+    }
+
+    @Test()
+    @Ignore("Github issues: https://github.com/opendistro-for-elasticsearch/sql/issues/194, " +
+            "https://github.com/opendistro-for-elasticsearch/sql/issues/234")
+    public void failingQueryWithHavingTest2() throws SqlParseException {
+        Select select =
+                parser.parseSelect((SQLQueryExpr) queryToExpr(
+                        "SELECT DestCountry, dayOfWeek, max(FlightDelayMin) " +
+                        "   FROM kibana_sample_data_flights\n" +
+                        "   GROUP BY DestCountry, dayOfWeek\n" +
+                        "   HAVING max(FlightDelayMin) - min(FlightDelayMin) > 100"));
+
+        AggregationQueryAction queryAction = new AggregationQueryAction(mock(Client.class), select);
+
+        String elasticDsl = queryAction.explain().explain();
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SqlParserTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/parser/SqlParserTest.java
@@ -42,7 +42,11 @@ import com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder.ScriptField;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.LinkedList;


### PR DESCRIPTION
*Issue #, if available:* #194, #234 

*Description of changes:*
Better error reporting for such queries

```
POST /_opendistro/_sql/_explain
{
  "query":"""SELECT DestCountry, dayOfWeek, max(FlightDelayMin) - min(FlightDelayMin) + avg(FlightDelayMin)
    FROM kibana_sample_data_flights
    GROUP BY DestCountry, dayOfWeek
  """
```

returns now 

```
{
  "error": {
    "reason": "There was internal problem at backend",
    "details": "The complex aggregate expressions are not implemented yet: MAX(FlightDelayMin) - MIN(FlightDelayMin)",
    "type": "SqlFeatureNotImplementedException"
  },
  "status": 503
}
```

instead of non-sensical:

```
{
  "error": {
    "reason": "Invalid SQL query",
    "details": "",
    "type": "NullPointerException"
  },
  "status": 400
}
```

and another example:
````
                        "SELECT DestCountry, dayOfWeek, log(max(FlightDelayMin))" +
                        "   FROM kibana_sample_data_flights\n" +
                        "   GROUP BY DestCountry, dayOfWeek\n"));
```

witll throw

                  "Function calls of form 'log(MAX(...))' are not implemented yet");


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
