### PR TITLE
Corrected the selected field names displayed in the schema of JDBC formatted response

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
@@ -81,10 +81,6 @@ public class FieldMaker {
 
             String methodName = mExpr.getMethodName();
 
-            if (Strings.isNullOrEmpty(alias)) {
-                alias = mExpr.toString();
-            }
-
             if (methodName.equalsIgnoreCase("nested") || methodName.equalsIgnoreCase("reverse_nested")) {
                 NestedType nestedType = new NestedType();
                 if (nestedType.tryFillFromExpr(mExpr)) {
@@ -99,6 +95,9 @@ public class FieldMaker {
                 return makeFilterMethodField(mExpr, alias);
             }
 
+            if ((SQLFunctions.builtInFunctions.contains(methodName.toLowerCase())) && Strings.isNullOrEmpty(alias)) {
+                alias = mExpr.toString();
+            }
             return makeMethodField(methodName, mExpr.getParameters(), null, alias, tableAlias, true);
         } else if (expr instanceof SQLAggregateExpr) {
             SQLAggregateExpr sExpr = (SQLAggregateExpr) expr;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/parser/FieldMaker.java
@@ -39,6 +39,7 @@ import com.amazon.opendistroforelasticsearch.sql.exception.SqlFeatureNotImplemen
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.utils.SQLFunctions;
 import com.amazon.opendistroforelasticsearch.sql.utils.Util;
+import com.google.common.base.Strings;
 import org.elasticsearch.common.collect.Tuple;
 
 import java.util.ArrayList;
@@ -79,6 +80,10 @@ public class FieldMaker {
             SQLMethodInvokeExpr mExpr = (SQLMethodInvokeExpr) expr;
 
             String methodName = mExpr.getMethodName();
+
+            if (Strings.isNullOrEmpty(alias)) {
+                alias = mExpr.toString();
+            }
 
             if (methodName.equalsIgnoreCase("nested") || methodName.equalsIgnoreCase("reverse_nested")) {
                 NestedType nestedType = new NestedType();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -153,7 +153,7 @@ public class JdbcTestIT extends SQLIntegTestCase {
     }
 
     @Test
-    public void functionWithAliasShoultHaveAliasAsNameInSchema() {
+    public void functionWithAliasShouldHaveAliasAsNameInSchema() {
         assertThat(
                 executeQuery("SELECT substring(lastname, 1, 2) AS substring FROM "
                         + TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY substring", "jdbc"),

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -145,11 +145,6 @@ public class JdbcTestIT extends SQLIntegTestCase {
                         + " ORDER BY substring(lastname, 1, 2)", "jdbc"),
                 containsString("\"name\": \"substring(lastname, 1, 2)\"")
         );
-        assertThat(
-                executeQuery("SELECT log(balance) FROM " + TestsConstants.TEST_INDEX_ACCOUNT
-                        + " ORDER BY log(balance)", "jdbc"),
-                containsString("\"name\": \"log(balance)\"")
-        );
     }
 
     @Test
@@ -158,11 +153,6 @@ public class JdbcTestIT extends SQLIntegTestCase {
                 executeQuery("SELECT substring(lastname, 1, 2) AS substring FROM "
                         + TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY substring", "jdbc"),
                 containsString("\"name\": \"substring\"")
-        );
-        assertThat(
-                executeQuery("SELECT log(balance) AS log FROM " + TestsConstants.TEST_INDEX_ACCOUNT
-                        + " ORDER BY log", "jdbc"),
-                containsString("\"name\": \"log\"")
         );
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/JdbcTestIT.java
@@ -137,4 +137,32 @@ public class JdbcTestIT extends SQLIntegTestCase {
                 containsString("\"type\": \"ip\"")
         );
     }
+
+    @Test
+    public void functionWithoutAliasShouldHaveEntireFunctionAsNameInSchema() {
+        assertThat(
+                executeQuery("SELECT substring(lastname, 1, 2) FROM " + TestsConstants.TEST_INDEX_ACCOUNT
+                        + " ORDER BY substring(lastname, 1, 2)", "jdbc"),
+                containsString("\"name\": \"substring(lastname, 1, 2)\"")
+        );
+        assertThat(
+                executeQuery("SELECT log(balance) FROM " + TestsConstants.TEST_INDEX_ACCOUNT
+                        + " ORDER BY log(balance)", "jdbc"),
+                containsString("\"name\": \"log(balance)\"")
+        );
+    }
+
+    @Test
+    public void functionWithAliasShoultHaveAliasAsNameInSchema() {
+        assertThat(
+                executeQuery("SELECT substring(lastname, 1, 2) AS substring FROM "
+                        + TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY substring", "jdbc"),
+                containsString("\"name\": \"substring\"")
+        );
+        assertThat(
+                executeQuery("SELECT log(balance) AS log FROM " + TestsConstants.TEST_INDEX_ACCOUNT
+                        + " ORDER BY log", "jdbc"),
+                containsString("\"name\": \"log\"")
+        );
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -127,7 +127,7 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
                 executeQuery(query),
                 hitAny(
                         kvString("/_source/address", equalTo("880 Holmes Lane")),
-                        kvString("/fields/LOWER_1/0", equalTo("amber")))
+                        kvString("/fields/LOWER(firstname)/0", equalTo("amber")))
         );
     }
 
@@ -144,20 +144,20 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
         assertThat(
                 executeQuery(query),
                 hitAny(
-                        kvString("/fields/LOWER_1/0", equalTo("ıl")))
+                        kvString("/fields/LOWER(state.keyword, 'tr')/0", equalTo("ıl")))
         );
     }
 
     @Test
     public void caseChangeWithAggregationTest() throws IOException {
-        String query = "SELECT UPPER(e.firstname), COUNT(*)" +
+        String query = "SELECT UPPER(e.firstname) AS upper, COUNT(*)" +
                 "FROM elasticsearch-sql_test_index_account/account e " +
                 "WHERE LOWER(e.lastname)='duke' " +
-                "GROUP BY UPPER(e.firstname) ";
+                "GROUP BY upper";
 
         assertThat(
                 executeQuery(query),
-                hitAny("/aggregations/UPPER_1/buckets", kvString("/key", equalTo("AMBER"))));
+                hitAny("/aggregations/upper/buckets", kvString("/key", equalTo("AMBER"))));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

* [**Issue #290 Fieldnames with functions in SELECT clause are not proper in the schema of JDBC format**](https://github.com/opendistro-for-elasticsearch/sql/issues/290)

*Description of changes:*

* Fixed the issue that names not displayed properly in the schema of JDBC format.
* Added IT.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
