### PR TITLE
Sql integ test external cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,10 @@ version = "${opendistroVersion}.0"
 
 apply plugin: 'elasticsearch.esplugin'
 apply plugin: 'jacoco'
-apply from: 'build-tools/sqlplugin-coverage.gradle'
+//apply from: 'build-tools/sqlplugin-coverage.gradle'
+if (!System.properties.containsKey('tests.rest.cluster') && !System.properties.containsKey('tests.cluster')){
+    apply from: 'build-tools/sqlplugin-coverage.gradle'
+}
 apply plugin: 'antlr'
 
 jacoco {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/ESActionFactory.java
@@ -44,6 +44,7 @@ import com.amazon.opendistroforelasticsearch.sql.query.multi.MultiQuerySelect;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.RewriteRuleExecutor;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.identifier.UnquoteIdentifierRule;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.alias.TableAliasPrefixRemoveRule;
+import com.amazon.opendistroforelasticsearch.sql.rewriter.indextype.IndexTypeRemoveRule;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.join.JoinRewriteRule;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.matchtoterm.TermFieldRewriter;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.matchtoterm.TermFieldRewriter.TermRewriterFilter;
@@ -82,6 +83,7 @@ public class ESActionFactory {
 
                 RewriteRuleExecutor<SQLQueryExpr> ruleExecutor = RewriteRuleExecutor.builder()
                         .withRule(new SQLExprParentSetterRule())
+                        .withRule(new IndexTypeRemoveRule())
                         .withRule(new OrdinalRewriterRule(sql))
                         .withRule(new UnquoteIdentifierRule())
                         .withRule(new TableAliasPrefixRemoveRule())

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/indextype/IndexTypeRemoveRule.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/indextype/IndexTypeRemoveRule.java
@@ -1,0 +1,68 @@
+package com.amazon.opendistroforelasticsearch.sql.rewriter.indextype;
+
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
+import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlASTVisitorAdapter;
+import com.amazon.opendistroforelasticsearch.sql.rewriter.RewriteRule;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Stack;
+
+/**
+ * Ignore and remove index type name.
+ */
+public class IndexTypeRemoveRule extends MySqlASTVisitorAdapter implements RewriteRule<SQLQueryExpr> {
+
+    private Map<SQLIdentifierExpr, SQLExprTableSource> indexAndTypeNameExpr = new HashMap<>();
+
+    private Stack<SQLExprTableSource> ancestors = new Stack<>();
+
+    @Override
+    public boolean match(SQLQueryExpr expr) {
+        expr.accept(this);
+        return !indexAndTypeNameExpr.isEmpty();
+    }
+
+    @Override
+    public void rewrite(SQLQueryExpr expr) {
+        indexAndTypeNameExpr.forEach((indexNameExpr, parentExpr) -> parentExpr.setExpr(indexNameExpr));
+    }
+
+    @Override
+    public boolean visit(SQLExprTableSource expr) {
+        ancestors.add(expr);
+        return super.visit(expr);
+    }
+
+    @Override
+    public void endVisit(SQLExprTableSource expr) {
+        if (ancestors.isEmpty()) {
+            throw new IllegalStateException("Cannot pop lowest ancestor from stack because it is empty");
+        }
+        ancestors.pop();
+    }
+
+    @Override
+    public boolean visit(SQLBinaryOpExpr expr) {
+        // Make sure we only touch slash (divide) in FROM, ex. cases like SELECT, WHERE, FROM(SELECT...)
+        // Rather than the real division in other places.
+        if (isInFromClause() && isIdentifierSlashIdentifier(expr)) {
+            indexAndTypeNameExpr.put((SQLIdentifierExpr) expr.getLeft(), ancestors.peek());
+        }
+        return false;
+    }
+
+    private boolean isInFromClause() {
+        return !ancestors.isEmpty();
+    }
+
+    private boolean isIdentifierSlashIdentifier(SQLBinaryOpExpr expr) {
+        return expr.getOperator() == SQLBinaryOperator.Divide
+            && expr.getLeft() instanceof SQLIdentifierExpr
+            && expr.getRight() instanceof SQLIdentifierExpr;
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
@@ -16,8 +16,6 @@
 package com.amazon.opendistroforelasticsearch.sql.esintgtest;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
-import org.elasticsearch.client.AdminClient;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -76,16 +74,12 @@ public abstract class SQLIntegTestCase extends ESIntegTestCase {
     protected void init() throws Exception {}
 
     protected void loadIndex(Index index) throws Exception {
-        AdminClient adminClient = this.admin();
-        Client esClient = ESIntegTestCase.client();
-
         String name = index.getName();
-        String type = index.getType();
         String mapping = index.getMapping();
         String dataSet = index.getDataSet();
 
-        TestUtils.createTestIndex(adminClient, name, type, mapping);
-        TestUtils.loadBulk(esClient, dataSet, name);
+        TestUtils.createIndexByRestClient(getRestClient(), name, mapping);
+        TestUtils.loadDataByRestClient(getRestClient(), name, dataSet);
         ensureGreen(name);
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -85,7 +85,7 @@ public class TestUtils {
         List<String> lines = Files.readAllLines(path);
 
         Request request = new Request("POST", "/" + indexName + "/_bulk");
-        request.setJsonEntity(readStringWithTypeNameRemoved(lines));
+        request.setJsonEntity(readWithTypeNameRemoved(lines));
         performRequest(client, request);
     }
 
@@ -111,25 +111,16 @@ public class TestUtils {
      * @param lines         lines in test data set file
      * @return              bulk request json without _type field in action line
      */
-    public static String readStringWithTypeNameRemoved(List<String> lines) {
+    public static String readWithTypeNameRemoved(List<String> lines) {
         StringBuilder bulkRequest = new StringBuilder();
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i);
-            if (i % 2 == 0 && i < lines.size() - 1) { // action line and not last blank line
-                JSONObject actionJson = null;
-                try {
-                    actionJson = new JSONObject(line);
-                } catch (Exception e) {
-                    throw new IllegalStateException("Illegal action line: " + line, e);
-                }
+            if (i % 2 == 0 && i < lines.size() - 1) { // action line and not the last blank line
+                JSONObject actionJson = new JSONObject(line);
                 JSONObject index = (JSONObject) actionJson.get("index");
                 index.remove("_type");
 
-                //if (index.isEmpty()) {
-                //    bulkRequest.append("{}").append('\n');
-                //} else {
-                    bulkRequest.append(actionJson.toString()).append('\n');
-                //}
+                bulkRequest.append(actionJson.toString()).append('\n');
             } else { // source line
                 bulkRequest.append(line).append('\n');
             }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/rewriter/indextype/IndexTypeRemoveRuleTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/rewriter/indextype/IndexTypeRemoveRuleTest.java
@@ -1,0 +1,23 @@
+package com.amazon.opendistroforelasticsearch.sql.rewriter.indextype;
+
+import com.alibaba.druid.sql.SQLUtils;
+import com.alibaba.druid.sql.ast.expr.SQLQueryExpr;
+import com.amazon.opendistroforelasticsearch.sql.util.SqlParserUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IndexTypeRemoveRuleTest {
+
+    private IndexTypeRemoveRule rule = new IndexTypeRemoveRule();
+
+    @Test
+    public void indexNameSlashTypeNameInFromClauseShouldKeepOnlyIndexName() {
+        SQLQueryExpr actual = SqlParserUtils.parse("SELECT * FROM accounts/test");
+        Assert.assertTrue(rule.match(actual));
+        rule.rewrite(actual);
+
+        String expected = SQLUtils.toMySqlString(SqlParserUtils.parse("SELECT * FROM accounts"));
+        Assert.assertEquals(expected, SQLUtils.toMySqlString(actual));
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/TestUtilsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/TestUtilsTest.java
@@ -1,0 +1,47 @@
+package com.amazon.opendistroforelasticsearch.sql.unittest;
+
+import com.amazon.opendistroforelasticsearch.sql.esintgtest.TestUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link TestUtils}
+ */
+public class TestUtilsTest {
+
+    @Test
+    public void typeNameInTestDataSetFileShouldBeRemoved() {
+        List<String> lines = Arrays.asList(
+            "{\"index\":{\"_type\": \"test\"}}",
+            "{\"name\": \"John\"}",
+            ""
+        );
+
+        String actual = TestUtils.readStringWithTypeNameRemoved(lines);
+        String expected = "{\"index\":{}}\n" +
+                          "{\"name\": \"John\"}\n" +
+                          "\n";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void otherFieldsThanTypeInTestDataSetFileShouldBeUntouched() {
+        List<String> lines = Arrays.asList(
+            "{\"index\":{\"_type\": \"test\", \"_id\": 1}}",
+            "{\"name\": \"John\"}",
+            ""
+        );
+
+        String actual = TestUtils.readStringWithTypeNameRemoved(lines);
+        String expected = "{\"index\":{\"_id\":1}}\n" + // no space after org.json format
+                          "{\"name\": \"John\"}\n" +
+                          "\n";
+        assertEquals(expected, actual);
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/TestUtilsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/TestUtilsTest.java
@@ -3,7 +3,6 @@ package com.amazon.opendistroforelasticsearch.sql.unittest;
 import com.amazon.opendistroforelasticsearch.sql.esintgtest.TestUtils;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -22,7 +21,7 @@ public class TestUtilsTest {
             ""
         );
 
-        String actual = TestUtils.readStringWithTypeNameRemoved(lines);
+        String actual = TestUtils.readWithTypeNameRemoved(lines);
         String expected = "{\"index\":{}}\n" +
                           "{\"name\": \"John\"}\n" +
                           "\n";
@@ -37,7 +36,7 @@ public class TestUtilsTest {
             ""
         );
 
-        String actual = TestUtils.readStringWithTypeNameRemoved(lines);
+        String actual = TestUtils.readWithTypeNameRemoved(lines);
         String expected = "{\"index\":{\"_id\":1}}\n" + // no space after org.json format
                           "{\"name\": \"John\"}\n" +
                           "\n";


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/353

*Description of changes:* This is a temporary PR for issue #353 investigation. With the PR changes, there were still many test cases that needed to look into. The changes I made in this PR include:

 1. I used command `./gradlew integTestRunner -Dtests.cluster=127.0.0.1:9300 -Dtests.rest.cluster=127.0.0.1:9200` because I felt `-Dtests.cluster` was referring to transport address.
2. Create test index mapping and load test data by REST client.
3. Added a rewriter as track to remove type name because it seems that internal ES cluster didn't complain type name in PUT mapping and bulk load but external ES cluster did. However, because this trick was tried out and unable to fix all broken ITs, we need to find the root cause.

```
641 tests completed, 109 failed, 35 skipped

Tests with failures:
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.CsvFormatResponseIT.includeIdAndTypeButNoScore
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.CsvFormatResponseIT.joinSearchResultNotNestedNotFlatNoAggs
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.CsvFormatResponseIT.includeTypeAndNotScore
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.CsvFormatResponseIT.includeScoreAndType
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusCMinusTNonExistentFieldOneFieldWithScrollingAndOptimization
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusCMinusDTwoFieldsAliasOnBothTables
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusCMinusDTwoFieldsNoAlias
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusAMinusBNoAliasWithScrolling
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusAMinusBNoAlias
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusCMinusTNonExistentOneFieldWithScrolling
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusAMinusBNoAliasWithScrollingAndTerms
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusCMinusTNonExistentFieldTwoFields
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.unionAllSameRequestOnlyOneRecordTwice
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusCMinusTNonExistentFieldOneField
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusCMinusDTwoFieldsAliasOnBothSecondTableFields
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusCMinusDTwoFieldsNoAliasWithScrolling
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MultiQueryIT.minusCMinusDTwoFieldsAliasOnBothTablesWithScrolling
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.SubqueryIT.testINWithInnerWhere
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.SubqueryIT.testIN
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.SubqueryIT.testINSelectAll
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.SubqueryIT.testINWithAlias
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MathFunctionsIT.logWithTwoParams
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MathFunctionsIT.atan2
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JdbcTestIT.stringOperatorNameCaseInsensitiveTest
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JdbcTestIT.numberOperatorNameCaseInsensitiveTest
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JdbcTestIT.trigFunctionNameCaseInsensitiveTest
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JdbcTestIT.dateFunctionNameCaseInsensitiveTest
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.GetEndpointQueryIT.unicodeTermInQuery
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.OrderIT.orderByScore
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.OrderIT.orderByIsNull
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.OrderIT.orderByIsNotNull
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HavingIT.notIn
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HavingIT.between
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HavingIT.notEqualsTo
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HavingIT.notBetween
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HavingIT.not
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HavingIT.lessThanOrEqual
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HavingIT.in
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HavingIT.or
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HavingIT.and
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HavingIT.equalsTo
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HavingIT.notAndOr
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinNoConditionButWithWhereHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.hintLimits_firstLimitSecondNullNL
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinWithAllFromSecondTableHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.leftJoinWithAllFromSecondTableHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinNoConditionAndNoWhereHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.hintLimits_firstLimitSecondLimitHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinWithAllAliasOnReturnHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinNoConditionAndNoWhereNL
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinWithSomeAliasOnReturnHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.hintLimits_firstLimitSecondNullHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.leftJoinNLWithNullInCondition2
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.leftJoinNLWithNullInCondition3
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinWithNoWhereButWithConditionHash
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.testLeftJoinHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.leftJoinNLWithNullInCondition1
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinWithStarHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.leftJoinNLWithNullInCondition
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinWithOrderbyFirstTableHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.hintLimits_firstNullSecondLimitNL
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinWithNestedFieldsOnComparisonAndOnReturnHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.testLeftJoinWithLimitHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinNoConditionButWithWhereNL
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.hintLimits_firstLimitSecondLimitNL
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.hintLimits_firstNullSecondLimitHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinWithAllFromFirstTableHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinWithNestedFieldsOnReturnHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinNoConditionAndNoWhereWithTotalLimitHASH
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.leftJoinWithAllFromSecondTableNL
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.testLeftJoinNL
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.hintMultiSearchCanRunFewTimesNL
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.joinNoConditionAndNoWhereWithTotalLimitNL
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.JoinIT.testLeftJoinWithLimitNL
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.PrettyFormatResponseIT.selectAllFromNestedWithMultipleFieldsInFrom
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.PrettyFormatResponseIT.selectAllFromNestedWithFieldInFrom
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.PrettyFormatResponseIT.selectAllNestedFromNestedWithFieldInFrom
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.PrettyFormatResponseIT.selectNestedFields
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.DateFormatIT.sortByAliasedDateFormat
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.DateFormatIT.sortByDateFormat
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.NestedFieldQueryIT.havingCountAggOnNestedInnerFieldWithoutWhere
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.NestedFieldQueryIT.havingCountAggWithWhereOnNested
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.NestedFieldQueryIT.countAggWithWhereOnParent
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.NestedFieldQueryIT.havingCountAggWithoutWhere
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.NestedFieldQueryIT.leftJoinSelectAll
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.NestedFieldQueryIT.havingCountAggWithWhereOnParentOrNested
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.NestedFieldQueryIT.countAggWithWhereOnParentOrNested
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.PreparedStatementIT.testPreparedStatement
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.HashJoinIT.innerJoin
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.PluginIT.sqlEnableSettingsTest
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.PluginIT.classMethod
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.SQLFunctionsIT.functionFieldAliasAndGroupByAlias
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.SQLFunctionsIT.caseChangeTest
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.SQLFunctionsIT.literalWithAlias
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.SQLFunctionsIT.isnullWithNullInputTest
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.SQLFunctionsIT.ascii
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.SQLFunctionsIT.castIntFieldToFloatWithAliasJdbcFormatGroupByTest
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.SQLFunctionsIT.classMethod
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.DateFunctionsIT.classMethod
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.ShowIT.classMethod
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.PrettyFormatterIT.classMethod
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.AggregationIT.reverseToRootGroupByOnNestedFieldWithFilterTestWithReverseNestedNoPath
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.AggregationIT.reverseToRootGroupByOnNestedFieldWithFilterAndSumOnReverseNestedField
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.AggregationIT.reverseToRootGroupByOnNestedFieldWithFilterTestWithReverseNestedAndEmptyPath
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.AggregationIT.classMethod
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.MethodQueryIT.classMethod
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.DeleteIT.deleteWithConditionTest
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.DeleteIT.deleteAllTest
 - com.amazon.opendistroforelasticsearch.sql.esintgtest.DeleteIT.classMethod
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
