### PR TITLE
Add post processing logic for aggregation query.

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/ColumnTypeProvider.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/ColumnTypeProvider.java
@@ -1,0 +1,92 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.domain;
+
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.Type;
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType;
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.special.Product;
+import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * The definition of column type provider
+ */
+public class ColumnTypeProvider {
+    private final List<Schema.Type> typeList;
+
+    private static final Map<ESDataType, Schema.Type> TYPE_MAP =
+            new ImmutableMap.Builder<ESDataType, Schema.Type>()
+                    .put(ESDataType.SHORT, Schema.Type.SHORT)
+                    .put(ESDataType.LONG, Schema.Type.LONG)
+                    .put(ESDataType.INTEGER, Schema.Type.INTEGER)
+                    .put(ESDataType.FLOAT, Schema.Type.FLOAT)
+                    .put(ESDataType.DOUBLE, Schema.Type.DOUBLE)
+                    .put(ESDataType.KEYWORD, Schema.Type.KEYWORD)
+                    .put(ESDataType.TEXT, Schema.Type.TEXT)
+                    .put(ESDataType.STRING, Schema.Type.TEXT)
+                    .put(ESDataType.DATE, Schema.Type.DATE)
+                    .put(ESDataType.BOOLEAN, Schema.Type.BOOLEAN)
+                    .put(ESDataType.UNKNOWN, Schema.Type.DOUBLE)
+                    .build();
+    public static final Schema.Type COLUMN_DEFAULT_TYPE = Schema.Type.DOUBLE;
+
+    public ColumnTypeProvider(Type type) {
+        this.typeList = convertOutputColumnType(type);
+    }
+
+    public ColumnTypeProvider() {
+        this.typeList = new ArrayList<>();
+    }
+
+    /**
+     * Get the type of column by index.
+     *
+     * @param index column index.
+     * @return column type.
+     */
+    public Schema.Type get(int index) {
+        if (typeList.isEmpty()) {
+            return COLUMN_DEFAULT_TYPE;
+        } else {
+            return typeList.get(index);
+        }
+    }
+
+    private List<Schema.Type> convertOutputColumnType(Type type) {
+        if (type instanceof Product) {
+            List<Type> types = ((Product) type).getTypes();
+            return types.stream().map(t -> convertType(t)).collect(Collectors.toList());
+        } else if (type instanceof ESDataType) {
+            return ImmutableList.of(convertType(type));
+        } else {
+            return ImmutableList.of(COLUMN_DEFAULT_TYPE);
+        }
+    }
+
+    private Schema.Type convertType(Type type) {
+        try {
+            return TYPE_MAP.getOrDefault(type, COLUMN_DEFAULT_TYPE);
+        } catch (Exception e) {
+            return COLUMN_DEFAULT_TYPE;
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/QueryActionRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/domain/QueryActionRequest.java
@@ -1,0 +1,31 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.domain;
+
+import com.amazon.opendistroforelasticsearch.sql.executor.Format;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * The definition of QueryActionRequest.
+ */
+@Getter
+@RequiredArgsConstructor
+public class QueryActionRequest {
+    private final String sql;
+    private final ColumnTypeProvider typeProvider;
+    private final Format format;
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/QueryActionElasticExecutor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/QueryActionElasticExecutor.java
@@ -18,6 +18,9 @@ package com.amazon.opendistroforelasticsearch.sql.executor;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.executor.join.ElasticJoinExecutor;
 import com.amazon.opendistroforelasticsearch.sql.executor.multi.MultiRequestExecutorFactory;
+import com.amazon.opendistroforelasticsearch.sql.executor.adapter.QueryPlanQueryAction;
+import com.amazon.opendistroforelasticsearch.sql.executor.adapter.QueryPlanRequestBuilder;
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
 import com.amazon.opendistroforelasticsearch.sql.query.AggregationQueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.DefaultQueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.DeleteQueryAction;
@@ -36,6 +39,7 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregations;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Created by Eliran on 3/10/2015.
@@ -58,6 +62,11 @@ public class QueryActionElasticExecutor {
             throws SqlParseException {
         SqlElasticSearchRequestBuilder select = aggregationQueryAction.explain();
         return ((SearchResponse) select.get()).getAggregations();
+    }
+
+    public static List<BindingTuple> executeQueryPlanQueryAction(QueryPlanQueryAction queryPlanQueryAction) {
+        QueryPlanRequestBuilder select = (QueryPlanRequestBuilder) queryPlanQueryAction.explain();
+        return select.execute();
     }
 
     public static ActionResponse executeShowQueryAction(ShowQueryAction showQueryAction) {
@@ -88,6 +97,9 @@ public class QueryActionElasticExecutor {
         }
         if (queryAction instanceof AggregationQueryAction) {
             return executeAggregationAction((AggregationQueryAction) queryAction);
+        }
+        if (queryAction instanceof QueryPlanQueryAction) {
+            return executeQueryPlanQueryAction((QueryPlanQueryAction) queryAction);
         }
         if (queryAction instanceof ShowQueryAction) {
             return executeShowQueryAction((ShowQueryAction) queryAction);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/adapter/QueryPlanQueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/adapter/QueryPlanQueryAction.java
@@ -1,0 +1,50 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.executor.adapter;
+
+import com.amazon.opendistroforelasticsearch.sql.query.QueryAction;
+import com.amazon.opendistroforelasticsearch.sql.query.SqlElasticRequestBuilder;
+import com.google.common.base.Strings;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * The definition of QueryPlan of QueryAction which works as the adapter to the current QueryAction framework.
+ */
+public class QueryPlanQueryAction extends QueryAction {
+    private final QueryPlanRequestBuilder requestBuilder;
+
+    public QueryPlanQueryAction(QueryPlanRequestBuilder requestBuilder) {
+        super(null, null);
+        this.requestBuilder = requestBuilder;
+    }
+
+    @Override
+    public SqlElasticRequestBuilder explain() {
+        return requestBuilder;
+    }
+
+    @Override
+    public Optional<List<String>> getFieldNames() {
+        List<String> fieldNames = ((QueryPlanRequestBuilder) requestBuilder).outputColumns()
+                .stream()
+                .map(node -> Strings.isNullOrEmpty(node.getAlias()) ? node.getName() : node.getAlias())
+                .collect(Collectors.toList());
+        return Optional.of(fieldNames);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/adapter/QueryPlanRequestBuilder.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/adapter/QueryPlanRequestBuilder.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.executor.adapter;
+
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ColumnNode;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.BindingTupleQueryPlanner;
+import com.amazon.opendistroforelasticsearch.sql.query.SqlElasticRequestBuilder;
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ActionResponse;
+
+import java.util.List;
+
+/**
+ * The definition of QueryPlan SqlElasticRequestBuilder.
+ */
+@RequiredArgsConstructor
+public class QueryPlanRequestBuilder implements SqlElasticRequestBuilder {
+    private final BindingTupleQueryPlanner queryPlanner;
+
+    public List<BindingTuple> execute() {
+        return queryPlanner.execute();
+    }
+
+    public List<ColumnNode> outputColumns() {
+        return queryPlanner.getColumnNodes();
+    }
+
+    @Override
+    public String explain() {
+        return queryPlanner.explain();
+    }
+
+    @Override
+    public ActionRequest request() {
+        throw new RuntimeException("unsupported operation");
+    }
+
+    @Override
+    public ActionResponse get() {
+        throw new RuntimeException("unsupported operation");
+    }
+
+    @Override
+    public ActionRequestBuilder getBuilder() {
+        throw new RuntimeException("unsupported operation");
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResultsExtractor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResultsExtractor.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistroforelasticsearch.sql.executor.csv;
 
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.utils.Util;
 import com.google.common.base.Joiner;
 import org.elasticsearch.common.document.DocumentField;
@@ -38,6 +40,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Created by Eliran on 27/12/2015.
@@ -83,6 +86,24 @@ public class CSVResultsExtractor {
 
             return new CSVResult(headers, csvLines);
 
+        }
+        // Handle List<BindingTuple> result.
+        if (queryResult instanceof List) {
+            List<BindingTuple> bindingTuples = (List<BindingTuple>) queryResult;
+            List<String> csvLines = bindingTuples.stream().map(tuple -> {
+                Map<String, ExprValue> bindingMap = tuple.getBindingMap();
+                List<Object> rowValues = new ArrayList<>();
+                for (String fieldName : fieldNames) {
+                    if (bindingMap.containsKey(fieldName)) {
+                        rowValues.add(bindingMap.get(fieldName).value());
+                    } else {
+                        rowValues.add("");
+                    }
+                }
+                return Joiner.on(separator).join(rowValues);
+            }).collect(Collectors.toList());
+
+            return new CSVResult(fieldNames, csvLines);
         }
         return null;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/BindingTupleResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/BindingTupleResultSet.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.executor.format;
+
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ColumnNode;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * The definition of BindingTuple ResultSet.
+ */
+public class BindingTupleResultSet extends ResultSet {
+
+    public BindingTupleResultSet(List<ColumnNode> columnNodes, List<BindingTuple> bindingTuples) {
+        this.schema = buildSchema(columnNodes);
+        this.dataRows = buildDataRows(bindingTuples);
+    }
+
+    @VisibleForTesting
+    public static Schema buildSchema(List<ColumnNode> columnNodes) {
+        List<Schema.Column> columnList = columnNodes.stream()
+                                                 .map(node -> new Schema.Column(
+                                                         node.getName(),
+                                                         node.getAlias(),
+                                                         node.getType()))
+                                                 .collect(Collectors.toList());
+        return new Schema("dummy", "dummy", columnList);
+    }
+
+    @VisibleForTesting
+    public static DataRows buildDataRows(List<BindingTuple> bindingTuples) {
+        List<DataRows.Row> rowList = bindingTuples.stream().map(tuple -> {
+            Map<String, ExprValue> bindingMap = tuple.getBindingMap();
+            Map<String, Object> rowMap = new HashMap<>();
+            for (String s : bindingMap.keySet()) {
+                rowMap.put(s, bindingMap.get(s).value());
+            }
+            return new DataRows.Row(rowMap);
+        }).collect(Collectors.toList());
+
+        return new DataRows(bindingTuples.size(), bindingTuples.size(), rowList);
+    }
+}
+

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/PrettyFormatRestExecutor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/PrettyFormatRestExecutor.java
@@ -67,7 +67,7 @@ public class PrettyFormatRestExecutor implements RestExecutor {
 
         try {
             Object queryResult = QueryActionElasticExecutor.executeAnyAction(client, queryAction);
-            protocol = new Protocol(client, queryAction.getQueryStatement(), queryResult, format);
+            protocol = new Protocol(client, queryAction, queryResult, format);
         } catch (Exception e) {
             LOG.error("Error happened in pretty formatter", e);
             protocol = new Protocol(e);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/Protocol.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/Protocol.java
@@ -21,10 +21,16 @@ import com.amazon.opendistroforelasticsearch.sql.domain.Query;
 import com.amazon.opendistroforelasticsearch.sql.domain.QueryStatement;
 import com.amazon.opendistroforelasticsearch.sql.executor.format.DataRows.Row;
 import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema.Column;
+import com.amazon.opendistroforelasticsearch.sql.executor.adapter.QueryPlanQueryAction;
+import com.amazon.opendistroforelasticsearch.sql.executor.adapter.QueryPlanRequestBuilder;
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ColumnNode;
+import com.amazon.opendistroforelasticsearch.sql.query.QueryAction;
 import org.elasticsearch.client.Client;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -41,10 +47,15 @@ public class Protocol {
     private long total;
     private ResultSet resultSet;
     private ErrorMessage error;
+    private List<ColumnNode> columnNodeList;
 
-    public Protocol(Client client, QueryStatement query, Object queryResult, String formatType) {
+    public Protocol(Client client, QueryAction queryAction, Object queryResult, String formatType) {
+        if (queryAction instanceof QueryPlanQueryAction) {
+            this.columnNodeList =
+                    ((QueryPlanRequestBuilder) (((QueryPlanQueryAction) queryAction).explain())).outputColumns();
+        }
         this.formatType = formatType;
-
+        QueryStatement query = queryAction.getQueryStatement();
         this.status = OK_STATUS;
         this.resultSet = loadResultSet(client, query, queryResult);
         this.size = resultSet.getDataRows().getSize();
@@ -58,6 +69,9 @@ public class Protocol {
     }
 
     private ResultSet loadResultSet(Client client, QueryStatement queryStatement, Object queryResult) {
+        if (queryResult instanceof List) {
+            return new BindingTupleResultSet(columnNodeList, (List<BindingTuple>) queryResult);
+        }
         if (queryStatement instanceof Delete) {
             return new DeleteResultSet(client, (Delete) queryStatement, queryResult);
         } else if (queryStatement instanceof Query) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/core/Expression.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/core/Expression.java
@@ -1,0 +1,32 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.core;
+
+
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue;
+
+/**
+ * The definition of the Expression.
+ */
+public interface Expression {
+    /**
+     * Evaluate the result on the BindingTuple context.
+     * @param tuple BindingTuple
+     * @return ExprValue
+     */
+    ExprValue valueOf(BindingTuple tuple);
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/core/ExpressionFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/core/ExpressionFactory.java
@@ -1,0 +1,143 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.core;
+
+
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue;
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValueFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.function.BiFunction;
+
+import static com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValueFactory.doubleValue;
+
+/**
+ * The definition of Expression factory.
+ */
+public class ExpressionFactory {
+    /**
+     * Reference
+     */
+    public static Expression ref(String bindingName) {
+        return new Expression() {
+            @Override
+            public String toString() {
+                return String.format("%s", bindingName);
+            }
+
+            @Override
+            public ExprValue valueOf(BindingTuple tuple) {
+                return tuple.resolve(bindingName);
+            }
+        };
+    }
+
+    @RequiredArgsConstructor
+    enum ArithmeticOperation {
+        ADD(Integer::sum, Double::sum),
+        SUB((arg1, arg2) -> arg1 - arg2,
+            (arg1, arg2) -> arg1 - arg2);
+
+        private final BiFunction<Integer, Integer, Integer> integerFunc;
+        private final BiFunction<Double, Double, Double> doubleFunc;
+    }
+
+    public static Expression add(Expression left, Expression right) {
+        return new Expression() {
+            @Override
+            public ExprValue valueOf(BindingTuple tuple) {
+                return arithmetic(ArithmeticOperation.ADD, left.valueOf(tuple), right.valueOf(tuple));
+            }
+
+            @Override
+            public String toString() {
+                return String.format("add(%s,%s)", left, right);
+            }
+        };
+    }
+
+    public static Expression sub(Expression left, Expression right) {
+        return new Expression() {
+            @Override
+            public ExprValue valueOf(BindingTuple tuple) {
+                return arithmetic(ArithmeticOperation.ADD, left.valueOf(tuple), right.valueOf(tuple));
+            }
+
+            @Override
+            public String toString() {
+                return String.format("sub(%s,%s)", left, right);
+            }
+        };
+    }
+
+    public static Expression log(Expression expr) {
+        return new Expression() {
+            @Override
+            public ExprValue valueOf(BindingTuple tuple) {
+                final ExprValue exprValue = expr.valueOf(tuple);
+                switch (exprValue.kind()) {
+                    case INTEGER_VALUE:
+                        return doubleValue(Math.log(exprValue.numberValue().intValue()));
+                    case DOUBLE_VALUE:
+                        return doubleValue(Math.log(exprValue.numberValue().doubleValue()));
+                    default:
+                        throw new RuntimeException("unsupported log operand: " + exprValue.kind());
+                }
+            }
+
+            @Override
+            public String toString() {
+                return String.format("log(%s)", expr);
+            }
+        };
+    }
+
+    public static Expression cast(Expression expr) {
+        return new Expression() {
+            @Override
+            public ExprValue valueOf(BindingTuple tuple) {
+                return expr.valueOf(tuple);
+            }
+
+            @Override
+            public String toString() {
+                return String.format("cast(%s)", expr);
+            }
+        };
+    }
+
+    private static ExprValue arithmetic(ArithmeticOperation op, ExprValue v1, ExprValue v2) {
+        if (v1.kind() != v2.kind()) {
+            throw new RuntimeException(
+                    String.format("operation with different type is unsupported: %s(%s, %s)", op.name(), v1.kind(),
+                                  v2.kind()));
+        } else {
+            switch (v1.kind()) {
+                case DOUBLE_VALUE:
+                    return ExprValueFactory.doubleValue(
+                            op.doubleFunc.apply(v1.numberValue().doubleValue(), v2.numberValue().doubleValue()));
+                case INTEGER_VALUE:
+                    return ExprValueFactory
+                            .integerValue(
+                                    op.integerFunc.apply(v1.numberValue().intValue(), v2.numberValue().intValue()));
+                default:
+                    throw new RuntimeException(String.format("unsupported operation: %s(%s, %s)", op.name(), v1.kind(),
+                                                             v2.kind()));
+            }
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/domain/BindingTuple.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/domain/BindingTuple.java
@@ -1,0 +1,83 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.domain;
+
+
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprMissingValue;
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Singular;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValueFactory.fromJson;
+
+/**
+ * BindingTuple represents the a relationship between bindingName and ExprValue.
+ * e.g. The operation output column name is bindingName, the value is the ExprValue.
+ */
+@Builder
+@Getter
+@EqualsAndHashCode
+public class BindingTuple {
+    @Singular("binding")
+    private Map<String, ExprValue> bindingMap;
+
+    /**
+     * Resolve the Binding Name in BindingTuple context.
+     * @param bindingName binding name.
+     * @return binding value.
+     */
+    public ExprValue resolve(String bindingName) {
+        return bindingMap.getOrDefault(bindingName, new ExprMissingValue());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("<");
+        final List<String> list = bindingMap.entrySet()
+                .stream()
+                .map(entry -> String.format("%s:%s", entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+        sb.append(String.join(",", list));
+        sb.append('>');
+        return sb.toString();
+    }
+
+    public static BindingTuple from(Map<String, Object> map) {
+        Map<String, ExprValue> ssValueMap = new HashMap<>();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            ssValueMap.put(entry.getKey(), fromJson(entry.getValue()));
+        }
+        return BindingTuple.builder()
+                .bindingMap(ssValueMap)
+                .build();
+    }
+
+    public static BindingTuple from(JSONObject json) {
+        Map<String, ExprValue> valueMap = new HashMap<>();
+        for (String s : json.keySet()) {
+            valueMap.put(s, fromJson(json.get(s)));
+        }
+        return new BindingTuple(valueMap);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/domain/BindingTuple.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/domain/BindingTuple.java
@@ -18,18 +18,15 @@ package com.amazon.opendistroforelasticsearch.sql.expression.domain;
 
 import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprMissingValue;
 import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue;
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValueFactory;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Singular;
 import org.json.JSONObject;
 
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValueFactory.fromJson;
 
 /**
  * BindingTuple represents the a relationship between bindingName and ExprValue.
@@ -40,10 +37,11 @@ import static com.amazon.opendistroforelasticsearch.sql.expression.model.ExprVal
 @EqualsAndHashCode
 public class BindingTuple {
     @Singular("binding")
-    private Map<String, ExprValue> bindingMap;
+    private final Map<String, ExprValue> bindingMap;
 
     /**
      * Resolve the Binding Name in BindingTuple context.
+     *
      * @param bindingName binding name.
      * @return binding value.
      */
@@ -53,31 +51,20 @@ public class BindingTuple {
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("<");
-        final List<String> list = bindingMap.entrySet()
+        return bindingMap.entrySet()
                 .stream()
                 .map(entry -> String.format("%s:%s", entry.getKey(), entry.getValue()))
-                .collect(Collectors.toList());
-        sb.append(String.join(",", list));
-        sb.append('>');
-        return sb.toString();
+                .collect(Collectors.joining(",", "<", ">"));
     }
 
     public static BindingTuple from(Map<String, Object> map) {
-        Map<String, ExprValue> ssValueMap = new HashMap<>();
-        for (Map.Entry<String, Object> entry : map.entrySet()) {
-            ssValueMap.put(entry.getKey(), fromJson(entry.getValue()));
-        }
-        return BindingTuple.builder()
-                .bindingMap(ssValueMap)
-                .build();
+        return from(new JSONObject(map));
     }
 
     public static BindingTuple from(JSONObject json) {
-        Map<String, ExprValue> valueMap = new HashMap<>();
-        for (String s : json.keySet()) {
-            valueMap.put(s, fromJson(json.get(s)));
-        }
-        return new BindingTuple(valueMap);
+        Map<String, Object> map = json.toMap();
+        BindingTupleBuilder bindingTupleBuilder = BindingTuple.builder();
+        map.forEach((key, value) -> bindingTupleBuilder.binding(key, ExprValueFactory.from(value)));
+        return bindingTupleBuilder.build();
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprBooleanValue.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprBooleanValue.java
@@ -1,0 +1,48 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public class ExprBooleanValue implements ExprValue {
+    private final Boolean value;
+
+    @Override
+    public Object value() {
+        return value;
+    }
+
+    @Override
+    public Boolean booleanValue() {
+        return value;
+    }
+
+    @Override
+    public ExprValueKind kind() {
+        return ExprValueKind.BOOLEAN_VALUE;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("SSBooleanValue{");
+        sb.append("value=").append(value);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprCollectionValue.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprCollectionValue.java
@@ -45,9 +45,8 @@ public class ExprCollectionValue implements ExprValue {
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("[");
-        sb.append(String.join(",", valueList.stream().map(tuple -> tuple.toString()).collect(Collectors.toList())));
-        sb.append("]");
-        return sb.toString();
+        return valueList.stream()
+                .map(Object::toString)
+                .collect(Collectors.joining(",", "[", "]"));
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprCollectionValue.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprCollectionValue.java
@@ -1,0 +1,53 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue.ExprValueKind.COLLECTION_VALUE;
+
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public class ExprCollectionValue implements ExprValue {
+    private final List<ExprValue> valueList;
+
+    @Override
+    public Object value() {
+        return valueList;
+    }
+
+    @Override
+    public List<ExprValue> collectionValue() {
+        return valueList;
+    }
+
+    @Override
+    public ExprValueKind kind() {
+        return COLLECTION_VALUE;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("[");
+        sb.append(String.join(",", valueList.stream().map(tuple -> tuple.toString()).collect(Collectors.toList())));
+        sb.append("]");
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprDoubleValue.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprDoubleValue.java
@@ -1,0 +1,45 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public class ExprDoubleValue implements ExprValue {
+    private final Double value;
+
+    @Override
+    public Object value() {
+        return value;
+    }
+
+    @Override
+    public Number numberValue() {
+        return value;
+    }
+
+    @Override
+    public ExprValueKind kind() {
+        return ExprValueKind.DOUBLE_VALUE;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprIntegerValue.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprIntegerValue.java
@@ -1,0 +1,45 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public class ExprIntegerValue implements ExprValue {
+    private final Integer value;
+
+    @Override
+    public Object value() {
+        return value;
+    }
+
+    @Override
+    public Number numberValue() {
+        return value;
+    }
+
+    @Override
+    public ExprValueKind kind() {
+        return ExprValueKind.INTEGER_VALUE;
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprMissingValue.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprMissingValue.java
@@ -1,0 +1,26 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.model;
+
+/**
+ * The definition of the missing value.
+ */
+public class ExprMissingValue implements ExprValue {
+    @Override
+    public ExprValueKind kind() {
+        return ExprValueKind.MISSING_VALUE;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprStringValue.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprStringValue.java
@@ -1,0 +1,45 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public class ExprStringValue implements ExprValue {
+    private final String value;
+
+    @Override
+    public Object value() {
+        return value;
+    }
+
+    @Override
+    public String stringValue() {
+        return value;
+    }
+
+    @Override
+    public ExprValueKind kind() {
+        return ExprValueKind.STRING_VALUE;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprTupleValue.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprTupleValue.java
@@ -18,7 +18,6 @@ package com.amazon.opendistroforelasticsearch.sql.expression.model;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -44,13 +43,9 @@ public class ExprTupleValue implements ExprValue {
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("{");
-        final List<String> list = valueMap.entrySet()
-                                          .stream()
-                                          .map(entry -> String.format("%s:%s", entry.getKey(), entry.getValue()))
-                                          .collect(Collectors.toList());
-        sb.append(String.join(",", list));
-        sb.append('}');
-        return sb.toString();
+        return valueMap.entrySet()
+                .stream()
+                .map(entry -> String.format("%s:%s", entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining(",", "{", "}"));
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprTupleValue.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprTupleValue.java
@@ -1,0 +1,56 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@EqualsAndHashCode
+@RequiredArgsConstructor
+public class ExprTupleValue implements ExprValue {
+    private final Map<String, ExprValue> valueMap;
+
+    @Override
+    public Object value() {
+        return valueMap;
+    }
+
+    @Override
+    public Map<String, ExprValue> tupleValue() {
+        return valueMap;
+    }
+
+    @Override
+    public ExprValueKind kind() {
+        return ExprValueKind.TUPLE_VALUE;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("{");
+        final List<String> list = valueMap.entrySet()
+                                          .stream()
+                                          .map(entry -> String.format("%s:%s", entry.getKey(), entry.getValue()))
+                                          .collect(Collectors.toList());
+        sb.append(String.join(",", list));
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprValue.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprValue.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.model;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The definition of the Value used in the Expression
+ */
+public interface ExprValue {
+    default Object value() {
+        throw new IllegalStateException("invalid value operation on " + kind());
+    }
+
+    default List<ExprValue> collectionValue() {
+        throw new IllegalStateException("invalid collectionValue operation on " + kind());
+    }
+
+    default Map<String, ExprValue> tupleValue() {
+        throw new IllegalStateException("invalid tupleValue on " + kind());
+    }
+
+    default Number numberValue() {
+        throw new IllegalStateException("invalid numberValue operation on " + kind());
+    }
+
+    default Boolean booleanValue() {
+        throw new IllegalStateException("invalid booleanValue operation on " + kind());
+    }
+
+    default String stringValue() {
+        throw new IllegalStateException("invalid stringValue operation on " + kind());
+    }
+
+    default ExprValueKind kind() {
+        throw new IllegalStateException("invalid kind operation");
+    }
+
+    enum ExprValueKind {
+        TUPLE_VALUE,
+        COLLECTION_VALUE,
+        MISSING_VALUE,
+
+        BOOLEAN_VALUE,
+        INTEGER_VALUE,
+        DOUBLE_VALUE,
+        STRING_VALUE
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprValueFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprValueFactory.java
@@ -15,9 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.sql.expression.model;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,27 +41,23 @@ public class ExprValueFactory {
         return new ExprStringValue(value);
     }
 
-    public static ExprValue tupleValue(JSONObject jsonObject) {
+    public static ExprValue tupleValue(Map<String, Object> map) {
         Map<String, ExprValue> valueMap = new HashMap<>();
-        for (String s : jsonObject.keySet()) {
-            valueMap.put(s, fromJson(jsonObject.get(s)));
-        }
+        map.forEach((k, v) -> valueMap.put(k, from(v)));
         return new ExprTupleValue(valueMap);
     }
 
-    public static ExprValue collectionValue(JSONArray array) {
+    public static ExprValue collectionValue(List<Object> list) {
         List<ExprValue> valueList = new ArrayList<>();
-        for (Object o : array) {
-            valueList.add(fromJson(o));
-        }
+        list.forEach(o -> valueList.add(from(o)));
         return new ExprCollectionValue(valueList);
     }
 
-    public static ExprValue fromJson(Object o) {
-        if (o instanceof JSONObject) {
-            return tupleValue((JSONObject) o);
-        } else if (o instanceof JSONArray) {
-            return collectionValue(((JSONArray) o));
+    public static ExprValue from(Object o) {
+        if (o instanceof Map) {
+            return tupleValue((Map) o);
+        } else if (o instanceof List) {
+            return collectionValue(((List) o));
         } else if (o instanceof Integer) {
             return integerValue((Integer) o);
         } else if (o instanceof Long) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprValueFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/model/ExprValueFactory.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.expression.model;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The definition of {@link ExprValue} factory.
+ */
+public class ExprValueFactory {
+
+    public static ExprValue booleanValue(Boolean value) {
+        return new ExprBooleanValue(value);
+    }
+
+    public static ExprValue integerValue(Integer value) {
+        return new ExprIntegerValue(value);
+    }
+
+    public static ExprValue doubleValue(Double value) {
+        return new ExprDoubleValue(value);
+    }
+
+    public static ExprValue stringValue(String value) {
+        return new ExprStringValue(value);
+    }
+
+    public static ExprValue tupleValue(JSONObject jsonObject) {
+        Map<String, ExprValue> valueMap = new HashMap<>();
+        for (String s : jsonObject.keySet()) {
+            valueMap.put(s, fromJson(jsonObject.get(s)));
+        }
+        return new ExprTupleValue(valueMap);
+    }
+
+    public static ExprValue collectionValue(JSONArray array) {
+        List<ExprValue> valueList = new ArrayList<>();
+        for (Object o : array) {
+            valueList.add(fromJson(o));
+        }
+        return new ExprCollectionValue(valueList);
+    }
+
+    public static ExprValue fromJson(Object o) {
+        if (o instanceof JSONObject) {
+            return tupleValue((JSONObject) o);
+        } else if (o instanceof JSONArray) {
+            return collectionValue(((JSONArray) o));
+        } else if (o instanceof Integer) {
+            return integerValue((Integer) o);
+        } else if (o instanceof Long) {
+            return integerValue(((Long) o).intValue());
+        } else if (o instanceof Boolean) {
+            return booleanValue((Boolean) o);
+        } else if (o instanceof Double) {
+            return doubleValue((Double) o);
+        } else if (o instanceof String) {
+            return stringValue((String) o);
+        } else {
+            throw new IllegalStateException("unsupported type " + o.getClass());
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
@@ -19,10 +19,14 @@ import com.alibaba.druid.sql.parser.ParserException;
 import com.amazon.opendistroforelasticsearch.sql.antlr.OpenDistroSqlAnalyzer;
 import com.amazon.opendistroforelasticsearch.sql.antlr.SqlAnalysisConfig;
 import com.amazon.opendistroforelasticsearch.sql.antlr.SqlAnalysisException;
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.Type;
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
+import com.amazon.opendistroforelasticsearch.sql.domain.QueryActionRequest;
 import com.amazon.opendistroforelasticsearch.sql.esdomain.LocalClusterState;
 import com.amazon.opendistroforelasticsearch.sql.exception.SQLFeatureDisabledException;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.executor.ActionRequestRestExecutorFactory;
+import com.amazon.opendistroforelasticsearch.sql.executor.Format;
 import com.amazon.opendistroforelasticsearch.sql.executor.RestExecutor;
 import com.amazon.opendistroforelasticsearch.sql.executor.format.ErrorMessage;
 import com.amazon.opendistroforelasticsearch.sql.metrics.MetricName;
@@ -52,6 +56,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -111,7 +116,8 @@ public class RestSqlAction extends BaseRestHandler {
             final SqlRequest sqlRequest = SqlRequestFactory.getSqlRequest(request);
             LOG.info("[{}] Incoming request {}: {}", LogUtils.getRequestId(), request.uri(), sqlRequest.getSql());
 
-            final QueryAction queryAction = explainRequest(client, sqlRequest);
+            final QueryAction queryAction =
+                    explainRequest(client, sqlRequest, SqlRequestParam.getFormat(request.params()));
             return channel -> executeSqlRequest(request, queryAction, client, channel);
         } catch (Exception e) {
             logAndPublishMetrics(e);
@@ -136,18 +142,19 @@ public class RestSqlAction extends BaseRestHandler {
         }
     }
 
-    private static QueryAction explainRequest(final NodeClient client, final SqlRequest sqlRequest)
+    private static QueryAction explainRequest(final NodeClient client, final SqlRequest sqlRequest, Format format)
             throws SQLFeatureNotSupportedException, SqlParseException {
 
-        performAnalysis(sqlRequest.getSql());
+        ColumnTypeProvider typeProvider = performAnalysis(sqlRequest.getSql());
 
-        final QueryAction queryAction = new SearchDao(client).explain(sqlRequest.getSql());
+        final QueryAction queryAction = new SearchDao(client)
+                .explain(new QueryActionRequest(sqlRequest.getSql(), typeProvider, format));
         queryAction.setSqlRequest(sqlRequest);
         return queryAction;
     }
 
-    private void executeSqlRequest(final RestRequest request, final QueryAction queryAction,
-                                   final Client client, final RestChannel channel) throws Exception {
+    private void executeSqlRequest(final RestRequest request, final QueryAction queryAction, final Client client,
+                                   final RestChannel channel) throws Exception {
         Map<String, String> params = request.params();
         if (isExplainRequest(request)) {
             final String jsonExplanation = queryAction.explain().explain();
@@ -202,7 +209,7 @@ public class RestSqlAction extends BaseRestHandler {
         return allowExplicitIndex && isSqlEnabled;
     }
 
-    private static void performAnalysis(String sql) {
+    private static ColumnTypeProvider performAnalysis(String sql) {
         LocalClusterState clusterState = LocalClusterState.state();
         SqlAnalysisConfig config = new SqlAnalysisConfig(
             clusterState.getSettingValue(QUERY_ANALYSIS_ENABLED),
@@ -211,6 +218,11 @@ public class RestSqlAction extends BaseRestHandler {
         );
 
         OpenDistroSqlAnalyzer analyzer = new OpenDistroSqlAnalyzer(config);
-        analyzer.analyze(sql, clusterState);
+        Optional<Type> outputColumnType = analyzer.analyze(sql, clusterState);
+        if (outputColumnType.isPresent()) {
+            return new ColumnTypeProvider(outputColumnType.get());
+        } else {
+            return new ColumnTypeProvider();
+        }
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/SearchDao.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/SearchDao.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.plugin;
 
+import com.amazon.opendistroforelasticsearch.sql.domain.QueryActionRequest;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.query.ESActionFactory;
 import com.amazon.opendistroforelasticsearch.sql.query.QueryAction;
@@ -51,11 +52,12 @@ public class SearchDao {
      * Prepare action And transform sql
      * into ES ActionRequest
      *
-     * @param sql SQL query to execute.
+     * @param queryActionRequest SQL query action request to execute.
      * @return ES request
      * @throws SqlParseException
      */
-    public QueryAction explain(String sql) throws SqlParseException, SQLFeatureNotSupportedException {
-        return ESActionFactory.create(client, sql);
+    public QueryAction explain(QueryActionRequest queryActionRequest)
+            throws SqlParseException, SQLFeatureNotSupportedException {
+        return ESActionFactory.create(client, queryActionRequest);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/converter/SQLAggregationParser.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/converter/SQLAggregationParser.java
@@ -1,0 +1,262 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.query.planner.converter;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.SQLAggregateExpr;
+import com.alibaba.druid.sql.ast.expr.SQLCastExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
+import com.alibaba.druid.sql.dialect.mysql.ast.expr.MySqlSelectGroupByExpr;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitorAdapter;
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
+import com.amazon.opendistroforelasticsearch.sql.expression.core.Expression;
+import com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ColumnNode;
+import com.google.common.base.Strings;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * The definition of SQL Aggregation Converter which will parse the query to project column node list and
+ * aggregation list
+ * e.g. parse the query: SELECT age, MAX(balance) - MIN(balance) FROM T GROUP BY age.
+ * will generate the
+ * node list: age, max_0 - min_0
+ * aggregation list: age, max(balance) as max_0, min(balance) as min_0
+ *
+ */
+@RequiredArgsConstructor
+public class SQLAggregationParser {
+    private final ColumnTypeProvider columnTypeProvider;
+    private Context context;
+    @Getter
+    private List<ColumnNode> columnNodes = new ArrayList<>();
+
+    public void parse(MySqlSelectQueryBlock queryBlock) {
+        context = new Context(constructSQLExprAliasMapFromSelect(queryBlock));
+
+        //2. find all GroupKeyExpr from GroupBy expression.
+        findAllGroupKeyExprFromGroupByAndSelect(queryBlock);
+        findAllAggregationExprFromSelect(queryBlock);
+
+        //3. parse the select list to expression
+        parseExprInSelectList(queryBlock, new SQLExprToExpressionConverter(context));
+    }
+
+    public List<SQLSelectItem> selectItemList() {
+        List<SQLSelectItem> sqlSelectItems = new ArrayList<>();
+        context.getGroupKeyExprMap().entrySet().forEach(entry -> sqlSelectItems
+                .add(new SQLSelectItem(entry.getKey(), entry.getValue().getExpression().toString())));
+        context.getAggregationExprMap().entrySet().forEach(entry -> sqlSelectItems
+                .add(new SQLSelectItem(entry.getKey(), entry.getValue().getExpression().toString())));
+        return sqlSelectItems;
+    }
+
+    private Map<SQLExpr, String> constructSQLExprAliasMapFromSelect(MySqlSelectQueryBlock queryBlock) {
+        return queryBlock.getSelectList().stream().filter(item -> !Strings.isNullOrEmpty(item.getAlias()))
+                .collect(Collectors.toMap(SQLSelectItem::getExpr, SQLSelectItem::getAlias));
+    }
+
+    /**
+     * The SQL-92 require nonaggregated name column in the select list must appear in the GROUP BY, But the
+     * existing uses cases violate this require. e.g. AggregationIT. countGroupByDateTest
+     * Ref the https://dev.mysql.com/doc/refman/8.0/en/group-by-handling.html for detail information
+     */
+    private void findAllGroupKeyExprFromGroupByAndSelect(MySqlSelectQueryBlock queryBlock) {
+        if (queryBlock.getGroupBy() == null) {
+            return;
+        }
+        // 1. fetch the expr from groupby clause.
+        List<SQLExpr> groupByKeyExprList =
+                queryBlock.getGroupBy().getItems().stream().map(item -> ((MySqlSelectGroupByExpr) item).getExpr())
+                        .collect(Collectors.toList());
+
+        // 2. find the group expr from select.
+        for (SQLSelectItem selectItem : queryBlock.getSelectList()) {
+            SQLExpr selectItemExpr = selectItem.getExpr();
+            // extension, group key in select could not in group by.
+            if (selectItemExpr instanceof SQLIdentifierExpr) {
+                context.addGroupKeyExpr(selectItemExpr);
+            } else {
+                for (SQLExpr groupByExpr : groupByKeyExprList) {
+                    // SQL-92,nonaggregated name column in the select list must appear in the GROUP BY
+                    if (compareSelectExprAndGroupByExpr(selectItemExpr, selectItem.getAlias(), groupByExpr)) {
+                        context.addGroupKeyExpr(selectItemExpr);
+                    } else if (groupByExpr instanceof SQLIdentifierExpr) {
+                        // support expression over group key, e.g. SELECT log(G), max(A) FROM T GROUP BY G.
+                        String groupByName = ((SQLIdentifierExpr) groupByExpr).getName();
+                        selectItemExpr.accept(new MySqlASTVisitorAdapter() {
+                            @Override
+                            public boolean visit(SQLAggregateExpr x) {
+                                return false;
+                            }
+
+                            @Override
+                            public boolean visit(SQLIdentifierExpr expr) {
+                                if (groupByName.equalsIgnoreCase(expr.getName())) {
+                                    expr.setParent(selectItem.getParent());
+                                    context.addGroupKeyExpr(expr);
+                                }
+                                return false;
+                            }
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean compareSelectExprAndGroupByExpr(SQLExpr selectItemExpr, String alias, SQLExpr groupByExpr) {
+        if (groupByExpr.equals(selectItemExpr)) {
+            return true;
+        } else if (groupByExpr instanceof SQLIdentifierExpr
+                   && ((SQLIdentifierExpr) groupByExpr).getName().equalsIgnoreCase(alias)) {
+                return true;
+        }
+        return false;
+    }
+
+    private void findAllAggregationExprFromSelect(MySqlSelectQueryBlock queryBlock) {
+        queryBlock.getSelectList().forEach(selectItem -> selectItem.accept(new MySqlASTVisitorAdapter() {
+            @Override
+            public boolean visit(SQLAggregateExpr expr) {
+                context.addAggregationExpr(expr);
+                return true;
+            }
+        }));
+    }
+
+    private void parseExprInSelectList(MySqlSelectQueryBlock queryBlock, SQLExprToExpressionConverter exprConverter) {
+        List<SQLSelectItem> selectItems = queryBlock.getSelectList();
+        for (int i = 0; i < selectItems.size(); i++) {
+            Expression expression = exprConverter.convert(selectItems.get(i).getExpr());
+            ColumnNode columnNode = ColumnNode.builder()
+                    .name(nameOfSelectItem(selectItems.get(i)))
+                    .alias(selectItems.get(i).getAlias())
+                    .type(columnTypeProvider.get(i))
+                    .expr(expression)
+                    .build();
+            columnNodes.add(columnNode);
+        }
+    }
+
+    private String nameOfSelectItem(SQLSelectItem selectItem) {
+        return Strings.isNullOrEmpty(selectItem.getAlias()) ? Context
+                .nameOfExpr(selectItem.getExpr()) : selectItem.getAlias();
+    }
+
+    @RequiredArgsConstructor
+    public static class Context {
+        private final AliasGenerator aliasGenerator = new AliasGenerator();
+
+        private final Map<SQLExpr, String> selectSQLExprAliasMap;
+
+        @Getter
+        private final Map<SQLExpr, GroupKeyExpr> groupKeyExprMap = new LinkedHashMap<>();
+        @Getter
+        private final Map<SQLExpr, AggregationExpr> aggregationExprMap = new LinkedHashMap<>();
+
+        Optional<Expression> resolve(SQLExpr expr) {
+            if (groupKeyExprMap.containsKey(expr)) {
+                return Optional.of(groupKeyExprMap.get(expr).getExpression());
+            } else if (aggregationExprMap.containsKey(expr)) {
+                return Optional.of(aggregationExprMap.get(expr).getExpression());
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        public void addGroupKeyExpr(SQLExpr groupKeyExpr) {
+            if (!groupKeyExprMap.containsKey(groupKeyExpr)) {
+                groupKeyExprMap.put(groupKeyExpr, new GroupKeyExpr(groupKeyExpr));
+            }
+        }
+
+        public void addAggregationExpr(SQLAggregateExpr aggregationExpr) {
+            if (!aggregationExprMap.containsKey(aggregationExpr)) {
+                aggregationExprMap.put(aggregationExpr, new AggregationExpr(aggregationExpr));
+            }
+        }
+
+        @Getter
+        public class GroupKeyExpr {
+            private final SQLExpr expr;
+            private final Expression expression;
+
+            public GroupKeyExpr(SQLExpr expr) {
+                this.expr = expr;
+                String exprName = nameOfExpr(expr).replace(".", "#");
+                if (expr instanceof SQLIdentifierExpr
+                    && selectSQLExprAliasMap.values().contains(((SQLIdentifierExpr) expr).getName())) {
+                    exprName = ((SQLIdentifierExpr) expr).getName();
+                }
+                this.expression = ExpressionFactory.ref(selectSQLExprAliasMap.getOrDefault(expr, exprName));
+            }
+        }
+
+        @Getter
+        public class AggregationExpr {
+            private final SQLAggregateExpr expr;
+            private final Expression expression;
+
+            public AggregationExpr(SQLAggregateExpr expr) {
+                this.expr = expr;
+                this.expression =
+                        ExpressionFactory.ref(selectSQLExprAliasMap.getOrDefault(expr, aliasGenerator
+                                .nextAlias(expr.getMethodName())));
+            }
+        }
+
+        public static String nameOfExpr(SQLExpr expr) {
+            String exprName = expr.toString().toLowerCase();
+            if (expr instanceof SQLAggregateExpr) {
+                exprName = String.format("%s(%s)", ((SQLAggregateExpr) expr).getMethodName(),
+                                         ((SQLAggregateExpr) expr).getArguments().get(0));
+            } else if (expr instanceof SQLMethodInvokeExpr) {
+                exprName = String.format("%s(%s)", ((SQLMethodInvokeExpr) expr).getMethodName(),
+                                         ((SQLMethodInvokeExpr) expr).getParameters().get(0));
+            } else if (expr instanceof SQLIdentifierExpr) {
+                exprName = ((SQLIdentifierExpr) expr).getName();
+            } else if (expr instanceof SQLCastExpr) {
+                exprName = String.format("CAST(%s AS %s)", ((SQLCastExpr) expr).getExpr(),
+                                         ((SQLCastExpr) expr).getDataType().getName());
+            }
+            return exprName;
+        }
+
+        static class AliasGenerator {
+            private int aliasSuffix = 0;
+
+            private String nextAlias(String name) {
+                return String.format("%s_%d", name, next());
+            }
+
+            private Integer next() {
+                return aliasSuffix++;
+            }
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/converter/SQLExprToExpressionConverter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/converter/SQLExprToExpressionConverter.java
@@ -1,0 +1,107 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.query.planner.converter;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
+import com.alibaba.druid.sql.ast.expr.SQLCastExpr;
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.amazon.opendistroforelasticsearch.sql.expression.core.Expression;
+import com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory;
+import com.google.common.collect.ImmutableMap;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory.cast;
+import static com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory.log;
+
+/**
+ * The definition of {@link SQLExpr} to {@link Expression} converter.
+ */
+@RequiredArgsConstructor
+public class SQLExprToExpressionConverter {
+    private final SQLAggregationParser.Context context;
+
+    /**
+     * Convert the {@link SQLExpr} to {@link Expression}
+     * @param expr {@link SQLExpr}
+     * @return expression {@link Expression}
+     */
+    public Expression convert(SQLExpr expr) {
+        Optional<Expression> resolvedExpression = context.resolve(expr);
+        if (resolvedExpression.isPresent()) {
+            return resolvedExpression.get();
+        } else {
+            if (expr instanceof SQLBinaryOpExpr) {
+                return binaryOperatorToExpression((SQLBinaryOpExpr) expr, this::convert);
+            } else if (expr instanceof SQLMethodInvokeExpr) {
+                return methodToExpression((SQLMethodInvokeExpr) expr, this::convert);
+            } else if (expr instanceof SQLCastExpr) {
+                return cast(convert(((SQLCastExpr) expr).getExpr()));
+            } else {
+                throw new RuntimeException("unsupported expr: " + expr);
+            }
+        }
+    }
+
+    private Expression binaryOperatorToExpression(SQLBinaryOpExpr expr,
+                                                        Function<SQLExpr, Expression> converter) {
+        return BinaryExpression.of(expr.getOperator())
+                               .map(binaryExpression -> binaryExpression.getExpressionBuilder()
+                                                                        .apply(converter.apply((expr.getLeft())),
+                                                                               converter.apply(expr.getRight())))
+                               .orElseThrow(() -> new RuntimeException(
+                                       "unsupported operator in select: " + (expr.getOperator())));
+    }
+
+    private Expression methodToExpression(SQLMethodInvokeExpr expr, Function<SQLExpr, Expression> converter) {
+        if (("log").equalsIgnoreCase(expr.getMethodName())) {
+            return log(converter.apply(expr.getParameters().get(0)));
+        } else {
+            throw new RuntimeException("unsupported operator in select: " + expr.getMethodName());
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private enum BinaryExpression {
+        ADD(SQLBinaryOperator.Add, ExpressionFactory::add),
+        SUB(SQLBinaryOperator.Subtract, ExpressionFactory::sub);
+
+        private final SQLBinaryOperator sqlBinaryOperator;
+        private final BiFunction<Expression, Expression, Expression> expressionBuilder;
+
+        private static final Map<SQLBinaryOperator, BinaryExpression> BINARY_OPERATOR_MAP;
+
+        static {
+            ImmutableMap.Builder<SQLBinaryOperator, BinaryExpression> builder = new ImmutableMap.Builder<>();
+            for (BinaryExpression operator : BinaryExpression.values()) {
+                builder.put(operator.getSqlBinaryOperator(), operator);
+            }
+            BINARY_OPERATOR_MAP = builder.build();
+        }
+
+        public static Optional<BinaryExpression> of(SQLBinaryOperator operator) {
+            return Optional.ofNullable(BINARY_OPERATOR_MAP.get(operator));
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/converter/SQLToOperatorConverter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/converter/SQLToOperatorConverter.java
@@ -1,0 +1,100 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.query.planner.converter;
+
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitorAdapter;
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
+import com.amazon.opendistroforelasticsearch.sql.domain.Select;
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.parser.SqlParser;
+import com.amazon.opendistroforelasticsearch.sql.query.AggregationQueryAction;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ColumnNode;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.PhysicalOperator;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.project.PhysicalProject;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll.PhysicalScroll;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.Client;
+
+import java.util.List;
+
+/**
+ * Definition of SQL to PhysicalOperator converter.
+ */
+public class SQLToOperatorConverter extends MySqlASTVisitorAdapter {
+    private static final Logger LOG = LogManager.getLogger(SQLToOperatorConverter.class);
+
+    private final Client client;
+    private final SQLAggregationParser aggregationParser;
+
+    @Getter
+    private PhysicalOperator<BindingTuple> physicalOperator;
+
+    public SQLToOperatorConverter(Client client, ColumnTypeProvider columnTypeProvider) {
+        this.client = client;
+        this.aggregationParser = new SQLAggregationParser(columnTypeProvider);
+    }
+
+    @Override
+    public boolean visit(MySqlSelectQueryBlock query) {
+        //1. rewrite all the function name to lower case.
+        rewriteFunctionNameToLowerCase(query);
+
+        //2. parse the aggregation
+        aggregationParser.parse(query);
+
+
+        //3. construct the PhysicalOperator
+        physicalOperator = project(
+                                scroll(query));
+        return false;
+    }
+
+    /**
+     * Get list of {@link ColumnNode}.
+     *
+     * @return list of {@link ColumnNode}.
+     */
+    public List<ColumnNode> getColumnNodes() {
+        return aggregationParser.getColumnNodes();
+    }
+
+    private void rewriteFunctionNameToLowerCase(MySqlSelectQueryBlock query) {
+        query.accept(new MySqlASTVisitorAdapter() {
+            @Override
+            public boolean visit(SQLMethodInvokeExpr x) {
+                x.setMethodName(x.getMethodName().toLowerCase());
+                return true;
+            }
+        });
+    }
+
+    private PhysicalOperator<BindingTuple> project(PhysicalOperator<BindingTuple> input) {
+        return new PhysicalProject(input, aggregationParser.getColumnNodes());
+    }
+
+    @SneakyThrows
+    private PhysicalOperator<BindingTuple> scroll(MySqlSelectQueryBlock query) {
+        query.getSelectList().clear();
+        query.getSelectList().addAll(aggregationParser.selectItemList());
+        Select select = new SqlParser().parseSelect(query);
+        return new PhysicalScroll(new AggregationQueryAction(client, select));
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/core/BindingTupleQueryPlanner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/core/BindingTupleQueryPlanner.java
@@ -1,0 +1,89 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.query.planner.core;
+
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.converter.SQLToOperatorConverter;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.PhysicalOperator;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll.PhysicalScroll;
+import lombok.Getter;
+import org.elasticsearch.client.Client;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The definition of QueryPlanner which return the {@link BindingTuple} as result.
+ */
+public class BindingTupleQueryPlanner {
+    private PhysicalOperator<BindingTuple> physicalOperator;
+    @Getter
+    private List<ColumnNode> columnNodes;
+
+    public BindingTupleQueryPlanner(Client client, SQLQueryExpr sqlExpr, ColumnTypeProvider columnTypeProvider) {
+        SQLToOperatorConverter converter = new SQLToOperatorConverter(client, columnTypeProvider);
+        sqlExpr.accept(converter);
+        this.physicalOperator = converter.getPhysicalOperator();
+        this.columnNodes = converter.getColumnNodes();
+    }
+
+    /**
+     * Execute the QueryPlanner.
+     * @return list of {@link BindingTuple}.
+     */
+    public List<BindingTuple> execute() {
+        PhysicalOperator<BindingTuple> op = physicalOperator;
+        List<BindingTuple> tuples = new ArrayList<>();
+        try {
+            op.open(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        while (op.hasNext()) {
+            tuples.add(op.next().data());
+        }
+        return tuples;
+    }
+
+    /**
+     * Explain the physical execution plan.
+     * @return execution plan.
+     */
+    public String explain() {
+        Explanation explanation = new Explanation();
+        physicalOperator.accept(explanation);
+        return explanation.explain();
+    }
+
+    private static class Explanation implements PlanNode.Visitor {
+        private String explain;
+
+        public String explain() {
+            return explain;
+        }
+
+        @Override
+        public boolean visit(PlanNode planNode) {
+            if (planNode instanceof PhysicalScroll) {
+                explain = planNode.toString();
+            }
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/core/ColumnNode.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/core/ColumnNode.java
@@ -1,0 +1,37 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.query.planner.core;
+
+import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema;
+import com.amazon.opendistroforelasticsearch.sql.expression.core.Expression;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * The definition of column node.
+ */
+@Builder
+@Setter
+@Getter
+@ToString
+public class ColumnNode {
+    private String name;
+    private String alias;
+    private Schema.Type type;
+    private Expression expr;
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/project/PhysicalProject.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/project/PhysicalProject.java
@@ -16,18 +16,15 @@
 package com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.project;
 
 import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
-import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue;
-import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll.BindingTupleRow;
 import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ColumnNode;
 import com.amazon.opendistroforelasticsearch.sql.query.planner.core.PlanNode;
 import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.PhysicalOperator;
 import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.Row;
 import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.estimation.Cost;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll.BindingTupleRow;
 import lombok.RequiredArgsConstructor;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * The definition of Project Operator.
@@ -55,11 +52,8 @@ public class PhysicalProject implements PhysicalOperator<BindingTuple> {
     @Override
     public Row<BindingTuple> next() {
         BindingTuple input = next.next().data();
-        Map<String, ExprValue> output = new HashMap<>();
-        for (ColumnNode field : fields) {
-            ExprValue exprValue = field.getExpr().valueOf(input);
-            output.put(field.getName(), exprValue);
-        }
-        return new BindingTupleRow(BindingTuple.builder().bindingMap(output).build());
+        BindingTuple.BindingTupleBuilder outputBindingTupleBuilder = BindingTuple.builder();
+        fields.forEach(field -> outputBindingTupleBuilder.binding(field.getName(), field.getExpr().valueOf(input)));
+        return new BindingTupleRow(outputBindingTupleBuilder.build());
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/project/PhysicalProject.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/project/PhysicalProject.java
@@ -1,0 +1,65 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.project;
+
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll.BindingTupleRow;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ColumnNode;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.PlanNode;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.PhysicalOperator;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.Row;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.estimation.Cost;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The definition of Project Operator.
+ */
+@RequiredArgsConstructor
+public class PhysicalProject implements PhysicalOperator<BindingTuple> {
+    private final PhysicalOperator<BindingTuple> next;
+    private final List<ColumnNode> fields;
+
+    @Override
+    public Cost estimate() {
+        return null;
+    }
+
+    @Override
+    public PlanNode[] children() {
+        return new PlanNode[]{next};
+    }
+
+    @Override
+    public boolean hasNext() {
+        return next.hasNext();
+    }
+
+    @Override
+    public Row<BindingTuple> next() {
+        BindingTuple input = next.next().data();
+        Map<String, ExprValue> output = new HashMap<>();
+        for (ColumnNode field : fields) {
+            ExprValue exprValue = field.getExpr().valueOf(input);
+            output.put(field.getName(), exprValue);
+        }
+        return new BindingTupleRow(BindingTuple.builder().bindingMap(output).build());
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/scroll/BindingTupleRow.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/scroll/BindingTupleRow.java
@@ -1,0 +1,47 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll;
+
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.Row;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class BindingTupleRow implements Row<BindingTuple> {
+    private final BindingTuple bindingTuple;
+
+    @Override
+    public RowKey key(String[] colNames) {
+        return null;
+    }
+
+    @Override
+    public Row<BindingTuple> combine(Row<BindingTuple> otherRow) {
+        throw new RuntimeException("unsupported operation");
+    }
+
+    @Override
+    public void retain(Map<String, String> colNameAlias) {
+        // do nothing
+    }
+
+    @Override
+    public BindingTuple data() {
+        return bindingTuple;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/scroll/PhysicalScroll.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/scroll/PhysicalScroll.java
@@ -1,0 +1,103 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll;
+
+import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue;
+import com.amazon.opendistroforelasticsearch.sql.query.AggregationQueryAction;
+import com.amazon.opendistroforelasticsearch.sql.query.QueryAction;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ExecuteParams;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.PlanNode;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.PhysicalOperator;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.Row;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.estimation.Cost;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.aggregations.Aggregations;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValueFactory.fromJson;
+import static com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll.SearchAggregationResponseHelper.flatten;
+
+/**
+ * The definition of Scroll Operator.
+ */
+@RequiredArgsConstructor
+public class PhysicalScroll implements PhysicalOperator<BindingTuple> {
+    private final QueryAction queryAction;
+
+    private Iterator<BindingTupleRow> rowIterator;
+
+    @Override
+    public Cost estimate() {
+        return null;
+    }
+
+    @Override
+    public PlanNode[] children() {
+        return new PlanNode[0];
+    }
+
+    @Override
+    public boolean hasNext() {
+        return rowIterator.hasNext();
+    }
+
+    @Override
+    public Row<BindingTuple> next() {
+        return rowIterator.next();
+    }
+
+    @Override
+    public void open(ExecuteParams params) {
+        try {
+            ActionResponse response = queryAction.explain().get();
+            if (queryAction instanceof AggregationQueryAction) {
+                populateSearchAggregationResponse(((SearchResponse) response).getAggregations());
+            } else {
+                throw new IllegalStateException("Not support QueryAction type: " + queryAction.getClass());
+            }
+        } catch (SqlParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void populateSearchAggregationResponse(Aggregations aggs) {
+        List<Map<String, Object>> flatten = flatten(aggs);
+        List<BindingTupleRow> bindingTupleList = flatten.stream().map(map -> {
+            Map<String, ExprValue> ssValueMap = new HashMap<>();
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                ssValueMap.put(entry.getKey(), fromJson(entry.getValue()));
+            }
+            return BindingTuple.builder().bindingMap(ssValueMap).build();
+        }).map(bindingTuple -> new BindingTupleRow(bindingTuple)).collect(Collectors.toList());
+        rowIterator = bindingTupleList.iterator();
+    }
+
+    @SneakyThrows
+    @Override
+    public String toString() {
+        return queryAction.explain().toString();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/scroll/PhysicalScroll.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/scroll/PhysicalScroll.java
@@ -17,7 +17,6 @@ package com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.sc
 
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
-import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.query.AggregationQueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.QueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ExecuteParams;
@@ -29,16 +28,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.search.aggregations.Aggregations;
 
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValueFactory.fromJson;
-import static com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll.SearchAggregationResponseHelper.flatten;
 
 /**
  * The definition of Scroll Operator.
@@ -74,25 +65,15 @@ public class PhysicalScroll implements PhysicalOperator<BindingTuple> {
         try {
             ActionResponse response = queryAction.explain().get();
             if (queryAction instanceof AggregationQueryAction) {
-                populateSearchAggregationResponse(((SearchResponse) response).getAggregations());
+                rowIterator = SearchAggregationResponseHelper
+                        .populateSearchAggregationResponse(((SearchResponse) response).getAggregations())
+                        .iterator();
             } else {
                 throw new IllegalStateException("Not support QueryAction type: " + queryAction.getClass());
             }
         } catch (SqlParseException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private void populateSearchAggregationResponse(Aggregations aggs) {
-        List<Map<String, Object>> flatten = flatten(aggs);
-        List<BindingTupleRow> bindingTupleList = flatten.stream().map(map -> {
-            Map<String, ExprValue> ssValueMap = new HashMap<>();
-            for (Map.Entry<String, Object> entry : map.entrySet()) {
-                ssValueMap.put(entry.getKey(), fromJson(entry.getValue()));
-            }
-            return BindingTuple.builder().bindingMap(ssValueMap).build();
-        }).map(bindingTuple -> new BindingTupleRow(bindingTuple)).collect(Collectors.toList());
-        rowIterator = bindingTupleList.iterator();
     }
 
     @SneakyThrows

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/scroll/SearchAggregationResponseHelper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/planner/physical/node/scroll/SearchAggregationResponseHelper.java
@@ -1,0 +1,101 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll;
+
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.google.common.annotations.VisibleForTesting;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.Percentile;
+import org.elasticsearch.search.aggregations.metrics.Percentiles;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * The definition of Search {@link Aggregations} parser helper class.
+ */
+public class SearchAggregationResponseHelper {
+    public static List<BindingTupleRow> populateSearchAggregationResponse(Aggregations aggs) {
+        List<Map<String, Object>> flatten = flatten(aggs);
+        List<BindingTupleRow> bindingTupleList = flatten.stream()
+                .map(BindingTuple::from)
+                .map(bindingTuple -> new BindingTupleRow(bindingTuple))
+                .collect(Collectors.toList());
+        return bindingTupleList;
+    }
+
+    @VisibleForTesting
+    public static List<Map<String, Object>> flatten(Aggregations aggregations) {
+        List<Aggregation> aggregationList = aggregations.asList();
+        List<Map<String, Object>> resultList = new ArrayList<>();
+        Map<String, Object> resultMap = new HashMap<>();
+        for (Aggregation aggregation : aggregationList) {
+            if (aggregation instanceof Terms) {
+                for (Terms.Bucket bucket : ((Terms) aggregation).getBuckets()) {
+                    List<Map<String, Object>> internalBucketList = flatten(bucket.getAggregations());
+                    fillResultListWithInternalBucket(resultList, internalBucketList, aggregation.getName(),
+                                                     bucket.getKey());
+                }
+            } else if (aggregation instanceof NumericMetricsAggregation.SingleValue) {
+                resultMap.put(aggregation.getName(), ((NumericMetricsAggregation.SingleValue) aggregation).value());
+            } else if (aggregation instanceof Percentiles) {
+                Percentiles percentiles = (Percentiles) aggregation;
+                resultMap.putAll((Map<String, Double>) StreamSupport.stream(percentiles.spliterator(), false)
+                        .collect(Collectors.toMap(
+                                (percentile) -> String.format("%s_%s", percentiles.getName(), percentile.getPercent()),
+                                Percentile::getValue, (v1, v2) -> {
+                                    throw new IllegalArgumentException(
+                                            String.format("Duplicate key for values %s and %s", v1, v2));
+                                }, HashMap::new)));
+            } else if (aggregation instanceof Histogram) {
+                for (Histogram.Bucket bucket : ((Histogram) aggregation).getBuckets()) {
+                    List<Map<String, Object>> internalBucketList = flatten(bucket.getAggregations());
+                    fillResultListWithInternalBucket(resultList, internalBucketList, aggregation.getName(),
+                                                     bucket.getKeyAsString());
+                }
+            } else {
+                throw new RuntimeException("unsupported aggregation type " + aggregation.getType());
+            }
+        }
+        if (!resultMap.isEmpty()) {
+            resultList.add(resultMap);
+        }
+        return resultList;
+    }
+
+    private static void fillResultListWithInternalBucket(List<Map<String, Object>> resultList,
+                                                         List<Map<String, Object>> internalBucketList,
+                                                         String aggregationName, Object bucketKey) {
+        if (internalBucketList.isEmpty()) {
+            resultList.add(new HashMap<String, Object>() {{
+                put(aggregationName, bucketKey);
+            }});
+        } else {
+            for (Map<String, Object> map : internalBucketList) {
+                map.put(aggregationName, bucketKey);
+            }
+            resultList.addAll(internalBucketList);
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/CsvFormatResponseIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/CsvFormatResponseIT.java
@@ -44,10 +44,10 @@ import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstant
 import static com.amazon.opendistroforelasticsearch.sql.esintgtest.TestsConstants.TEST_INDEX_ONLINE;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 
@@ -371,15 +371,12 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
                 TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false);
         List<String> headers = csvResult.getHeaders();
-        Assert.assertEquals(2, headers.size());
-        Assert.assertEquals("gender", headers.get(0));
-        Assert.assertEquals("COUNT(*)", headers.get(1));
+        Assert.assertEquals(1, headers.size());
+        assertThat(headers, contains(equalTo("COUNT(*)")));
 
         List<String> lines = csvResult.getLines();
         Assert.assertEquals(2, lines.size());
-        Assert.assertTrue("m,507.0", lines.contains("m,507.0"));
-        Assert.assertTrue("f,493.0", lines.contains("f,493.0"));
-
+        assertThat(lines, containsInAnyOrder(equalTo("507.0"), equalTo("493.0")));
     }
 
     @Test
@@ -389,18 +386,16 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
                 TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false);
         List<String> headers = csvResult.getHeaders();
-        Assert.assertEquals(3, headers.size());
-        Assert.assertEquals("gender", headers.get(0));
-        Assert.assertEquals("age", headers.get(1));
-        Assert.assertEquals("COUNT(*)", headers.get(2));
+        Assert.assertEquals(1, headers.size());
+        assertThat(headers, contains(equalTo("COUNT(*)")));
 
         List<String> lines = csvResult.getLines();
         Assert.assertEquals(4, lines.size());
-        Assert.assertTrue("m,36,31.0", lines.contains("m,36,31.0"));
-        Assert.assertTrue("m,35,28.0", lines.contains("m,36,31.0"));
-        Assert.assertTrue("f,36,21.0", lines.contains("f,36,21.0"));
-        Assert.assertTrue("f,35,24.0", lines.contains("f,35,24.0"));
-
+        assertThat(lines, containsInAnyOrder(
+                equalTo("31.0"),
+                equalTo("28.0"),
+                equalTo("21.0"),
+                equalTo("24.0")));
     }
 
     @Test
@@ -410,23 +405,16 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
                 TEST_INDEX_ACCOUNT);
         CSVResult csvResult = executeCsvRequest(query, false);
         List<String> headers = csvResult.getHeaders();
-        Assert.assertEquals(4, headers.size());
-        Assert.assertEquals("gender", headers.get(0));
-        Assert.assertEquals("age", headers.get(1));
-        Assert.assertTrue(headers.get(2).equals("COUNT(*)") || headers.get(2).equals("SUM(balance)"));
-        Assert.assertTrue(headers.get(3).equals("COUNT(*)") || headers.get(3).equals("SUM(balance)"));
+        Assert.assertEquals(2, headers.size());
+        assertThat(headers, contains(equalTo("COUNT(*)"), equalTo("SUM(balance)")));
 
         List<String> lines = csvResult.getLines();
         Assert.assertEquals(4, lines.size());
-        Assert.assertTrue("m,36,31.0,647425.0",
-                lines.contains("m,36,31.0,647425.0") || lines.contains("m,36,647425.0,31.0"));
-        Assert.assertTrue("m,35,28.0,678337.0",
-                lines.contains("m,35,28.0,678337.0") || lines.contains("m,35,678337.0,28.0"));
-        Assert.assertTrue("f,36,21.0,505660.0",
-                lines.contains("f,36,21.0,505660.0") || lines.contains("f,36,505660.0,21.0"));
-        Assert.assertTrue("f,35,24.0,472771.0",
-                lines.contains("f,35,24.0,472771.0") || lines.contains("f,35,472771.0,24.0"));
-
+        assertThat(lines, containsInAnyOrder(
+                equalTo("31.0,647425.0"),
+                equalTo("28.0,678337.0"),
+                equalTo("21.0,505660.0"),
+                equalTo("24.0,472771.0")));
     }
 
     @Test
@@ -435,14 +423,15 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
                 " group by date_histogram('field'='insert_time','interval'='4d','alias'='days')", TEST_INDEX_ONLINE);
         CSVResult csvResult = executeCsvRequest(query, false);
         List<String> headers = csvResult.getHeaders();
-        Assert.assertEquals(2, headers.size());
-        Assert.assertEquals("days", headers.get(0));
-        Assert.assertEquals("COUNT(*)", headers.get(1));
+        Assert.assertEquals(1, headers.size());
+        assertThat(headers, contains(equalTo("COUNT(*)")));
 
         List<String> lines = csvResult.getLines();
         Assert.assertEquals(3, lines.size());
-        Assert.assertThat(lines,
-                hasItems("2014-08-14 00:00:00,477.0", "2014-08-18 00:00:00,5664.0", "2014-08-22 00:00:00,3795.0"));
+        assertThat(lines, containsInAnyOrder(
+                equalTo("477.0"),
+                equalTo("5664.0"),
+                equalTo("3795.0")));
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/PrettyFormatResponseIT.java
@@ -313,8 +313,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
                                 String.format(Locale.ROOT, "SELECT COUNT(*) FROM %s GROUP BY age",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
-        String count = "COUNT(*)";
-        List<String> fields = Arrays.asList("age", count);
+        List<String> fields = Arrays.asList("COUNT(*)");
         assertContainsColumns(getSchema(response), fields);
 
         JSONArray dataRows = getDataRows(response);
@@ -332,8 +331,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
                                 String.format(Locale.ROOT, "SELECT count(*) FROM %s GROUP BY age",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
-        String count = "COUNT(*)";
-        List<String> fields = Arrays.asList("age", count);
+        List<String> fields = Arrays.asList("COUNT(*)");
         assertContainsColumns(getSchema(response), fields);
 
         JSONArray dataRows = getDataRows(response);
@@ -351,8 +349,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
                                 String.format(Locale.ROOT, "SELECT COUNT(*) AS total FROM %s GROUP BY age",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
-        String count = "total";
-        List<String> fields = Arrays.asList("age", count);
+        List<String> fields = Arrays.asList("total");
         assertContainsColumns(getSchema(response), fields);
 
         JSONArray dataRows = getDataRows(response);
@@ -370,7 +367,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
                                 String.format(Locale.ROOT, "SELECT SUM(age) FROM %s GROUP BY age, state.keyword",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
-        List<String> fields = Arrays.asList("age", "state.keyword", "SUM(age)");
+        List<String> fields = Arrays.asList("SUM(age)");
         assertContainsColumns(getSchema(response), fields);
         assertContainsData(getDataRows(response), fields);
     }
@@ -398,7 +395,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
                                 String.format(Locale.ROOT, "SELECT COUNT(*), AVG(age) FROM %s GROUP BY age",
                                         TestsConstants.TEST_INDEX_ACCOUNT));
 
-        List<String> fields = Arrays.asList("age", "COUNT(*)", "AVG(age)");
+        List<String> fields = Arrays.asList("COUNT(*)", "AVG(age)");
         assertContainsColumns(getSchema(response), fields);
         assertContainsData(getDataRows(response), fields);
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLFunctionsIT.java
@@ -262,10 +262,12 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
                 "SELECT CAST(balance AS FLOAT) FROM " +
                         TestsConstants.TEST_INDEX_ACCOUNT + " GROUP BY balance DESC LIMIT 5");
 
-        String float_type_cast = "{\"name\":\"balance\",\"type\":\"long\"}";
-        assertEquals(response.getJSONArray("schema").get(0).toString(), float_type_cast);
-        Float[] expectedOutput = new Float[] {22026.0F, 23285.0F, 36038.0F, 39063.0F, 45493.0F};
+        assertEquals("CAST(balance AS FLOAT)", response.query("/schema/0/name"));
+        assertNull(response.query("/schema/0/alias"));
+        assertEquals("float", response.query("/schema/0/type"));
 
+        Float[] expectedOutput = new Float[] {22026.0F, 23285.0F, 36038.0F, 39063.0F, 45493.0F};
+        assertEquals(5, response.getJSONArray("datarows").length());
         for (int i = 0; i < response.getJSONArray("datarows").length(); ++i) {
             Assert.assertThat(
                     response.getJSONArray("datarows")
@@ -280,10 +282,12 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
                 "SELECT CAST(balance AS FLOAT) AS jdbc_float_alias " +
                         "FROM " + TestsConstants.TEST_INDEX_ACCOUNT + " GROUP BY jdbc_float_alias ASC LIMIT 5");
 
-        String float_type_cast = "{\"name\":\"jdbc_float_alias\",\"type\":\"float\"}";
-        assertEquals(response.getJSONArray("schema").get(0).toString(), float_type_cast);
-        Float[] expectedOutput = new Float[] {22026.0F, 23285.0F, 36038.0F, 39063.0F, 45493.0F};
+        assertEquals("jdbc_float_alias", response.query("/schema/0/name"));
+        assertEquals("jdbc_float_alias", response.query("/schema/0/alias"));
+        assertEquals("float", response.query("/schema/0/type"));
 
+        Float[] expectedOutput = new Float[] {22026.0F, 23285.0F, 36038.0F, 39063.0F, 45493.0F};
+        assertEquals(5, response.getJSONArray("datarows").length());
         for (int i = 0; i < response.getJSONArray("datarows").length(); ++i) {
             Assert.assertThat(
                     response.getJSONArray("datarows")
@@ -298,10 +302,12 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
                 "SELECT CAST(age AS DOUBLE) AS jdbc_double_alias " +
                         "FROM " + TestsConstants.TEST_INDEX_ACCOUNT + " GROUP BY jdbc_double_alias DESC LIMIT 5");
 
-        String float_type_cast = "{\"name\":\"jdbc_double_alias\",\"type\":\"double\"}";
-        assertEquals(response.getJSONArray("schema").get(0).toString(), float_type_cast);
-        Double[] expectedOutput = new Double[] {31.0, 39.0, 26.0, 32.0, 35.0};
+        assertEquals("jdbc_double_alias", response.query("/schema/0/name"));
+        assertEquals("jdbc_double_alias", response.query("/schema/0/alias"));
+        assertEquals("double", response.query("/schema/0/type"));
 
+        Double[] expectedOutput = new Double[] {31.0, 39.0, 26.0, 32.0, 35.0};
+        assertEquals(5, response.getJSONArray("datarows").length());
         for (int i = 0; i < response.getJSONArray("datarows").length(); ++i) {
             Assert.assertThat(
                     response.getJSONArray("datarows")
@@ -510,11 +516,12 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
     @Test
     public void ifFuncShouldPassJDBC() {
-        assertThat(
-                executeQuery("SELECT IF(age > 30, 'True', 'False') AS Ages FROM " + TEST_INDEX_ACCOUNT
-                        + " WHERE age IS NOT NULL GROUP BY Ages", "jdbc"),
-                containsString("\"type\": \"keyword\"")
-        );
+        JSONObject response = executeJdbcRequest(
+                "SELECT IF(age > 30, 'True', 'False') AS Ages FROM " + TEST_INDEX_ACCOUNT
+                + " WHERE age IS NOT NULL GROUP BY Ages");
+        assertEquals("Ages", response.query("/schema/0/name"));
+        assertEquals("Ages", response.query("/schema/0/alias"));
+        assertEquals("double", response.query("/schema/0/type"));
     }
 
     @Test
@@ -547,12 +554,12 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
     @Test
     public void ifnullShouldPassJDBC() throws IOException {
-        assertThat(
-                executeQuery("SELECT IFNULL(lastname, 'unknown') AS name FROM " + TEST_INDEX_ACCOUNT
-                        + " GROUP BY name", "jdbc"),
-                containsString("\"type\": \"keyword\"")
-        );
-
+        JSONObject response = executeJdbcRequest(
+                "SELECT IFNULL(lastname, 'unknown') AS name FROM " + TEST_INDEX_ACCOUNT
+                + " GROUP BY name");
+        assertEquals("name", response.query("/schema/0/name"));
+        assertEquals("name", response.query("/schema/0/alias"));
+        assertEquals("double", response.query("/schema/0/type"));
     }
 
     @Test
@@ -577,10 +584,11 @@ public class SQLFunctionsIT extends SQLIntegTestCase {
 
     @Test
     public void isnullShouldPassJDBC() {
-        assertThat(
-                executeQuery("SELECT ISNULL(lastname) AS name FROM " + TEST_INDEX_ACCOUNT + " GROUP BY name", "jdbc"),
-                containsString("\"type\": \"keyword\"")
-        );
+        JSONObject response =
+                executeJdbcRequest("SELECT ISNULL(lastname) AS name FROM " + TEST_INDEX_ACCOUNT + " GROUP BY name");
+        assertEquals("name", response.query("/schema/0/name"));
+        assertEquals("name", response.query("/schema/0/alias"));
+        assertEquals("integer", response.query("/schema/0/type"));
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/domain/ColumnTypeProviderTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/domain/ColumnTypeProviderTest.java
@@ -1,0 +1,54 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.domain;
+
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType;
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.operator.SetOperator;
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.special.Product;
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
+import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import static com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider.COLUMN_DEFAULT_TYPE;
+import static org.junit.Assert.assertEquals;
+
+public class ColumnTypeProviderTest {
+    @Test
+    public void singleESDataTypeShouldReturnCorrectSchemaType() {
+        assertEquals(Schema.Type.LONG, new ColumnTypeProvider(ESDataType.LONG).get(0));
+    }
+
+    @Test
+    public void productTypeShouldReturnCorrectSchemaType() {
+        ColumnTypeProvider columnTypeProvider =
+                new ColumnTypeProvider(new Product(ImmutableList.of(ESDataType.LONG, ESDataType.SHORT)));
+        assertEquals(Schema.Type.LONG, columnTypeProvider.get(0));
+        assertEquals(Schema.Type.SHORT, columnTypeProvider.get(1));
+    }
+
+    @Test
+    public void unSupportedTypeShouldReturnDefaultSchemaType() {
+        ColumnTypeProvider columnTypeProvider = new ColumnTypeProvider(SetOperator.UNION);
+        assertEquals(COLUMN_DEFAULT_TYPE, columnTypeProvider.get(0));
+    }
+
+    @Test
+    public void providerWithoutColumnTypeShouldReturnDefaultSchemaType() {
+        ColumnTypeProvider columnTypeProvider = new ColumnTypeProvider();
+        assertEquals(COLUMN_DEFAULT_TYPE, columnTypeProvider.get(0));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/executor/format/BindingTupleResultSetTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/executor/format/BindingTupleResultSetTest.java
@@ -1,0 +1,57 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.executor.format;
+
+import com.amazon.opendistroforelasticsearch.sql.executor.format.BindingTupleResultSet;
+import com.amazon.opendistroforelasticsearch.sql.executor.format.DataRows;
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.featureValueOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasEntry;
+
+public class BindingTupleResultSetTest {
+
+    @Test
+    public void buildDataRowsFromBindingTupleShouldPass() {
+        assertThat(row(Arrays.asList(BindingTuple.from(ImmutableMap.of("age", 31, "gender", "m")),
+                                     BindingTuple.from(ImmutableMap.of("age", 31, "gender", "f")),
+                                     BindingTuple.from(ImmutableMap.of("age", 39, "gender", "m")),
+                                     BindingTuple.from(ImmutableMap.of("age", 39, "gender", "f")))),
+                   containsInAnyOrder(rowContents(allOf(hasEntry("age", 31), hasEntry("gender", (Object) "m"))),
+                                      rowContents(allOf(hasEntry("age", 31), hasEntry("gender", (Object) "f"))),
+                                      rowContents(allOf(hasEntry("age", 39), hasEntry("gender", (Object) "m"))),
+                                      rowContents(allOf(hasEntry("age", 39), hasEntry("gender", (Object) "f")))));
+    }
+
+    private static Matcher<DataRows.Row> rowContents(Matcher<Map<String, Object>> matcher) {
+        return featureValueOf("DataRows.Row", matcher, DataRows.Row::getContents);
+    }
+
+    private List<DataRows.Row> row(List<BindingTuple> bindingTupleList) {
+        return ImmutableList.copyOf(BindingTupleResultSet.buildDataRows(bindingTupleList).iterator());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/executor/format/CSVResultsExtractorTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/executor/format/CSVResultsExtractorTest.java
@@ -1,0 +1,49 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.executor.format;
+
+import com.amazon.opendistroforelasticsearch.sql.executor.csv.CSVResult;
+import com.amazon.opendistroforelasticsearch.sql.executor.csv.CSVResultsExtractor;
+import com.amazon.opendistroforelasticsearch.sql.executor.csv.CsvExtractorException;
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+public class CSVResultsExtractorTest {
+    private final CSVResultsExtractor csvResultsExtractor = new CSVResultsExtractor(false, false, false);
+
+    @Test
+    public void extractResultsFromBindingTupleListShouldPass() throws CsvExtractorException {
+        CSVResult csvResult = csv(Arrays.asList(BindingTuple.from(ImmutableMap.of("age", 31, "gender", "m")),
+                                                BindingTuple.from(ImmutableMap.of("age", 31, "gender", "f")),
+                                                BindingTuple.from(ImmutableMap.of("age", 39, "gender", "m")),
+                                                BindingTuple.from(ImmutableMap.of("age", 39, "gender", "f"))),
+                                  Arrays.asList("age", "gender"));
+
+        assertThat(csvResult.getHeaders(), contains("age", "gender"));
+        assertThat(csvResult.getLines(), contains("31,m", "31,f", "39,m", "39,f"));
+    }
+
+    private CSVResult csv(List<BindingTuple> bindingTupleList, List<String> fieldNames) throws CsvExtractorException {
+        return csvResultsExtractor.extractResults(bindingTupleList, false, ",", fieldNames);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/expression/core/ArithmeticExpressionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/expression/core/ArithmeticExpressionTest.java
@@ -1,0 +1,56 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.expression.core;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory.add;
+import static com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory.ref;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ArithmeticExpressionTest extends ExpressionTest {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void addIntegerValueShouldPass() {
+        assertEquals(2, add(ref("intValue"), ref("intValue")).valueOf(bindingTuple()).numberValue());
+    }
+
+    @Test
+    public void multipleAddIntegerValueShouldPass() {
+        assertEquals(3,
+                     add(ref("intValue"), add(ref("intValue"), ref("intValue"))).valueOf(bindingTuple()).numberValue());
+    }
+
+    @Test
+    public void addDoubleValueShouldPass() {
+        assertEquals(4d, add(ref("doubleValue"), ref("doubleValue")).valueOf(bindingTuple()).numberValue());
+    }
+
+    @Test
+    public void addDoubleAndIntegerShouldThrowException() {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage("operation with different type is unsupported: ADD(DOUBLE_VALUE, INTEGER_VALUE)");
+
+        add(ref("doubleValue"), ref("intValue")).valueOf(bindingTuple());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/expression/core/ExpressionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/expression/core/ExpressionTest.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.expression.core;
+
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import org.json.JSONObject;
+
+public class ExpressionTest {
+    protected BindingTuple bindingTuple() {
+        String json = "{\n" +
+                      "  \"intValue\": 1,\n" +
+                      "  \"doubleValue\": 2.0,\n" +
+                      "  \"stringValue\": \"string\",\n" +
+                      "  \"booleanValue\": true,\n" +
+                      "  \"tupleValue\": {\n" +
+                      "    \"intValue\": 1,\n" +
+                      "    \"doubleValue\": 2.0,\n" +
+                      "    \"stringValue\": \"string\"\n" +
+                      "  },\n" +
+                      "  \"collectValue\": [\n" +
+                      "    1,\n" +
+                      "    2,\n" +
+                      "    3\n" +
+                      "  ]\n" +
+                      "}";
+        return BindingTuple.from(new JSONObject(json));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/expression/core/RefExpressionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/expression/core/RefExpressionTest.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.expression.core;
+
+import org.junit.Test;
+
+import static com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory.ref;
+import static com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValueFactory.doubleValue;
+import static com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValueFactory.integerValue;
+import static com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValueFactory.stringValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertEquals;
+
+public class RefExpressionTest extends ExpressionTest {
+    @Test
+    public void refIntegerValueShouldPass() {
+        assertEquals(1, ref("intValue").valueOf(bindingTuple()).numberValue());
+    }
+
+    @Test
+    public void refDoubleValueShouldPass() {
+        assertEquals(2.0d, ref("doubleValue").valueOf(bindingTuple()).numberValue());
+    }
+
+    @Test
+    public void refStringValueShouldPass() {
+        assertEquals("string", ref("stringValue").valueOf(bindingTuple()).stringValue());
+    }
+
+    @Test
+    public void refBooleanValueShouldPass() {
+        assertEquals(true, ref("booleanValue").valueOf(bindingTuple()).booleanValue());
+    }
+
+    @Test
+    public void refTupleValueShouldPass() {
+        assertThat(ref("tupleValue").valueOf(bindingTuple()).tupleValue(),
+                   allOf(hasEntry("intValue", integerValue(1)), hasEntry("doubleValue", doubleValue(2d)),
+                         hasEntry("stringValue", stringValue("string"))));
+    }
+
+    @Test
+    public void refCollectValueShouldPass() {
+        assertThat(ref("collectValue").valueOf(bindingTuple()).collectionValue(),
+                   contains(integerValue(1), integerValue(2), integerValue(3)));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/expression/model/ExprValueTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/expression/model/ExprValueTest.java
@@ -1,0 +1,47 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.expression.model;
+
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprIntegerValue;
+import com.amazon.opendistroforelasticsearch.sql.expression.model.ExprValue;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExprValueTest {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void interValueShouldReturnCorrectValue() {
+        ExprValue value = new ExprIntegerValue(1);
+        assertEquals(1, value.numberValue());
+    }
+
+    @Test
+    public void stringValueOnInterValueShouldThrowException() {
+        exceptionRule.expect(IllegalStateException.class);
+        exceptionRule.expectMessage("invalid stringValue operation on INTEGER_VALUE");
+
+        ExprValue value = new ExprIntegerValue(1);
+        value.stringValue();
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/BindingTupleQueryPlannerExecuteTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/BindingTupleQueryPlannerExecuteTest.java
@@ -1,0 +1,123 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.planner;
+
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.BindingTupleQueryPlanner;
+import com.amazon.opendistroforelasticsearch.sql.util.AggregationUtils;
+import com.amazon.opendistroforelasticsearch.sql.util.SqlParserUtils;
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BindingTupleQueryPlannerExecuteTest {
+    @Mock
+    private Client client;
+    @Mock
+    private SearchResponse aggResponse;
+    @Mock
+    private ColumnTypeProvider columnTypeProvider;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+
+        ActionFuture mockFuture = mock(ActionFuture.class);
+        when(client.execute(any(), any())).thenReturn(mockFuture);
+        when(mockFuture.actionGet()).thenAnswer(invocationOnMock -> aggResponse);
+    }
+
+    @Test
+    public void testAggregationShouldPass() {
+        assertThat(query("SELECT gender, MAX(age) as max, MIN(age) as min FROM accounts GROUP BY gender",
+                         mockSearchAggregation()),
+                   containsInAnyOrder(
+                           BindingTuple.from(ImmutableMap.of("gender", "m", "max", 20d, "min", 10d)),
+                           BindingTuple.from(ImmutableMap.of("gender", "f", "max", 40d, "min", 20d))));
+    }
+
+
+    protected List<BindingTuple> query(String sql, MockSearchAggregation mockAgg) {
+        doAnswer(mockAgg).when(aggResponse).getAggregations();
+
+        BindingTupleQueryPlanner queryPlanner =
+                new BindingTupleQueryPlanner(client, SqlParserUtils.parse(sql), columnTypeProvider);
+        return queryPlanner.execute();
+    }
+
+    private MockSearchAggregation mockSearchAggregation() {
+        return new MockSearchAggregation("{\n"
+                                         + "  \"sterms#gender\": {\n"
+                                         + "    \"buckets\": [\n"
+                                         + "      {\n"
+                                         + "        \"key\": \"m\",\n"
+                                         + "        \"doc_count\": 507,\n"
+                                         + "        \"min#min\": {\n"
+                                         + "          \"value\": 10\n"
+                                         + "        },\n"
+                                         + "        \"max#max\": {\n"
+                                         + "          \"value\": 20\n"
+                                         + "        }\n"
+                                         + "      },\n"
+                                         + "      {\n"
+                                         + "        \"key\": \"f\",\n"
+                                         + "        \"doc_count\": 493,\n"
+                                         + "        \"min#min\": {\n"
+                                         + "          \"value\": 20\n"
+                                         + "        },\n"
+                                         + "        \"max#max\": {\n"
+                                         + "          \"value\": 40\n"
+                                         + "        }\n"
+                                         + "      }\n"
+                                         + "    ]\n"
+                                         + "  }\n"
+                                         + "}");
+    }
+
+    protected static class MockSearchAggregation implements Answer<Aggregations> {
+        private final Aggregations aggregation;
+
+        public MockSearchAggregation(String agg) {
+            aggregation = AggregationUtils.fromJson(agg);
+        }
+
+        @Override
+        public Aggregations answer(InvocationOnMock invocationOnMock) throws Throwable {
+            return aggregation;
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/ESActionFactoryTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/ESActionFactoryTest.java
@@ -1,0 +1,77 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.planner;
+
+import com.amazon.opendistroforelasticsearch.sql.executor.Format;
+import com.amazon.opendistroforelasticsearch.sql.query.ESActionFactory;
+import com.amazon.opendistroforelasticsearch.sql.util.SqlParserUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ESActionFactoryTest {
+    @Test
+    public void josnOutputRequestShouldNotMigrateToQueryPlan() {
+        String sql = "SELECT age, MAX(balance) " +
+                     "FROM account " +
+                     "GROUP BY age";
+
+        assertFalse(ESActionFactory.shouldMigrateToQueryPlan(SqlParserUtils.parse(sql), Format.JSON));
+    }
+
+    @Test
+    public void nestQueryShouldNotMigrateToQueryPlan() {
+        String sql = "SELECT age, nested(balance) " +
+                     "FROM account " +
+                     "GROUP BY age";
+
+        assertFalse(ESActionFactory.shouldMigrateToQueryPlan(SqlParserUtils.parse(sql), Format.JDBC));
+    }
+
+    @Test
+    public void nonAggregationQueryShouldNotMigrateToQueryPlan() {
+        String sql = "SELECT age " +
+                     "FROM account ";
+
+        assertFalse(ESActionFactory.shouldMigrateToQueryPlan(SqlParserUtils.parse(sql), Format.JDBC));
+    }
+
+    @Test
+    public void aggregationQueryWithoutGroupByShouldMigrateToQueryPlan() {
+        String sql = "SELECT age, COUNT(balance) " +
+                     "FROM account ";
+
+        assertTrue(ESActionFactory.shouldMigrateToQueryPlan(SqlParserUtils.parse(sql), Format.JDBC));
+    }
+
+    @Test
+    public void aggregationQueryWithExpressionByShouldMigrateToQueryPlan() {
+        String sql = "SELECT age, MAX(balance) - MIN(balance) " +
+                     "FROM account ";
+
+        assertTrue(ESActionFactory.shouldMigrateToQueryPlan(SqlParserUtils.parse(sql), Format.JDBC));
+    }
+
+    @Test
+    public void queryOnlyHasGroupByShouldMigrateToQueryPlan() {
+        String sql = "SELECT CAST(age AS DOUBLE) as alias " +
+                     "FROM account " +
+                     "GROUP BY alias";
+
+        assertTrue(ESActionFactory.shouldMigrateToQueryPlan(SqlParserUtils.parse(sql), Format.JDBC));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/converter/SQLAggregationParserTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/converter/SQLAggregationParserTest.java
@@ -1,0 +1,306 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.planner.converter;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.expr.SQLAggregateExpr;
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelectItem;
+import com.alibaba.druid.sql.dialect.mysql.ast.statement.MySqlSelectQueryBlock;
+import com.alibaba.druid.util.JdbcConstants;
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
+import com.amazon.opendistroforelasticsearch.sql.expression.core.Expression;
+import com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.converter.SQLAggregationParser;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ColumnNode;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory.add;
+import static com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory.cast;
+import static com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory.log;
+import static com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory.ref;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SQLAggregationParserTest {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Test
+    public void parseAggWithoutExpressionShouldPass() {
+        String sql = "SELECT dayOfWeek, max(FlightDelayMin), MIN(FlightDelayMin) as min " +
+                     "FROM kibana_sample_data_flights " +
+                     "GROUP BY dayOfWeek";
+        SQLAggregationParser parser = new SQLAggregationParser(new ColumnTypeProvider());
+        parser.parse(mYSqlSelectQueryBlock(sql));
+        List<SQLSelectItem> sqlSelectItems = parser.selectItemList();
+        List<ColumnNode> columnNodes = parser.getColumnNodes();
+
+        assertThat(sqlSelectItems, containsInAnyOrder(group("dayOfWeek", "dayOfWeek"),
+                                                      agg("MAX", "FlightDelayMin", "MAX_0"),
+                                                      agg("MIN", "FlightDelayMin", "min")));
+
+        assertThat(columnNodes, containsInAnyOrder(columnNode("dayOfWeek", null, ExpressionFactory.ref("dayOfWeek")),
+                                                   columnNode("MAX(FlightDelayMin)", null, ExpressionFactory
+                                                           .ref("MAX_0")),
+                                                   columnNode("min", "min", ExpressionFactory.ref("min"))));
+    }
+
+    @Test
+    public void parseAggWithFunctioniWithoutExpressionShouldPass() {
+        String sql = "SELECT dayOfWeek, max(FlightDelayMin), MIN(FlightDelayMin) as min " +
+                     "FROM kibana_sample_data_flights " +
+                     "GROUP BY dayOfWeek";
+        SQLAggregationParser parser = new SQLAggregationParser(new ColumnTypeProvider());
+        parser.parse(mYSqlSelectQueryBlock(sql));
+        List<SQLSelectItem> sqlSelectItems = parser.selectItemList();
+        List<ColumnNode> columnNodes = parser.getColumnNodes();
+
+        assertThat(sqlSelectItems, containsInAnyOrder(group("dayOfWeek", "dayOfWeek"),
+                                                      agg("MAX", "FlightDelayMin", "MAX_0"),
+                                                      agg("MIN", "FlightDelayMin", "min")));
+
+        assertThat(columnNodes, containsInAnyOrder(columnNode("dayOfWeek", null, ExpressionFactory.ref("dayOfWeek")),
+                                                   columnNode("MAX(FlightDelayMin)", null, ExpressionFactory
+                                                           .ref("MAX_0")),
+                                                   columnNode("min", "min", ExpressionFactory.ref("min"))));
+    }
+
+    @Test
+    public void parseAggWithExpressionShouldPass() {
+        String sql = "SELECT dayOfWeek, max(FlightDelayMin) + MIN(FlightDelayMin) as sub " +
+                     "FROM kibana_sample_data_flights " +
+                     "GROUP BY dayOfWeek";
+        SQLAggregationParser parser = new SQLAggregationParser(new ColumnTypeProvider());
+        parser.parse(mYSqlSelectQueryBlock(sql));
+        List<SQLSelectItem> sqlSelectItems = parser.selectItemList();
+        List<ColumnNode> columnNodes = parser.getColumnNodes();
+
+        assertThat(sqlSelectItems, containsInAnyOrder(group("dayOfWeek", "dayOfWeek"),
+                                                      agg("MAX", "FlightDelayMin", "MAX_0"),
+                                                      agg("MIN", "FlightDelayMin", "MIN_1")));
+
+        assertThat(columnNodes, containsInAnyOrder(columnNode("dayOfWeek", null, ExpressionFactory.ref("dayOfWeek")),
+                                                   columnNode("sub", "sub", add(ExpressionFactory.ref("MAX_0"), ExpressionFactory
+                                                           .ref("MIN_1")))));
+    }
+
+    @Test
+    public void functionOverFiledShouldPass() {
+        String sql = "SELECT dayOfWeek, max(FlightDelayMin) + MIN(FlightDelayMin) as sub " +
+                     "FROM kibana_sample_data_flights " +
+                     "GROUP BY dayOfWeek";
+        SQLAggregationParser parser = new SQLAggregationParser(new ColumnTypeProvider());
+        parser.parse(mYSqlSelectQueryBlock(sql));
+        List<SQLSelectItem> sqlSelectItems = parser.selectItemList();
+        List<ColumnNode> columnNodes = parser.getColumnNodes();
+
+        assertThat(sqlSelectItems, containsInAnyOrder(group("dayOfWeek", "dayOfWeek"),
+                                                      agg("MAX", "FlightDelayMin", "MAX_0"),
+                                                      agg("MIN", "FlightDelayMin", "MIN_1")));
+
+        assertThat(columnNodes, containsInAnyOrder(columnNode("dayOfWeek", null, ExpressionFactory.ref("dayOfWeek")),
+                                                   columnNode("sub", "sub", add(ExpressionFactory.ref("MAX_0"), ExpressionFactory
+                                                           .ref("MIN_1")))));
+    }
+
+    @Test
+    public void parseCompoundAggWithExpressionShouldPass() {
+        String sql = "SELECT ASCII(dayOfWeek), log(max(FlightDelayMin) + MIN(FlightDelayMin)) as log " +
+                     "FROM kibana_sample_data_flights " +
+                     "GROUP BY ASCII(dayOfWeek)";
+        SQLAggregationParser parser = new SQLAggregationParser(new ColumnTypeProvider());
+        parser.parse(mYSqlSelectQueryBlock(sql));
+        List<SQLSelectItem> sqlSelectItems = parser.selectItemList();
+        List<ColumnNode> columnNodes = parser.getColumnNodes();
+
+        assertThat(sqlSelectItems, containsInAnyOrder(group("ASCII(dayOfWeek)", "ASCII(dayOfWeek)"),
+                                                      agg("MAX", "FlightDelayMin", "MAX_0"),
+                                                      agg("MIN", "FlightDelayMin", "MIN_1")));
+
+        assertThat(columnNodes, containsInAnyOrder(columnNode("ASCII(dayOfWeek)", null, ExpressionFactory
+                                                           .ref("ASCII(dayOfWeek)")),
+                                                   columnNode("log", "log", log(add(ExpressionFactory.ref("MAX_0"), ExpressionFactory
+                                                           .ref("MIN_1"))))));
+    }
+
+    @Test
+    public void parseFunctionGroupColumnOverShouldPass() {
+        String sql = "SELECT CAST(balance AS FLOAT) FROM accounts GROUP BY balance";
+        SQLAggregationParser parser = new SQLAggregationParser(new ColumnTypeProvider());
+        parser.parse(mYSqlSelectQueryBlock(sql));
+        List<SQLSelectItem> sqlSelectItems = parser.selectItemList();
+        List<ColumnNode> columnNodes = parser.getColumnNodes();
+
+        assertThat(sqlSelectItems, containsInAnyOrder(group("balance", "balance")));
+        assertThat(columnNodes, containsInAnyOrder(columnNode("CAST(balance AS FLOAT)", null, cast(
+                ExpressionFactory.ref("balance")))));
+    }
+
+    @Test
+    public void withoutAggregationShouldPass() {
+        String sql = "SELECT age, gender FROM accounts GROUP BY age, gender";
+        SQLAggregationParser parser = new SQLAggregationParser(new ColumnTypeProvider());
+        parser.parse(mYSqlSelectQueryBlock(sql));
+        List<SQLSelectItem> sqlSelectItems = parser.selectItemList();
+        List<ColumnNode> columnNodes = parser.getColumnNodes();
+
+        assertThat(sqlSelectItems, containsInAnyOrder(
+                group("age", "age"),
+                group("gender", "gender")));
+        assertThat(columnNodes, containsInAnyOrder(
+                columnNode("age", null, ExpressionFactory.ref("age")),
+                columnNode("gender", null, ExpressionFactory.ref("gender"))));
+    }
+
+    @Test
+    public void groupKeyInSelectWithFunctionShouldPass() {
+        String sql = "SELECT log(age), max(balance) FROM accounts GROUP BY age";
+        SQLAggregationParser parser = new SQLAggregationParser(new ColumnTypeProvider());
+        parser.parse(mYSqlSelectQueryBlock(sql));
+        List<SQLSelectItem> sqlSelectItems = parser.selectItemList();
+        List<ColumnNode> columnNodes = parser.getColumnNodes();
+
+        assertThat(sqlSelectItems, containsInAnyOrder(
+                group("age", "age"),
+                agg("max", "balance", "max_0")));
+        assertThat(columnNodes, containsInAnyOrder(
+                columnNode("log(age)", null, log(ExpressionFactory.ref("age"))),
+                columnNode("max(balance)", null, ExpressionFactory.ref("max_0"))));
+    }
+
+    @Test
+    public void theDotInFieldNameShouldBeReplaceWithSharp() {
+        String sql = "SELECT name.lastname, max(balance) FROM accounts GROUP BY name.lastname";
+        SQLAggregationParser parser = new SQLAggregationParser(new ColumnTypeProvider());
+        parser.parse(mYSqlSelectQueryBlock(sql));
+        List<SQLSelectItem> sqlSelectItems = parser.selectItemList();
+        List<ColumnNode> columnNodes = parser.getColumnNodes();
+
+        assertThat(sqlSelectItems, containsInAnyOrder(
+                group("name.lastname", "name#lastname"),
+                agg("max", "balance", "max_0")));
+        assertThat(columnNodes, containsInAnyOrder(
+                columnNode("name.lastname", null, ExpressionFactory.ref("name#lastname")),
+                columnNode("max(balance)", null, ExpressionFactory.ref("max_0"))));
+    }
+
+    @Test
+    public void noGroupKeyInSelectShouldPass() {
+        String sql = "SELECT AVG(age) FROM t GROUP BY age";
+        SQLAggregationParser parser = new SQLAggregationParser(new ColumnTypeProvider());
+        parser.parse(mYSqlSelectQueryBlock(sql));
+        List<SQLSelectItem> sqlSelectItems = parser.selectItemList();
+        List<ColumnNode> columnNodes = parser.getColumnNodes();
+
+        assertThat(sqlSelectItems, containsInAnyOrder(
+                agg("avg", "age", "avg_0")));
+        assertThat(columnNodes, containsInAnyOrder(
+                columnNode("avg(age)", null, ExpressionFactory.ref("avg_0"))));
+    }
+
+    /**
+     * TermQueryExplainIT.testNestedSingleGroupBy
+     */
+    @Test
+    public void aggregationWithNestedShouldThrowException() {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage("unsupported operator in select: nested");
+
+        String sql = "SELECT nested(projects.name, 'projects'),id "
+                     + "FROM t "
+                     + "GROUP BY nested(projects.name.keyword, 'projects')";
+        SQLAggregationParser parser = new SQLAggregationParser(new ColumnTypeProvider());
+        parser.parse(mYSqlSelectQueryBlock(sql));
+    }
+
+    private MySqlSelectQueryBlock mYSqlSelectQueryBlock(String sql) {
+        String dbType = JdbcConstants.MYSQL;
+        SQLQueryExpr sqlQueryExpr = (SQLQueryExpr) SQLUtils.toSQLExpr(sql, dbType);
+        return ((MySqlSelectQueryBlock) sqlQueryExpr.getSubQuery().getQuery());
+    }
+
+    private TypeSafeMatcher<ColumnNode> columnNode(String name, String alias, Expression expr) {
+        return new TypeSafeMatcher<ColumnNode>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(String.format("(name=%s,alias=%s,expression=%s)", name, alias, expr));
+            }
+
+            @Override
+            protected boolean matchesSafely(ColumnNode item) {
+                if (name == null) {
+                    return false;
+                }
+                if (alias == null && item.getAlias() != null) {
+                    return false;
+                }
+
+                return name.equalsIgnoreCase(item.getName()) &&
+                       ((alias == null && item.getAlias() == null) || alias.equals(item.getAlias())) &&
+                       expr.toString().equalsIgnoreCase(item.getExpr().toString());
+            }
+        };
+    }
+
+    private TypeSafeMatcher<SQLSelectItem> agg(String methodName, String name, String alias) {
+        return new TypeSafeMatcher<SQLSelectItem>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(String.format("(methodName=%s, name=%s, alias=%s)", methodName, name, alias));
+            }
+
+            @Override
+            protected boolean matchesSafely(SQLSelectItem item) {
+                if (item.getExpr() instanceof SQLAggregateExpr) {
+                    return ((SQLAggregateExpr) item.getExpr()).getMethodName().equalsIgnoreCase(methodName) &&
+                           ((SQLAggregateExpr) item.getExpr()).getArguments()
+                                                              .get(0)
+                                                              .toString()
+                                                              .equalsIgnoreCase(name) &&
+                           ((item.getAlias() == null && alias == null) || item.getAlias().equalsIgnoreCase(alias));
+                } else {
+                    return false;
+                }
+            }
+        };
+    }
+
+    private TypeSafeMatcher<SQLSelectItem> group(String name, String alias) {
+        return new TypeSafeMatcher<SQLSelectItem>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(String.format("(name=%s, alias=%s)", name, alias));
+            }
+
+            @Override
+            protected boolean matchesSafely(SQLSelectItem item) {
+                boolean b = item.getExpr().toString().equalsIgnoreCase(name) &&
+                            ((item.getAlias() == null && alias == null) || item.getAlias().equalsIgnoreCase(alias));
+                return b;
+            }
+        };
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/converter/SQLExprToExpressionConverterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/converter/SQLExprToExpressionConverterTest.java
@@ -1,0 +1,141 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.planner.converter;
+
+import com.alibaba.druid.sql.ast.expr.SQLAggregateExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.amazon.opendistroforelasticsearch.sql.expression.core.Expression;
+import com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.converter.SQLAggregationParser;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.converter.SQLExprToExpressionConverter;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory.add;
+import static com.amazon.opendistroforelasticsearch.sql.expression.core.ExpressionFactory.log;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SQLExprToExpressionConverterTest {
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    private SQLExprToExpressionConverter converter;
+    private SQLAggregationParser.Context context;
+    private final SQLAggregateExpr maxA = new SQLAggregateExpr("MAX");
+    private final SQLAggregateExpr maxB = new SQLAggregateExpr("MAX");
+    private final SQLAggregateExpr minA = new SQLAggregateExpr("MIN");
+    private final SQLIdentifierExpr groupG = new SQLIdentifierExpr("A");
+    private final SQLIdentifierExpr aggA = new SQLIdentifierExpr("A");
+    private final SQLIdentifierExpr aggB = new SQLIdentifierExpr("B");
+
+    @Before
+    public void setup() {
+        maxA.getArguments().add(aggA);
+        maxB.getArguments().add(aggB);
+        minA.getArguments().add(aggA);
+        context = new SQLAggregationParser.Context(ImmutableMap.of());
+        converter = new SQLExprToExpressionConverter(context);
+    }
+
+    @Test
+    public void identifierShouldReturnVarExpression() {
+        context.addGroupKeyExpr(groupG);
+        Expression expression = converter.convert(groupG);
+
+        assertEquals(ExpressionFactory.ref("A").toString(), expression.toString());
+    }
+
+    @Test
+    public void binaryOperatorAddShouldReturnAddExpression() {
+        context.addAggregationExpr(maxA);
+        context.addAggregationExpr(minA);
+
+        Expression expression = converter.convert(new SQLBinaryOpExpr(maxA, SQLBinaryOperator.Add, minA));
+        assertEquals(add(ExpressionFactory.ref("MAX_0"), ExpressionFactory.ref("MIN_1")).toString(), expression.toString());
+    }
+
+    @Test
+    public void compoundBinaryOperatorShouldReturnCorrectExpression() {
+        context.addAggregationExpr(maxA);
+        context.addAggregationExpr(minA);
+
+        Expression expression = converter.convert(new SQLBinaryOpExpr(maxA, SQLBinaryOperator.Add,
+                                                                      new SQLBinaryOpExpr(maxA, SQLBinaryOperator.Add,
+                                                                                          minA)));
+        assertEquals(add(ExpressionFactory.ref("MAX_0"), add(ExpressionFactory.ref("MAX_0"), ExpressionFactory
+                .ref("MIN_1"))).toString(), expression.toString());
+    }
+
+    @Test
+    public void functionOverCompoundBinaryOperatorShouldReturnCorrectExpression() {
+        context.addAggregationExpr(maxA);
+        context.addAggregationExpr(minA);
+
+        SQLMethodInvokeExpr methodInvokeExpr = new SQLMethodInvokeExpr("LOG");
+        methodInvokeExpr.addParameter(new SQLBinaryOpExpr(maxA, SQLBinaryOperator.Add,
+                                                          new SQLBinaryOpExpr(maxA, SQLBinaryOperator.Add,
+                                                                              minA)));
+
+        Expression expression = converter.convert(methodInvokeExpr);
+        assertEquals(log(add(ExpressionFactory.ref("MAX_0"), add(ExpressionFactory.ref("MAX_0"), ExpressionFactory
+                .ref("MIN_1")))).toString(), expression.toString());
+    }
+
+    @Test
+    public void functionOverGroupColumn() {
+        context.addAggregationExpr(maxA);
+        context.addAggregationExpr(minA);
+
+        SQLMethodInvokeExpr methodInvokeExpr = new SQLMethodInvokeExpr("LOG");
+        methodInvokeExpr.addParameter(new SQLBinaryOpExpr(maxA, SQLBinaryOperator.Add,
+                                                          new SQLBinaryOpExpr(maxA, SQLBinaryOperator.Add,
+                                                                              minA)));
+
+        Expression expression = converter.convert(methodInvokeExpr);
+        assertEquals(log(add(ExpressionFactory.ref("MAX_0"), add(ExpressionFactory.ref("MAX_0"), ExpressionFactory
+                .ref("MIN_1")))).toString(), expression.toString());
+    }
+
+    @Test
+    public void unknownIdentifierShouldThrowException() {
+        context.addAggregationExpr(maxA);
+        context.addAggregationExpr(minA);
+
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage("unsupported expr");
+        converter.convert(new SQLBinaryOpExpr(maxA, SQLBinaryOperator.Add, maxB));
+    }
+
+    @Test
+    public void unsupportOperationShouldThrowException() {
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage("unsupported operator in select: LOG10");
+
+        context.addAggregationExpr(maxA);
+        SQLMethodInvokeExpr methodInvokeExpr = new SQLMethodInvokeExpr("LOG10");
+        methodInvokeExpr.addParameter(maxA);
+        converter.convert(methodInvokeExpr);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/converter/SQLToOperatorConverterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/converter/SQLToOperatorConverterTest.java
@@ -1,0 +1,84 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.planner.converter;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.alibaba.druid.util.JdbcConstants;
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.converter.SQLToOperatorConverter;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.PhysicalOperator;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.project.PhysicalProject;
+import org.elasticsearch.client.Client;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SQLToOperatorConverterTest {
+    @Mock
+    private Client client;
+
+    private SQLToOperatorConverter converter;
+
+    @Before
+    public void setup() {
+        converter = new SQLToOperatorConverter(client, new ColumnTypeProvider());
+    }
+
+    @Test
+    public void convertAggShouldPass() {
+        String sql = "SELECT dayOfWeek, max(FlightDelayMin), MIN(FlightDelayMin) as min " +
+                     "FROM kibana_sample_data_flights " +
+                     "GROUP BY dayOfWeek";
+        toExpr(sql).accept(converter);
+        PhysicalOperator<BindingTuple> physicalOperator = converter.getPhysicalOperator();
+
+        assertTrue(physicalOperator instanceof PhysicalProject);
+    }
+
+    @Test
+    public void convertMaxMinusMinShouldPass() {
+        String sql = "SELECT dayOfWeek, max(FlightDelayMin) - MIN(FlightDelayMin) as diff " +
+                     "FROM kibana_sample_data_flights " +
+                     "GROUP BY dayOfWeek";
+        toExpr(sql).accept(converter);
+        PhysicalOperator<BindingTuple> physicalOperator = converter.getPhysicalOperator();
+
+        assertTrue(physicalOperator instanceof PhysicalProject);
+    }
+
+    @Test
+    public void convertDistinctPass() {
+        String sql = "SELECT dayOfWeek, max(FlightDelayMin) - MIN(FlightDelayMin) as diff " +
+                     "FROM kibana_sample_data_flights " +
+                     "GROUP BY dayOfWeek";
+        toExpr(sql).accept(converter);
+        PhysicalOperator<BindingTuple> physicalOperator = converter.getPhysicalOperator();
+
+        assertTrue(physicalOperator instanceof PhysicalProject);
+    }
+
+    private SQLQueryExpr toExpr(String sql) {
+        String dbType = JdbcConstants.MYSQL;
+        return (SQLQueryExpr) SQLUtils.toSQLExpr(sql, dbType);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/physical/SearchAggregationResponseHelperTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/physical/SearchAggregationResponseHelperTest.java
@@ -1,0 +1,343 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.unittest.planner.physical;
+
+import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll.BindingTupleRow;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.physical.node.scroll.SearchAggregationResponseHelper;
+import com.amazon.opendistroforelasticsearch.sql.util.AggregationUtils;
+import com.google.common.collect.ImmutableMap;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.featureValueOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SearchAggregationResponseHelperTest {
+    /**
+     * SELECT MAX(age) as max
+     * FROM accounts
+     */
+    @Test
+    public void noBucketOneMetricShouldPass() {
+        String json = "{\n"
+                      + "  \"max#max\": {\n"
+                      + "    \"value\": 40\n"
+                      + "  }\n"
+                      + "}";
+        List<Map<String, Object>> result = SearchAggregationResponseHelper.flatten(AggregationUtils.fromJson(json));
+        assertThat(result, contains(allOf(hasEntry("max", 40d))));
+    }
+
+    /**
+     * SELECT MAX(age) as max, MIN(age) as min
+     * FROM accounts
+     */
+    @Test
+    public void noBucketMultipleMetricShouldPass() {
+        String json = "{\n"
+                      + "  \"max#max\": {\n"
+                      + "    \"value\": 40\n"
+                      + "  },\n"
+                      + "  \"min#min\": {\n"
+                      + "    \"value\": 20\n"
+                      + "  }\n"
+                      + "}";
+        List<Map<String, Object>> result = SearchAggregationResponseHelper.flatten(AggregationUtils.fromJson(json));
+        assertThat(result, contains(allOf(hasEntry("max", 40d), hasEntry("min", 20d))));
+    }
+
+    /**
+     * SELECT gender, MAX(age) as max, MIN(age) as min
+     * FROM accounts
+     * GROUP BY gender
+     */
+    @Test
+    public void oneBucketMultipleMetricShouldPass() {
+        String json = "{\n"
+                      + "  \"sterms#gender\": {\n"
+                      + "    \"buckets\": [\n"
+                      + "      {\n"
+                      + "        \"key\": \"m\",\n"
+                      + "        \"doc_count\": 507,\n"
+                      + "        \"min#min\": {\n"
+                      + "          \"value\": 10\n"
+                      + "        },\n"
+                      + "        \"max#max\": {\n"
+                      + "          \"value\": 20\n"
+                      + "        }\n"
+                      + "      },\n"
+                      + "      {\n"
+                      + "        \"key\": \"f\",\n"
+                      + "        \"doc_count\": 493,\n"
+                      + "        \"min#min\": {\n"
+                      + "          \"value\": 20\n"
+                      + "        },\n"
+                      + "        \"max#max\": {\n"
+                      + "          \"value\": 40\n"
+                      + "        }\n"
+                      + "      }\n"
+                      + "    ]\n"
+                      + "  }\n"
+                      + "}";
+        List<Map<String, Object>> result = SearchAggregationResponseHelper.flatten(AggregationUtils.fromJson(json));
+        assertThat(result, contains(allOf(hasEntry("gender", (Object) "m"), hasEntry("min", 10d), hasEntry("max", 20d)),
+                                    allOf(hasEntry("gender", (Object) "f"), hasEntry("min", 20d),
+                                          hasEntry("max", 40d))));
+    }
+
+    /**
+     * SELECT gender, state, MAX(age) as max, MIN(age) as min
+     * FROM accounts
+     * GROUP BY gender, state
+     */
+    @Test
+    public void multipleBucketMultipleMetricShouldPass() {
+        String json = "{\n"
+                      + "  \"sterms#gender\": {\n"
+                      + "    \"buckets\": [\n"
+                      + "      {\n"
+                      + "        \"key\": \"m\",\n"
+                      + "        \"sterms#state\": {\n"
+                      + "          \"buckets\": [\n"
+                      + "            {\n"
+                      + "              \"key\": \"MD\",\n"
+                      + "              \"min#min\": {\n"
+                      + "                \"value\": 22\n"
+                      + "              },\n"
+                      + "              \"max#max\": {\n"
+                      + "                \"value\": 39\n"
+                      + "              }\n"
+                      + "            },\n"
+                      + "            {\n"
+                      + "              \"key\": \"ID\",\n"
+                      + "              \"min#min\": {\n"
+                      + "                \"value\": 23\n"
+                      + "              },\n"
+                      + "              \"max#max\": {\n"
+                      + "                \"value\": 40\n"
+                      + "              }\n"
+                      + "            }\n"
+                      + "          ]\n"
+                      + "        }\n"
+                      + "      },\n"
+                      + "      {\n"
+                      + "        \"key\": \"f\",\n"
+                      + "        \"sterms#state\": {\n"
+                      + "          \"buckets\": [\n"
+                      + "            {\n"
+                      + "              \"key\": \"TX\",\n"
+                      + "              \"min#min\": {\n"
+                      + "                \"value\": 20\n"
+                      + "              },\n"
+                      + "              \"max#max\": {\n"
+                      + "                \"value\": 38\n"
+                      + "              }\n"
+                      + "            },\n"
+                      + "            {\n"
+                      + "              \"key\": \"MI\",\n"
+                      + "              \"min#min\": {\n"
+                      + "                \"value\": 22\n"
+                      + "              },\n"
+                      + "              \"max#max\": {\n"
+                      + "                \"value\": 40\n"
+                      + "              }\n"
+                      + "            }\n"
+                      + "          ]\n"
+                      + "        }\n"
+                      + "      }\n"
+                      + "    ]\n"
+                      + "  }\n"
+                      + "}";
+        List<Map<String, Object>> result = SearchAggregationResponseHelper.flatten(AggregationUtils.fromJson(json));
+        assertThat(result, contains(
+                allOf(hasEntry("gender", (Object) "m"), hasEntry("state", (Object) "MD"), hasEntry("min", 22d),
+                      hasEntry("max", 39d)),
+                allOf(hasEntry("gender", (Object) "m"), hasEntry("state", (Object) "ID"), hasEntry("min", 23d),
+                      hasEntry("max", 40d)),
+                allOf(hasEntry("gender", (Object) "f"), hasEntry("state", (Object) "TX"), hasEntry("min", 20d),
+                      hasEntry("max", 38d)),
+                allOf(hasEntry("gender", (Object) "f"), hasEntry("state", (Object) "MI"), hasEntry("min", 22d),
+                      hasEntry("max", 40d))));
+    }
+
+    /**
+     * SELECT age, gender FROM accounts GROUP BY age, gender
+     */
+    @Test
+    public void multipleBucketWithoutMetricShouldPass() {
+        String json = "{\n"
+                      + "  \"lterms#age\": {\n"
+                      + "    \"buckets\": [\n"
+                      + "      {\n"
+                      + "        \"key\": 31,\n"
+                      + "        \"doc_count\": 61,\n"
+                      + "        \"sterms#gender\": {\n"
+                      + "          \"buckets\": [\n"
+                      + "            {\n"
+                      + "              \"key\": \"m\",\n"
+                      + "              \"doc_count\": 35\n"
+                      + "            },\n"
+                      + "            {\n"
+                      + "              \"key\": \"f\",\n"
+                      + "              \"doc_count\": 26\n"
+                      + "            }\n"
+                      + "          ]\n"
+                      + "        }\n"
+                      + "      },\n"
+                      + "      {\n"
+                      + "        \"key\": 39,\n"
+                      + "        \"doc_count\": 60,\n"
+                      + "        \"sterms#gender\": {\n"
+                      + "          \"buckets\": [\n"
+                      + "            {\n"
+                      + "              \"key\": \"f\",\n"
+                      + "              \"doc_count\": 38\n"
+                      + "            },\n"
+                      + "            {\n"
+                      + "              \"key\": \"m\",\n"
+                      + "              \"doc_count\": 22\n"
+                      + "            }\n"
+                      + "          ]\n"
+                      + "        }\n"
+                      + "      }\n"
+                      + "    ]\n"
+                      + "  }\n"
+                      + "}";
+        List<Map<String, Object>> result = SearchAggregationResponseHelper.flatten(AggregationUtils.fromJson(json));
+        assertThat(result, containsInAnyOrder(
+                allOf(hasEntry("age", (Object) 31L), hasEntry("gender","m")),
+                allOf(hasEntry("age", (Object) 31L), hasEntry("gender","f")),
+                allOf(hasEntry("age", (Object) 39L), hasEntry("gender","m")),
+                allOf(hasEntry("age", (Object) 39L), hasEntry("gender","f"))));
+    }
+
+    /**
+     * SELECT PERCENTILES(age) FROM accounts
+     */
+    @Test
+    public void noBucketPercentilesShouldPass() {
+        String json = "{\n"
+                      + "  \"percentiles_bucket#age\": {\n"
+                      + "    \"values\": {\n"
+                      + "      \"1.0\": 20,\n"
+                      + "      \"5.0\": 21,\n"
+                      + "      \"25.0\": 25,\n"
+                      + "      \"50.0\": 30.90909090909091,\n"
+                      + "      \"75.0\": 35,\n"
+                      + "      \"95.0\": 39,\n"
+                      + "      \"99.0\": 40\n"
+                      + "    }\n"
+                      + "  }\n"
+                      + "}";
+        List<Map<String, Object>> result = SearchAggregationResponseHelper.flatten(AggregationUtils.fromJson(json));
+        assertThat(result, contains(allOf(hasEntry("age_1.0", 20d))));
+    }
+
+    /**
+     * SELECT count(*) from online
+     * GROUP BY date_histogram('field'='insert_time','interval'='4d','alias'='days')
+     */
+    @Test
+    public void populateShouldPass() {
+        String json = "{\n"
+                      + "  \"date_histogram#days\": {\n"
+                      + "    \"buckets\": [\n"
+                      + "      {\n"
+                      + "        \"key_as_string\": \"2014-08-14 00:00:00\",\n"
+                      + "        \"key\": 1407974400000,\n"
+                      + "        \"doc_count\": 477,\n"
+                      + "        \"value_count#COUNT_0\": {\n"
+                      + "          \"value\": 477\n"
+                      + "        }\n"
+                      + "      }\n"
+                      + "    ]\n"
+                      + "  }\n"
+                      + "}";
+        List<Map<String, Object>> result = SearchAggregationResponseHelper.flatten(AggregationUtils.fromJson(json));
+        assertThat(result, containsInAnyOrder(
+                allOf(hasEntry("days", (Object) "2014-08-14 00:00:00"), hasEntry("COUNT_0",477d))));
+    }
+
+    /**
+     * SELECT s
+     */
+    @Test
+    public void populateSearchAggregationResponeShouldPass() {
+        String json = "{\n"
+                      + "  \"lterms#age\": {\n"
+                      + "    \"buckets\": [\n"
+                      + "      {\n"
+                      + "        \"key\": 31,\n"
+                      + "        \"doc_count\": 61,\n"
+                      + "        \"sterms#gender\": {\n"
+                      + "          \"buckets\": [\n"
+                      + "            {\n"
+                      + "              \"key\": \"m\",\n"
+                      + "              \"doc_count\": 35\n"
+                      + "            },\n"
+                      + "            {\n"
+                      + "              \"key\": \"f\",\n"
+                      + "              \"doc_count\": 26\n"
+                      + "            }\n"
+                      + "          ]\n"
+                      + "        }\n"
+                      + "      },\n"
+                      + "      {\n"
+                      + "        \"key\": 39,\n"
+                      + "        \"doc_count\": 60,\n"
+                      + "        \"sterms#gender\": {\n"
+                      + "          \"buckets\": [\n"
+                      + "            {\n"
+                      + "              \"key\": \"f\",\n"
+                      + "              \"doc_count\": 38\n"
+                      + "            },\n"
+                      + "            {\n"
+                      + "              \"key\": \"m\",\n"
+                      + "              \"doc_count\": 22\n"
+                      + "            }\n"
+                      + "          ]\n"
+                      + "        }\n"
+                      + "      }\n"
+                      + "    ]\n"
+                      + "  }\n"
+                      + "}";
+        List<BindingTupleRow> bindingTupleRows =
+                SearchAggregationResponseHelper.populateSearchAggregationResponse(AggregationUtils.fromJson(json));
+        assertEquals(4, bindingTupleRows.size());
+        assertThat(bindingTupleRows, containsInAnyOrder(
+                bindingTupleRow(BindingTuple.from(ImmutableMap.of("age", 31L, "gender", "m"))),
+                bindingTupleRow(BindingTuple.from(ImmutableMap.of("age", 31L, "gender", "f"))),
+                bindingTupleRow(BindingTuple.from(ImmutableMap.of("age", 39L, "gender", "m"))),
+                bindingTupleRow(BindingTuple.from(ImmutableMap.of("age", 39L, "gender", "f")))));
+    }
+
+    private static Matcher<BindingTupleRow> bindingTupleRow(BindingTuple bindingTuple) {
+        return featureValueOf("BindingTuple", equalTo(bindingTuple), BindingTupleRow::data);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/AggregationUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/AggregationUtils.java
@@ -1,0 +1,93 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.util;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.SneakyThrows;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.xcontent.ContextParser;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContent;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
+import org.elasticsearch.search.aggregations.bucket.terms.DoubleTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedDoubleTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedLongTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
+import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.ParsedAvg;
+import org.elasticsearch.search.aggregations.metrics.ParsedMax;
+import org.elasticsearch.search.aggregations.metrics.ParsedMin;
+import org.elasticsearch.search.aggregations.metrics.ParsedSum;
+import org.elasticsearch.search.aggregations.metrics.ParsedValueCount;
+import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilder;
+import org.elasticsearch.search.aggregations.pipeline.ParsedPercentilesBucket;
+import org.elasticsearch.search.aggregations.pipeline.PercentilesBucketPipelineAggregationBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AggregationUtils {
+    private final static List<NamedXContentRegistry.Entry> entryList =
+            new ImmutableMap.Builder<String, ContextParser<Object, ? extends Aggregation>>().put(
+                    MinAggregationBuilder.NAME, (p, c) -> ParsedMin.fromXContent(p, (String) c))
+                    .put(MaxAggregationBuilder.NAME, (p, c) -> ParsedMax.fromXContent(p, (String) c))
+                    .put(SumAggregationBuilder.NAME, (p, c) -> ParsedSum.fromXContent(p, (String) c))
+                    .put(AvgAggregationBuilder.NAME, (p, c) -> ParsedAvg.fromXContent(p, (String) c))
+                    .put(StringTerms.NAME, (p, c) -> ParsedStringTerms.fromXContent(p, (String) c))
+                    .put(LongTerms.NAME, (p, c) -> ParsedLongTerms.fromXContent(p, (String) c))
+                    .put(DoubleTerms.NAME, (p, c) -> ParsedDoubleTerms.fromXContent(p, (String) c))
+                    .put(ValueCountAggregationBuilder.NAME, (p, c) -> ParsedValueCount.fromXContent(p, (String) c))
+                    .put(PercentilesBucketPipelineAggregationBuilder.NAME,
+                         (p, c) -> ParsedPercentilesBucket.fromXContent(p, (String) c))
+                    .put(DateHistogramAggregationBuilder.NAME, (p, c) -> ParsedDateHistogram.fromXContent(p, (String) c))
+                    .build()
+                    .entrySet()
+                    .stream()
+                    .map(entry -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(entry.getKey()),
+                                                                  entry.getValue()))
+                    .collect(Collectors.toList());
+    private final static NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(entryList);
+    private final static XContent xContent = XContentFactory.xContent(XContentType.JSON);
+
+    /**
+     * Populate {@link Aggregations} from JSON string.
+     * @param json json string
+     * @return {@link Aggregations}
+     */
+    public static Aggregations fromJson(String json) {
+        try {
+            XContentParser xContentParser =
+                    xContent.createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, json);
+            xContentParser.nextToken();
+            return Aggregations.fromXContent(xContentParser);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
## Problem Statement
Support expression over aggregation function is an important feature has been request a lot by customer. The current SQL engine try to translate all the expression to painless script if possible which limit the implementation. This PR works on add the post processing logic into the current framework for aggregation query which is the first step to enable the expression over aggregation function support.
## Change Notes
1. Construct the QueryPlan for aggregation query if possible.
2. Add the SQLExpr to PhysicalOperator convert.
3. Add the ExprValue and Expression(SUM, SUB, LOG)
4. Change the JDBC and CSF Formatter.
## Integration Test changes
1. CsvFormatResponseIT, fix the incorrect column assertion
2. PrettyFormatResponseIT, fix the incorrect column assertion
3. SQLFunctionsIT, fix the incorrect column assertion
## Todo
The next PR will address the following pieces
1. More Expression support
2. Integration Test cases for expression over aggregation function
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
