### PR TITLE
Update the opendistro sql 1.4.0 release notes

### DIFF
--- a/opendistro-elasticsearch-sql.release-notes.md
+++ b/opendistro-elasticsearch-sql.release-notes.md
@@ -52,7 +52,7 @@
 * Enhancement [#254](https://github.com/opendistro-for-elasticsearch/sql/issues/254): Support SELECT <number_literal>
 * Enhancement [#251](https://github.com/opendistro-for-elasticsearch/sql/pull/251): Support number operators: POWER, ATAN2, COT, SIGN/SIGNUM
 * Enhancement [#215](https://github.com/opendistro-for-elasticsearch/sql/issues215): Support ordinal in GROUP/ORDER BY clause
-* Enhancement [#213](https://github.com/opendistro-for-elasticsearch/sql/issues/213): Support <table>.<column> syntax
+* Enhancement [#213](https://github.com/opendistro-for-elasticsearch/sql/issues/213): Support `<table>.<column>` syntax
 * Enhancement [#212](https://github.com/opendistro-for-elasticsearch/sql/issues/212): Support Quoted identifiers
 * Enhancement [#199](https://github.com/opendistro-for-elasticsearch/sql/issues/199): Support NOT operator with nested field query
 * Enhancement [#166](https://github.com/opendistro-for-elasticsearch/sql/issues/166): Support pretty option for explain request

--- a/opendistro-elasticsearch-sql.release-notes.md
+++ b/opendistro-elasticsearch-sql.release-notes.md
@@ -5,7 +5,7 @@
 * Feature [#312](https://github.com/opendistro-for-elasticsearch/sql/issues/312): Elasticsearch 7.4.2 compatibility 
 
 #### Testing
-* Feature ([#335](https://github.com/opendistro-for-elasticsearch/sql/pull/335), [#343](https://github.com/opendistro-for-elasticsearch/sql/pull/343)): Sql test bench bug fix, improvement and more test cases (issues: [#335](https://github.com/opendistro-for-elasticsearch/sql/issues/335), [#339]((https://github.com/opendistro-for-elasticsearch/sql/issues/339)))
+* Feature ([#335](https://github.com/opendistro-for-elasticsearch/sql/pull/335), [#343](https://github.com/opendistro-for-elasticsearch/sql/pull/343)): Sql test bench bug fix, improvement and more test cases (issues: [#335](https://github.com/opendistro-for-elasticsearch/sql/issues/335), [#339](https://github.com/opendistro-for-elasticsearch/sql/issues/339))
 
 #### Documentation
 * Feature ([#302](https://github.com/opendistro-for-elasticsearch/sql/pull/302), [#305](https://github.com/opendistro-for-elasticsearch/sql/pull/305), [#303](https://github.com/opendistro-for-elasticsearch/sql/pull/303)): Documentation for basic usage of plugin & improvement of contributing docs (issues: [#293](https://github.com/opendistro-for-elasticsearch/sql/issues/293), [#243](https://github.com/opendistro-for-elasticsearch/sql/issues/243))

--- a/opendistro-elasticsearch-sql.release-notes.md
+++ b/opendistro-elasticsearch-sql.release-notes.md
@@ -1,37 +1,43 @@
 ## 2020-1-24, Version 1.4.0 (Current)
 
-### Notable changes
+### Features
+#### Elasticsearch Compatibility
+* Feature [#312](https://github.com/opendistro-for-elasticsearch/sql/issues/312): Elasticsearch 7.4.2 compatibility 
 
-* Feature [#283](https://github.com/opendistro-for-elasticsearch/sql/pull/283): Added github action to build and run tests
-* Feature [#302](https://github.com/opendistro-for-elasticsearch/sql/pull/302): Documentation for basic usage of plugin
-* Feature [#312](https://github.com/opendistro-for-elasticsearch/sql/issues/312): OD 1.4 Release components
-* Feature [#334](https://github.com/opendistro-for-elasticsearch/sql/pull/334): Change the default response format to JDBC
-* Feature [#335](https://github.com/opendistro-for-elasticsearch/sql/pull/335): Sql test bench
+#### Testing
+* Feature ([#335](https://github.com/opendistro-for-elasticsearch/sql/pull/335), [#343](https://github.com/opendistro-for-elasticsearch/sql/pull/343)): Sql test bench bug fix, improvement and more test cases (issues: [#335](https://github.com/opendistro-for-elasticsearch/sql/issues/335), [#339]((https://github.com/opendistro-for-elasticsearch/sql/issues/339)))
 
-* Enhancement [#273](https://github.com/opendistro-for-elasticsearch/sql/pull/273): Support conditional functions: IF, IFNULL, ISNULL
-* Enhancement [#274](https://github.com/opendistro-for-elasticsearch/sql/pull/274): Support JOIN without table alias
-* Enhancement [#278](https://github.com/opendistro-for-elasticsearch/sql/pull/278): Support subquery in from with parent only has select
-* Enhancement [#282](https://github.com/opendistro-for-elasticsearch/sql/pull/282): Support datetime functions: MONTH, DAYOFMONTH, DATE, MONTHNAME, TIMESTAMP, MAKETIME, NOW, CURDATE
-* Enhancement [#286](https://github.com/opendistro-for-elasticsearch/sql/pull/286): Better error reporting for unsupported case like max(x) - min(y)
-* Enhancement [#287](https://github.com/opendistro-for-elasticsearch/sql/pull/287): Gradle build will publish compiled plugin, that is ready to install into elastic
-* Enhancement [#300](https://github.com/opendistro-for-elasticsearch/sql/pull/300): Support DISTINCT feature in SELECT clause
-* Enhancement [#303](https://github.com/opendistro-for-elasticsearch/sql/pull/303): Attributions
-* Enhancement [#305](https://github.com/opendistro-for-elasticsearch/sql/pull/305): Improve contributing docs
-* Enhancement [#340](https://github.com/opendistro-for-elasticsearch/sql/pull/340): Fix the issue in semantic analyzer
-* Enhancement [#343](https://github.com/opendistro-for-elasticsearch/sql/pull/343): Sql test bench bug fix, improvement and more test cases
-* Enhancement [#345](https://github.com/opendistro-for-elasticsearch/sql/pull/345): Syntax and semantic exceptions handling for unsupported features
-* Enhancement [#346](https://github.com/opendistro-for-elasticsearch/sql/pull/346): Add post processing logic for aggregation query
-* Enhancement [#352](https://github.com/opendistro-for-elasticsearch/sql/pull/352): Add the expression support post processing
+#### Documentation
+* Feature ([#302](https://github.com/opendistro-for-elasticsearch/sql/pull/302), [#305](https://github.com/opendistro-for-elasticsearch/sql/pull/305), [#303](https://github.com/opendistro-for-elasticsearch/sql/pull/303)): Documentation for basic usage of plugin & improvement of contributing docs (issues: [#293](https://github.com/opendistro-for-elasticsearch/sql/issues/293), [#243](https://github.com/opendistro-for-elasticsearch/sql/issues/243))
 
-* BugFix [#267](https://github.com/opendistro-for-elasticsearch/sql/pull/267): Fixed operatorReplace Integration Test
-* BugFix [#275](https://github.com/opendistro-for-elasticsearch/sql/pull/275): Fix issue that IP type cannot pass JDBC formatter
-* BugFix [#284](https://github.com/opendistro-for-elasticsearch/sql/pull/284): Fixed flaky test suite, that was breaking github action build
-* BugFix [#295](https://github.com/opendistro-for-elasticsearch/sql/pull/295): Corrected the selected field names displayed in the schema of JDBC formatted response
-* BugFix [#296](https://github.com/opendistro-for-elasticsearch/sql/pull/296): Fixed functions work improperly with fieldvalue/constant param for current use
-* BugFix [#298](https://github.com/opendistro-for-elasticsearch/sql/pull/298): Fixed issue of log10 function gets inaccurate results
-* BugFix [#307](https://github.com/opendistro-for-elasticsearch/sql/pull/307): Fix the issue of column alias not working for GROUP BY
-* BugFix [#333](https://github.com/opendistro-for-elasticsearch/sql/pull/333): Fixed the issue of substring not working correctly when fieldname is put as <table>.<column>
-* BugFix [#337](https://github.com/opendistro-for-elasticsearch/sql/pull/337): Fix JDBC response for delete query
+#### Github Actions
+* Feature ([#283](https://github.com/opendistro-for-elasticsearch/sql/pull/283), [#287](https://github.com/opendistro-for-elasticsearch/sql/pull/287)): Added github action to build and run tests. Gradle build will publish compiled plugin, that is ready to install into elastic
+
+### Enhancements
+#### Lexer and Semantic
+* Enhancement [#345](https://github.com/opendistro-for-elasticsearch/sql/pull/345): Syntax and semantic exceptions handling for unsupported features (issue: [#320](https://github.com/opendistro-for-elasticsearch/sql/issues/320))
+
+#### SQL Feature
+* Enhancement ([#346](https://github.com/opendistro-for-elasticsearch/sql/pull/346), [#352](https://github.com/opendistro-for-elasticsearch/sql/pull/352)): Support function over aggregation result (issues: [#194](https://github.com/opendistro-for-elasticsearch/sql/issues/194), [#229](https://github.com/opendistro-for-elasticsearch/sql/issues/229), [#270](https://github.com/opendistro-for-elasticsearch/sql/issues/270), [#292](https://github.com/opendistro-for-elasticsearch/sql/issues/292))
+* Enhancement [#273](https://github.com/opendistro-for-elasticsearch/sql/pull/273): Support conditional functions: IF, IFNULL, ISNULL (issues: [#224](https://github.com/opendistro-for-elasticsearch/sql/issues/224), [#235](https://github.com/opendistro-for-elasticsearch/sql/issues/235)) 
+* Enhancement [#274](https://github.com/opendistro-for-elasticsearch/sql/pull/274): Support JOIN without table alias (issue: [#232](https://github.com/opendistro-for-elasticsearch/sql/issues/232))
+* Enhancement [#278](https://github.com/opendistro-for-elasticsearch/sql/pull/278): Support subquery in from with parent only has select (issue: [#230](https://github.com/opendistro-for-elasticsearch/sql/issues/230))
+* Enhancement [#282](https://github.com/opendistro-for-elasticsearch/sql/pull/282): Support datetime functions: MONTH, DAYOFMONTH, DATE, MONTHNAME, TIMESTAMP, MAKETIME, NOW, CURDATE (issue: [#235](https://github.com/opendistro-for-elasticsearch/sql/issues/235))
+* Enhancement [#300](https://github.com/opendistro-for-elasticsearch/sql/pull/300): Support DISTINCT feature in SELECT clause (issue: [#294](https://github.com/opendistro-for-elasticsearch/sql/issues/294))
+
+#### Response
+* Enhancement [#334](https://github.com/opendistro-for-elasticsearch/sql/pull/334): Change the default response format to JDBC (issue: [#159](https://github.com/opendistro-for-elasticsearch/sql/issues/159))
+
+### Bugfixes
+* BugFix [#267](https://github.com/opendistro-for-elasticsearch/sql/pull/267): Fixed operatorReplace Integration Test (issue: [#266](https://github.com/opendistro-for-elasticsearch/sql/issues/266))
+* BugFix [#275](https://github.com/opendistro-for-elasticsearch/sql/pull/275): Fix issue that IP type cannot pass JDBC formatter (issue: [#272](https://github.com/opendistro-for-elasticsearch/sql/issues/272))
+* BugFix [#284](https://github.com/opendistro-for-elasticsearch/sql/pull/284): Fixed flaky test suite, that was breaking Github action build
+* BugFix [#295](https://github.com/opendistro-for-elasticsearch/sql/pull/295): Corrected the selected field names displayed in the schema of JDBC formatted response (issue: [#290](https://github.com/opendistro-for-elasticsearch/sql/issues/290))
+* BugFix [#296](https://github.com/opendistro-for-elasticsearch/sql/pull/296): Fixed functions work improperly with fieldvalue/constant param for current use (issues: [#279](https://github.com/opendistro-for-elasticsearch/sql/issues/279), [#291](https://github.com/opendistro-for-elasticsearch/sql/issues/291), [#224](https://github.com/opendistro-for-elasticsearch/sql/issues/224))
+* BugFix [#298](https://github.com/opendistro-for-elasticsearch/sql/pull/298): Fixed issue of log10 function gets inaccurate results （issue: [#297](https://github.com/opendistro-for-elasticsearch/sql/issues/297))
+* BugFix [#307](https://github.com/opendistro-for-elasticsearch/sql/pull/307): Fix the issue of column alias not working for GROUP BY (issue: [#299](https://github.com/opendistro-for-elasticsearch/sql/issues/299))
+* BugFix [#333](https://github.com/opendistro-for-elasticsearch/sql/pull/333): Fixed the issue of substring not working correctly when fieldname is put as <table>.<column> (issue: [#330](https://github.com/opendistro-for-elasticsearch/sql/issues/330))
+* BugFix [#337](https://github.com/opendistro-for-elasticsearch/sql/pull/337): Fix JDBC response for delete query (issue: [#131](https://github.com/opendistro-for-elasticsearch/sql/issues/131))
 
 ## 2019-10-29, Version 1.3.0
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. separate the release notes to three sections: Features, Enhancements and BugFixs.
2. add the **md** suffix to the opendistro-elasticsearch-sql.release-notes file.

*test link*
https://github.com/penghuo/sql/blob/release-od-1.4.0/opendistro-elasticsearch-sql.release-notes.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
