### PR TITLE
Fixed the issue of substring not working correctly when fieldname is put as <table>.<column>

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -736,6 +736,7 @@ public class SQLFunctions {
     // es behavior: 1-index, supports out-of-bound index
     public Tuple<String, String> substring(SQLExpr field, int pos, int len) {
         String name = nextId("substring");
+        // start and end are 0-indexes
         int start = pos < 1 ? 0 : pos - 1;
         return new Tuple<>(name, StringUtils.format(
                 "def end = (int) Math.min(%s + %s, %s.length()); "
@@ -744,24 +745,6 @@ public class SQLFunctions {
                 Integer.toString(start), Integer.toString(len), getPropertyOrStringValue(field)
         ));
     }
-
-//    public Tuple<String, String> substring(SQLExpr field, int pos, int len, String valueName) {
-//        String name = nextId("substring");
-//
-//        // start and end are 0-indexes
-//        int start = pos < 1 ? 0 : pos - 1;
-//        int end = Math.min(start + len, getPropertyOrValue(field).length());
-//        if (valueName == null) {
-//            return new Tuple<>(name, def(name, getPropertyOrStringValue(field) + "."
-//                    + func("substring", false,
-//                    Integer.toString(start), Integer.toString(end))));
-//        } else {
-//            return new Tuple<>(name, getPropertyOrStringValue(field) + "; "
-//                    + def(name, valueName + "."
-//                    + func("substring", false,
-//                    Integer.toString(start), Integer.toString(end))));
-//        }
-//    }
 
     private String lower(String property, String culture) {
         return property + ".toLowerCase(Locale.forLanguageTag(\"" + culture + "\"))";

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -284,8 +284,7 @@ public class SQLFunctions {
             case "substring":
                 functionStr = substring((SQLExpr) paramers.get(0).value,
                         Integer.parseInt(Util.expr2Object((SQLExpr) paramers.get(1).value).toString()),
-                        Integer.parseInt(Util.expr2Object((SQLExpr) paramers.get(2).value).toString())
-                        , name);
+                        Integer.parseInt(Util.expr2Object((SQLExpr) paramers.get(2).value).toString()));
                 break;
 
             case "degrees":
@@ -735,23 +734,34 @@ public class SQLFunctions {
     // query: substring(Column expr, int pos, int len)
     // painless script: substring(int begin, int end)
     // es behavior: 1-index, supports out-of-bound index
-    public Tuple<String, String> substring(SQLExpr field, int pos, int len, String valueName) {
+    public Tuple<String, String> substring(SQLExpr field, int pos, int len) {
         String name = nextId("substring");
-
-        // start and end are 0-indexes
         int start = pos < 1 ? 0 : pos - 1;
-        int end = Math.min(start + len, getPropertyOrValue(field).length());
-        if (valueName == null) {
-            return new Tuple<>(name, def(name, getPropertyOrStringValue(field) + "."
-                    + func("substring", false,
-                    Integer.toString(start), Integer.toString(end))));
-        } else {
-            return new Tuple<>(name, getPropertyOrStringValue(field) + "; "
-                    + def(name, valueName + "."
-                    + func("substring", false,
-                    Integer.toString(start), Integer.toString(end))));
-        }
+        return new Tuple<>(name, StringUtils.format(
+                "def end = (int) Math.min(%s + %s, %s.length()); "
+                + def(name, getPropertyOrStringValue(field) + "."
+                + func("substring", false, Integer.toString(start), "end")),
+                Integer.toString(start), Integer.toString(len), getPropertyOrStringValue(field)
+        ));
     }
+
+//    public Tuple<String, String> substring(SQLExpr field, int pos, int len, String valueName) {
+//        String name = nextId("substring");
+//
+//        // start and end are 0-indexes
+//        int start = pos < 1 ? 0 : pos - 1;
+//        int end = Math.min(start + len, getPropertyOrValue(field).length());
+//        if (valueName == null) {
+//            return new Tuple<>(name, def(name, getPropertyOrStringValue(field) + "."
+//                    + func("substring", false,
+//                    Integer.toString(start), Integer.toString(end))));
+//        } else {
+//            return new Tuple<>(name, getPropertyOrStringValue(field) + "; "
+//                    + def(name, valueName + "."
+//                    + func("substring", false,
+//                    Integer.toString(start), Integer.toString(end))));
+//        }
+//    }
 
     private String lower(String property, String culture) {
         return property + ".toLowerCase(Locale.forLanguageTag(\"" + culture + "\"))";

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/StringOperatorsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/StringOperatorsTest.java
@@ -40,13 +40,13 @@ public class StringOperatorsTest {
         assertTrue(
                 CheckScriptContents.scriptContainsString(
                         scriptField,
-                        "doc['lastname'].value.substring(1, 2)"));
+                        "doc['lastname'].value.substring(1, end)"));
 
         ScriptFilter scriptFilter = CheckScriptContents.getScriptFilterFromQuery(query, parser);
         assertTrue(
                 CheckScriptContents.scriptContainsString(
                         scriptFilter,
-                        "doc['lastname'].value.substring(1, 2)"
+                        "doc['lastname'].value.substring(1, end)"
                 )
         );
     }
@@ -58,7 +58,7 @@ public class StringOperatorsTest {
         assertTrue(
                 CheckScriptContents.scriptContainsString(
                         scriptField,
-                        "'sampleName'.substring(0, 10)"
+                        "def end = (int) Math.min(0 + 20, 'sampleName'.length())"
                 )
         );
     }


### PR DESCRIPTION
*Issue #, if available:*

* [Issue #330 Substring function throws server exception](https://github.com/opendistro-for-elasticsearch/sql/issues/330)

*Description of changes:*

* Let the calculation of string length occur within the script
* Made changes to the corresponding unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
