### PR TITLE
Return Correct Type Information for Fields 

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/ScalarFunction.java
@@ -33,20 +33,20 @@ import static com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.spe
 public enum ScalarFunction implements TypeExpression {
 
     ABS(func(T(NUMBER)).to(T)), // translate to Java: <T extends Number> T ABS(T)
-    ACOS(func(T(NUMBER)).to(T)),
+    ACOS(func(T(NUMBER)).to(DOUBLE)),
     ADD(func(T(NUMBER), NUMBER).to(T)),
     ASCII(func(T(STRING)).to(INTEGER)),
-    ASIN(func(T(NUMBER)).to(T)),
-    ATAN(func(T(NUMBER)).to(T)),
-    ATAN2(func(T(NUMBER), NUMBER).to(T)),
+    ASIN(func(T(NUMBER)).to(DOUBLE)),
+    ATAN(func(T(NUMBER)).to(DOUBLE)),
+    ATAN2(func(T(NUMBER), NUMBER).to(DOUBLE)),
     CAST(),
     CBRT(func(T(NUMBER)).to(T)),
     CEIL(func(T(NUMBER)).to(T)),
     CONCAT(), // TODO: varargs support required
     CONCAT_WS(),
-    COS(func(T(NUMBER)).to(T)),
-    COSH(func(T(NUMBER)).to(T)),
-    COT(func(T(NUMBER)).to(T)),
+    COS(func(T(NUMBER)).to(DOUBLE)),
+    COSH(func(T(NUMBER)).to(DOUBLE)),
+    COT(func(T(NUMBER)).to(DOUBLE)),
     CURDATE(func().to(ESDataType.DATE)),
     DATE(func(ESDataType.DATE).to(ESDataType.DATE)),
     DATE_FORMAT(
@@ -54,7 +54,7 @@ public enum ScalarFunction implements TypeExpression {
         func(ESDataType.DATE, STRING, STRING).to(STRING)
     ),
     DAYOFMONTH(func(ESDataType.DATE).to(INTEGER)),
-    DEGREES(func(T(NUMBER)).to(T)),
+    DEGREES(func(T(NUMBER)).to(DOUBLE)),
     DIVIDE(func(T(NUMBER), NUMBER).to(T)),
     E(func().to(DOUBLE)),
     EXP(func(T(NUMBER)).to(T)),
@@ -96,7 +96,7 @@ public enum ScalarFunction implements TypeExpression {
         func(T(NUMBER)).to(T),
         func(T(NUMBER), NUMBER).to(T)
     ),
-    RADIANS(func(T(NUMBER)).to(T)),
+    RADIANS(func(T(NUMBER)).to(DOUBLE)),
     RAND(
             func().to(NUMBER),
             func(T(NUMBER)).to(T)
@@ -108,12 +108,12 @@ public enum ScalarFunction implements TypeExpression {
     RTRIM(func(T(STRING)).to(T)),
     SIGN(func(T(NUMBER)).to(T)),
     SIGNUM(func(T(NUMBER)).to(T)),
-    SIN(func(T(NUMBER)).to(T)),
-    SINH(func(T(NUMBER)).to(T)),
+    SIN(func(T(NUMBER)).to(DOUBLE)),
+    SINH(func(T(NUMBER)).to(DOUBLE)),
     SQRT(func(T(NUMBER)).to(T)),
     SUBSTRING(func(T(STRING), INTEGER, INTEGER).to(T)),
     SUBTRACT(func(T(NUMBER), NUMBER).to(T)),
-    TAN(func(T(NUMBER)).to(T)),
+    TAN(func(T(NUMBER)).to(DOUBLE)),
     TIMESTAMP(func(ESDataType.DATE).to(ESDataType.DATE)),
     TRIM(func(T(STRING)).to(T)),
     UPPER(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/Protocol.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/Protocol.java
@@ -25,7 +25,6 @@ import com.amazon.opendistroforelasticsearch.sql.executor.adapter.QueryPlanReque
 import com.amazon.opendistroforelasticsearch.sql.executor.format.DataRows.Row;
 import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema.Column;
 import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
-import com.amazon.opendistroforelasticsearch.sql.plugin.RestSqlAction;
 import com.amazon.opendistroforelasticsearch.sql.query.DefaultQueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.QueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ColumnNode;
@@ -58,7 +57,7 @@ public class Protocol {
             this.columnNodeList =
                     ((QueryPlanRequestBuilder) (((QueryPlanQueryAction) queryAction).explain())).outputColumns();
         } else if (queryAction instanceof DefaultQueryAction) {
-            scriptColumnType = RestSqlAction.performAnalysis(queryAction.getSqlRequest().getSql());
+            scriptColumnType = queryAction.getScriptColumnType();
         }
         this.formatType = formatType;
         QueryStatement query = queryAction.getQueryStatement();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/Protocol.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/Protocol.java
@@ -15,17 +15,20 @@
 
 package com.amazon.opendistroforelasticsearch.sql.executor.format;
 
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
 import com.amazon.opendistroforelasticsearch.sql.domain.Delete;
 import com.amazon.opendistroforelasticsearch.sql.domain.IndexStatement;
 import com.amazon.opendistroforelasticsearch.sql.domain.Query;
 import com.amazon.opendistroforelasticsearch.sql.domain.QueryStatement;
-import com.amazon.opendistroforelasticsearch.sql.executor.format.DataRows.Row;
-import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema.Column;
 import com.amazon.opendistroforelasticsearch.sql.executor.adapter.QueryPlanQueryAction;
 import com.amazon.opendistroforelasticsearch.sql.executor.adapter.QueryPlanRequestBuilder;
+import com.amazon.opendistroforelasticsearch.sql.executor.format.DataRows.Row;
+import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema.Column;
 import com.amazon.opendistroforelasticsearch.sql.expression.domain.BindingTuple;
-import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ColumnNode;
+import com.amazon.opendistroforelasticsearch.sql.plugin.RestSqlAction;
+import com.amazon.opendistroforelasticsearch.sql.query.DefaultQueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.QueryAction;
+import com.amazon.opendistroforelasticsearch.sql.query.planner.core.ColumnNode;
 import org.elasticsearch.client.Client;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -48,11 +51,14 @@ public class Protocol {
     private ResultSet resultSet;
     private ErrorMessage error;
     private List<ColumnNode> columnNodeList;
+    private ColumnTypeProvider scriptColumnType = new ColumnTypeProvider();
 
     public Protocol(Client client, QueryAction queryAction, Object queryResult, String formatType) {
         if (queryAction instanceof QueryPlanQueryAction) {
             this.columnNodeList =
                     ((QueryPlanRequestBuilder) (((QueryPlanQueryAction) queryAction).explain())).outputColumns();
+        } else if (queryAction instanceof DefaultQueryAction) {
+            scriptColumnType = RestSqlAction.performAnalysis(queryAction.getSqlRequest().getSql());
         }
         this.formatType = formatType;
         QueryStatement query = queryAction.getQueryStatement();
@@ -75,7 +81,7 @@ public class Protocol {
         if (queryStatement instanceof Delete) {
             return new DeleteResultSet(client, (Delete) queryStatement, queryResult);
         } else if (queryStatement instanceof Query) {
-            return new SelectResultSet(client, (Query) queryStatement, queryResult);
+            return new SelectResultSet(client, (Query) queryStatement, queryResult, scriptColumnType);
         } else if (queryStatement instanceof IndexStatement) {
             IndexStatement statement = (IndexStatement) queryStatement;
             StatementType statementType = statement.getStatementType();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -66,19 +66,19 @@ public class SelectResultSet extends ResultSet {
     private String indexName;
     private String typeName;
     private List<Schema.Column> columns = new ArrayList<>();
-    private ColumnTypeProvider scriptColumnType;
+    private ColumnTypeProvider outputColumnType;
 
     private List<String> head;
     private long size;
     private long totalHits;
     private List<DataRows.Row> rows;
 
-    public SelectResultSet(Client client, Query query, Object queryResult, ColumnTypeProvider scriptColumnType) {
+    public SelectResultSet(Client client, Query query, Object queryResult, ColumnTypeProvider outputColumnType) {
         this.client = client;
         this.query = query;
         this.queryResult = queryResult;
         this.selectAll = false;
-        this.scriptColumnType = scriptColumnType;
+        this.outputColumnType = outputColumnType;
 
         if (isJoinQuery()) {
             JoinSelect joinQuery = (JoinSelect) query;
@@ -328,7 +328,8 @@ public class SelectResultSet extends ResultSet {
                 if (field.getExpression() instanceof SQLCaseExpr) {
                     return Schema.Type.TEXT;
                 }
-                return SQLFunctions.getScriptFunctionReturnType(fieldIndex, field, scriptColumnType);
+                Schema.Type resolvedType = outputColumnType.get(fieldIndex);
+                return SQLFunctions.getScriptFunctionReturnType(field, resolvedType);
             }
             default:
                 throw new UnsupportedOperationException(
@@ -377,7 +378,6 @@ public class SelectResultSet extends ResultSet {
              * name instead.
              */
             if (fieldMap.get(fieldName) instanceof MethodField) {
-
                 MethodField methodField = (MethodField) fieldMap.get(fieldName);
                 int fieldIndex = fieldNameList.indexOf(fieldName);
                 columns.add(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -311,7 +311,7 @@ public class SelectResultSet extends ResultSet {
         }
     }
 
-    private Schema.Type fetchMethodReturnType(Field field) {
+    private Schema.Type fetchMethodReturnType(int fieldIndex, Field field) {
         switch (field.getName().toLowerCase()) {
             case "count":
                 return Schema.Type.LONG;
@@ -328,7 +328,7 @@ public class SelectResultSet extends ResultSet {
                 if (field.getExpression() instanceof SQLCaseExpr) {
                     return Schema.Type.TEXT;
                 }
-                 return SQLFunctions.getScriptFunctionReturnType(field, scriptColumnType);
+                 return SQLFunctions.getScriptFunctionReturnType(fieldIndex, field, scriptColumnType);
             }
             default:
                 throw new UnsupportedOperationException(
@@ -379,11 +379,12 @@ public class SelectResultSet extends ResultSet {
             if (fieldMap.get(fieldName) instanceof MethodField) {
 
                 Field methodField = fieldMap.get(fieldName);
+                int fieldIndex = fieldNameList.indexOf(fieldName);
                 columns.add(
                         new Schema.Column(
                                 methodField.getAlias(),
                                 null,
-                                fetchMethodReturnType(methodField)
+                                fetchMethodReturnType(fieldIndex, methodField)
                         )
                 );
             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/SelectResultSet.java
@@ -311,7 +311,7 @@ public class SelectResultSet extends ResultSet {
         }
     }
 
-    private Schema.Type fetchMethodReturnType(int fieldIndex, Field field) {
+    private Schema.Type fetchMethodReturnType(int fieldIndex, MethodField field) {
         switch (field.getName().toLowerCase()) {
             case "count":
                 return Schema.Type.LONG;
@@ -328,7 +328,7 @@ public class SelectResultSet extends ResultSet {
                 if (field.getExpression() instanceof SQLCaseExpr) {
                     return Schema.Type.TEXT;
                 }
-                 return SQLFunctions.getScriptFunctionReturnType(fieldIndex, field, scriptColumnType);
+                return SQLFunctions.getScriptFunctionReturnType(fieldIndex, field, scriptColumnType);
             }
             default:
                 throw new UnsupportedOperationException(
@@ -378,7 +378,7 @@ public class SelectResultSet extends ResultSet {
              */
             if (fieldMap.get(fieldName) instanceof MethodField) {
 
-                Field methodField = fieldMap.get(fieldName);
+                MethodField methodField = (MethodField) fieldMap.get(fieldName);
                 int fieldIndex = fieldNameList.indexOf(fieldName);
                 columns.add(
                         new Schema.Column(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
@@ -210,7 +210,7 @@ public class RestSqlAction extends BaseRestHandler {
         return allowExplicitIndex && isSqlEnabled;
     }
 
-    public static ColumnTypeProvider performAnalysis(String sql) {
+    private static ColumnTypeProvider performAnalysis(String sql) {
         LocalClusterState clusterState = LocalClusterState.state();
         SqlAnalysisConfig config = new SqlAnalysisConfig(
             clusterState.getSettingValue(QUERY_ANALYSIS_ENABLED),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
@@ -117,7 +117,6 @@ public class RestSqlAction extends BaseRestHandler {
             LOG.info("[{}] Incoming request {}: {}", LogUtils.getRequestId(), request.uri(), sqlRequest.getSql());
 
             final QueryAction queryAction =
-
                     explainRequest(client, sqlRequest, SqlRequestParam.getFormat(request.params()));
             return channel -> executeSqlRequest(request, queryAction, client, channel);
         } catch (Exception e) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
@@ -150,6 +150,7 @@ public class RestSqlAction extends BaseRestHandler {
         final QueryAction queryAction = new SearchDao(client)
                 .explain(new QueryActionRequest(sqlRequest.getSql(), typeProvider, format));
         queryAction.setSqlRequest(sqlRequest);
+        queryAction.setColumnTypeProvider(typeProvider);
         return queryAction;
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/RestSqlAction.java
@@ -117,6 +117,7 @@ public class RestSqlAction extends BaseRestHandler {
             LOG.info("[{}] Incoming request {}: {}", LogUtils.getRequestId(), request.uri(), sqlRequest.getSql());
 
             final QueryAction queryAction =
+
                     explainRequest(client, sqlRequest, SqlRequestParam.getFormat(request.params()));
             return channel -> executeSqlRequest(request, queryAction, client, channel);
         } catch (Exception e) {
@@ -209,7 +210,7 @@ public class RestSqlAction extends BaseRestHandler {
         return allowExplicitIndex && isSqlEnabled;
     }
 
-    private static ColumnTypeProvider performAnalysis(String sql) {
+    public static ColumnTypeProvider performAnalysis(String sql) {
         LocalClusterState clusterState = LocalClusterState.state();
         SqlAnalysisConfig config = new SqlAnalysisConfig(
             clusterState.getSettingValue(QUERY_ANALYSIS_ENABLED),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
@@ -19,7 +19,6 @@ import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
 import com.alibaba.druid.sql.ast.expr.SQLCastExpr;
-import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
 import com.amazon.opendistroforelasticsearch.sql.domain.Field;
 import com.amazon.opendistroforelasticsearch.sql.domain.KVValue;
 import com.amazon.opendistroforelasticsearch.sql.domain.MethodField;
@@ -30,7 +29,6 @@ import com.amazon.opendistroforelasticsearch.sql.domain.hints.Hint;
 import com.amazon.opendistroforelasticsearch.sql.domain.hints.HintType;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema;
-import com.amazon.opendistroforelasticsearch.sql.plugin.RestSqlAction;
 import com.amazon.opendistroforelasticsearch.sql.query.maker.QueryMaker;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.nestedfield.NestedFieldProjection;
 import com.amazon.opendistroforelasticsearch.sql.utils.SQLFunctions;
@@ -269,10 +267,7 @@ public class DefaultQueryAction extends QueryAction {
 
     private ScriptSortType getScriptSortType(Order order) {
         ScriptSortType scriptSortType;
-        Schema.Type scriptFunctionReturnType;
-        ColumnTypeProvider scriptColumnType = RestSqlAction.performAnalysis(this.sqlRequest.getSql());
-        scriptFunctionReturnType = SQLFunctions.getScriptFunctionReturnType(
-                order.getSortField(), scriptColumnType);
+        Schema.Type scriptFunctionReturnType = SQLFunctions.getOrderByFieldType(order.getSortField());
 
 
         // as of now script function return type returns only text and double

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/DefaultQueryAction.java
@@ -19,6 +19,7 @@ import com.alibaba.druid.sql.ast.SQLExpr;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOpExpr;
 import com.alibaba.druid.sql.ast.expr.SQLBinaryOperator;
 import com.alibaba.druid.sql.ast.expr.SQLCastExpr;
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
 import com.amazon.opendistroforelasticsearch.sql.domain.Field;
 import com.amazon.opendistroforelasticsearch.sql.domain.KVValue;
 import com.amazon.opendistroforelasticsearch.sql.domain.MethodField;
@@ -29,6 +30,7 @@ import com.amazon.opendistroforelasticsearch.sql.domain.hints.Hint;
 import com.amazon.opendistroforelasticsearch.sql.domain.hints.HintType;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema;
+import com.amazon.opendistroforelasticsearch.sql.plugin.RestSqlAction;
 import com.amazon.opendistroforelasticsearch.sql.query.maker.QueryMaker;
 import com.amazon.opendistroforelasticsearch.sql.rewriter.nestedfield.NestedFieldProjection;
 import com.amazon.opendistroforelasticsearch.sql.utils.SQLFunctions;
@@ -268,12 +270,9 @@ public class DefaultQueryAction extends QueryAction {
     private ScriptSortType getScriptSortType(Order order) {
         ScriptSortType scriptSortType;
         Schema.Type scriptFunctionReturnType;
-        if (order.getSortField().getExpression() instanceof SQLCastExpr) {
-            scriptFunctionReturnType = SQLFunctions.getCastFunctionReturnType(
-                    ((SQLCastExpr) order.getSortField().getExpression()).getDataType().getName());
-        } else {
-            scriptFunctionReturnType = SQLFunctions.getScriptFunctionReturnType(order.getSortField());
-        }
+        ColumnTypeProvider scriptColumnType = RestSqlAction.performAnalysis(this.sqlRequest.getSql());
+        scriptFunctionReturnType = SQLFunctions.getScriptFunctionReturnType(
+                order.getSortField(), scriptColumnType);
 
 
         // as of now script function return type returns only text and double

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/QueryAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/query/QueryAction.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.query;
 
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
 import com.amazon.opendistroforelasticsearch.sql.domain.Query;
 import com.amazon.opendistroforelasticsearch.sql.domain.QueryStatement;
 import com.amazon.opendistroforelasticsearch.sql.domain.Select;
@@ -48,6 +49,7 @@ public abstract class QueryAction {
     protected Query query;
     protected Client client;
     protected SqlRequest sqlRequest = SqlRequest.NULL;
+    protected ColumnTypeProvider scriptColumnType;
 
     public QueryAction(Client client, Query query) {
         this.client = client;
@@ -66,8 +68,16 @@ public abstract class QueryAction {
         this.sqlRequest = sqlRequest;
     }
 
+    public void setColumnTypeProvider(ColumnTypeProvider scriptColumnType) {
+        this.scriptColumnType = scriptColumnType;
+    }
+
     public SqlRequest getSqlRequest() {
         return sqlRequest;
+    }
+
+    public ColumnTypeProvider getScriptColumnType() {
+        return scriptColumnType;
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -26,7 +26,6 @@ import com.alibaba.druid.sql.ast.expr.SQLNumericLiteralExpr;
 import com.alibaba.druid.sql.ast.expr.SQLPropertyExpr;
 import com.alibaba.druid.sql.ast.expr.SQLTextLiteralExpr;
 import com.alibaba.druid.sql.ast.expr.SQLVariantRefExpr;
-import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
 import com.amazon.opendistroforelasticsearch.sql.domain.Field;
 import com.amazon.opendistroforelasticsearch.sql.domain.KVValue;
 import com.amazon.opendistroforelasticsearch.sql.domain.MethodField;
@@ -974,25 +973,14 @@ public class SQLFunctions {
      * approach will return type of result column as DOUBLE, although there is enough information to understand that
      * it might be safely treated as INTEGER.
      */
-    public static Schema.Type getScriptFunctionReturnType(
-            int fieldIndex, MethodField field, ColumnTypeProvider scriptColumnType) {
+    public static Schema.Type getScriptFunctionReturnType(MethodField field, Schema.Type resolvedType) {
         Schema.Type returnType;
         String functionName = ((ScriptMethodField) field).getFunctionName().toLowerCase();
-        if (!numberOperators.contains(functionName) && !mathConstants.contains(functionName)
-                && !trigFunctions.contains(functionName) && !stringOperators.contains(functionName)
-                && !stringFunctions.contains(functionName) && !binaryOperators.contains(functionName)
-                && !dateFunctions.contains(functionName) && !conditionalFunctions.contains(functionName)
-                && !utilityFunctions.contains(functionName)) {
-            throw new UnsupportedOperationException(
-                    String.format(
-                            "The following method is not supported in Schema: %s",
-                            functionName));
-        }
         if (functionName.equals("cast")) {
             String castType = ((SQLCastExpr) field.getExpression()).getDataType().getName();
             return getCastFunctionReturnType(castType);
         } else {
-            returnType = scriptColumnType.get(fieldIndex);
+            returnType = resolvedType;
         }
         return returnType;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -521,8 +521,7 @@ public class SQLFunctions {
     private Tuple<String, String> date_format(SQLExpr field, String pattern, String zoneId, String valueName) {
         String name = nextId("date_format");
         if (valueName == null) {
-            return new Tuple<>(name, "def " + name + " = DateTimeFormatter.ofPattern('"
-                    + pattern + "').withZone("
+            return new Tuple<>(name, "def " + name + " = DateTimeFormatter.ofPattern('" + pattern + "').withZone("
                     + (zoneId != null ? "ZoneId.of('" + zoneId + "')" : "ZoneId.systemDefault()")
                     + ").format(Instant.ofEpochMilli(" + getPropertyOrValue(field) + ".toInstant().toEpochMilli()))");
         } else {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -974,15 +974,12 @@ public class SQLFunctions {
      * it might be safely treated as INTEGER.
      */
     public static Schema.Type getScriptFunctionReturnType(MethodField field, Schema.Type resolvedType) {
-        Schema.Type returnType;
         String functionName = ((ScriptMethodField) field).getFunctionName().toLowerCase();
         if (functionName.equals("cast")) {
             String castType = ((SQLCastExpr) field.getExpression()).getDataType().getName();
             return getCastFunctionReturnType(castType);
-        } else {
-            returnType = resolvedType;
         }
-        return returnType;
+        return resolvedType;
     }
 
     public static Schema.Type getCastFunctionReturnType(String castType) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/utils/SQLFunctions.java
@@ -26,6 +26,7 @@ import com.alibaba.druid.sql.ast.expr.SQLNumericLiteralExpr;
 import com.alibaba.druid.sql.ast.expr.SQLPropertyExpr;
 import com.alibaba.druid.sql.ast.expr.SQLTextLiteralExpr;
 import com.alibaba.druid.sql.ast.expr.SQLVariantRefExpr;
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
 import com.amazon.opendistroforelasticsearch.sql.domain.Field;
 import com.amazon.opendistroforelasticsearch.sql.domain.KVValue;
 import com.amazon.opendistroforelasticsearch.sql.domain.MethodField;
@@ -973,28 +974,21 @@ public class SQLFunctions {
      * approach will return type of result column as DOUBLE, although there is enough information to understand that
      * it might be safely treated as INTEGER.
      */
-    public static Schema.Type getScriptFunctionReturnType(Field field) {
+    public static Schema.Type getScriptFunctionReturnType(Field field, ColumnTypeProvider scriptColumnType) {
+        Schema.Type returnType = null;
+        if (scriptColumnType != null) {
+            returnType = scriptColumnType.get(0);
+        }
         String functionName = ((ScriptMethodField) field).getFunctionName().toLowerCase();
         if (functionName.equals("cast")) {
             String castType = ((SQLCastExpr) field.getExpression()).getDataType().getName();
             return getCastFunctionReturnType(castType);
         }
-        if (dateFunctions.contains(functionName) || stringOperators.contains(functionName)) {
+        if (dateFunctions.contains(functionName)) {
             return Schema.Type.TEXT;
         }
-
-        if (mathConstants.contains(functionName) || numberOperators.contains(functionName)
-                || trigFunctions.contains(functionName) || binaryOperators.contains(functionName)
-                || utilityFunctions.contains(functionName)) {
-            return Schema.Type.DOUBLE;
-        }
-
-        if (stringFunctions.contains(functionName)) {
-            return Schema.Type.INTEGER;
-        }
-
-        if (conditionalFunctions.contains(functionName)) {
-            return Schema.Type.KEYWORD;
+        if (returnType != null) {
+            return returnType;
         }
 
         throw new UnsupportedOperationException(

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TypeInformationIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TypeInformationIT.java
@@ -15,13 +15,10 @@
 
 package com.amazon.opendistroforelasticsearch.sql.esintgtest;
 
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 
-import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.rows;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.schema;
-import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.verifyDataRows;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.verifySchema;
 
 public class TypeInformationIT extends SQLIntegTestCase {
@@ -41,12 +38,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
                 " ORDER BY age LIMIT 5");
 
         verifySchema(response, schema("ABS(age)", null, "long"));
-        verifyDataRows(response,
-                rows(20),
-                rows(20),
-                rows(20),
-                rows(20),
-                rows(20));
     }
 
     @Test
@@ -55,12 +46,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
                 " ORDER BY balance LIMIT 5");
 
         verifySchema(response, schema("CEIL(balance)", null, "long"));
-        verifyDataRows(response,
-                rows(1011),
-                rows(1031),
-                rows(1110),
-                rows(1133),
-                rows(1172));
     }
 
     /*
@@ -72,8 +57,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
                 + " LIMIT 1");
 
         verifySchema(response, schema("PI()", null, "double"));
-        verifyDataRows(response,
-                rows(3.141592653589793));
     }
 
     /*
@@ -85,9 +68,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
                 TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname_alias LIMIT 2");
 
         verifySchema(response, schema("firstname_alias", null, "text"));
-        verifyDataRows(response,
-                rows("ABBOTT"),
-                rows("ABIGAIL"));
     }
 
     @Test
@@ -96,9 +76,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
                 TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
 
         verifySchema(response, schema("LOWER(firstname)", null, "text"));
-        verifyDataRows(response,
-                rows("abbott"),
-                rows("abigail"));
     }
 
     /*
@@ -110,34 +87,25 @@ public class TypeInformationIT extends SQLIntegTestCase {
                 TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
 
         verifySchema(response, schema("length(firstname)", null, "integer"));
-        verifyDataRows(response,
-                rows(6),
-                rows(7));
     }
 
     /*
     trigFunctions
      */
     @Test
-    public void testSinWithLongFieldReturnsLong() {
+    public void testSinWithLongFieldReturnsDouble() {
         JSONObject response = executeJdbcRequest("SELECT sin(balance) FROM " +
                 TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
 
-        verifySchema(response, schema("sin(balance)", null, "long"));
-        verifyDataRows(response,
-                rows(0.544804964572613),
-                rows(0.5375391881734781));
+        verifySchema(response, schema("sin(balance)", null, "double"));
     }
 
     @Test
-    public void testRadiansWithLongFieldReturnsLong() {
+    public void testRadiansWithLongFieldReturnsDouble() {
         JSONObject response = executeJdbcRequest("SELECT radians(balance) FROM " +
                 TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
 
-        verifySchema(response, schema("radians(balance)", null, "long"));
-        verifyDataRows(response,
-                rows(192.2480171071754),
-                rows(235.23547658379573));
+        verifySchema(response, schema("radians(balance)", null, "double"));
     }
 
     /*
@@ -149,9 +117,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
                 TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
 
         verifySchema(response, schema("balance_add_five", null, "integer"));
-        verifyDataRows(response,
-                rows(11020),
-                rows(13483));
     }
 
     @Test
@@ -160,9 +125,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
                 TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
 
         verifySchema(response, schema("subtract(balance, balance)", null, "long"));
-        verifyDataRows(response,
-                rows(0),
-                rows(0));
     }
 
     /*
@@ -175,10 +137,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
 
         verifySchema(response,
                 schema("DAY_OF_WEEK(insert_time)", null, "integer"));
-
-        verifyDataRows(response,
-                rows(7),
-                rows(7));
     }
 
     @Test
@@ -187,10 +145,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
                 + TestsConstants.TEST_INDEX_ONLINE + " LIMIT 2");
 
         verifySchema(response, schema("YEAR(insert_time)", null, "integer"));
-
-        verifyDataRows(response,
-                rows(2014),
-                rows(2014));
     }
 
     private JSONObject executeJdbcRequest(String query) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TypeInformationIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TypeInformationIT.java
@@ -64,14 +64,27 @@ public class TypeInformationIT extends SQLIntegTestCase {
     }
 
     /*
+    mathConstants
+     */
+    @Test
+    public void testPiReturnsDouble() {
+        JSONObject response = executeJdbcRequest("SELECT PI() FROM " + TestsConstants.TEST_INDEX_ACCOUNT
+                + " LIMIT 1");
+
+        verifySchema(response, schema("PI()", null, "double"));
+        verifyDataRows(response,
+                rows(3.141592653589793));
+    }
+
+    /*
     stringOperators
      */
     @Test
     public void testUpperWithStringFieldReturnsString() {
-        JSONObject response = executeJdbcRequest("SELECT UPPER(firstname) FROM " +
-                TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
+        JSONObject response = executeJdbcRequest("SELECT UPPER(firstname) AS firstname_alias FROM " +
+                TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname_alias LIMIT 2");
 
-        verifySchema(response, schema("UPPER(firstname)", null, "text"));
+        verifySchema(response, schema("firstname_alias", null, "text"));
         verifyDataRows(response,
                 rows("ABBOTT"),
                 rows("ABIGAIL"));
@@ -133,17 +146,17 @@ public class TypeInformationIT extends SQLIntegTestCase {
 
     @Test
     public void testAddWithIntReturnsInt() {
-        JSONObject response = executeJdbcRequest("SELECT (balance + 5) FROM " +
+        JSONObject response = executeJdbcRequest("SELECT (balance + 5) AS balance_add_five FROM " +
                 TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
 
-        verifySchema(response, schema("add(balance, 5)", null, "integer"));
+        verifySchema(response, schema("balance_add_five", null, "integer"));
         verifyDataRows(response,
                 rows(11020),
                 rows(13483));
     }
 
     @Test
-    public void testSubtractWithLongReturnsLong() {
+    public void testSubtractLongWithLongReturnsLong() {
         JSONObject response = executeJdbcRequest("SELECT (balance - balance) FROM " +
                 TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
 
@@ -179,14 +192,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
         verifyDataRows(response,
                 rows(2014),
                 rows(2014));
-    }
-
-    /*
-    utilityFunctions
-     */
-    @Test
-    public void testAssign() {
-
     }
 
     private JSONObject executeJdbcRequest(String query) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TypeInformationIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TypeInformationIT.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.esintgtest;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 
@@ -29,7 +30,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
     protected void init() throws Exception {
         loadIndex(Index.ACCOUNT);
         loadIndex(Index.ONLINE);
-        loadIndex(Index.DATE);
     }
 
     /*
@@ -143,7 +143,6 @@ public class TypeInformationIT extends SQLIntegTestCase {
     /*
     binaryOperators
      */
-
     @Test
     public void testAddWithIntReturnsInt() {
         JSONObject response = executeJdbcRequest("SELECT (balance + 5) AS balance_add_five FROM " +
@@ -175,7 +174,7 @@ public class TypeInformationIT extends SQLIntegTestCase {
                 + TestsConstants.TEST_INDEX_ONLINE + " LIMIT 2");
 
         verifySchema(response,
-                schema("DAY_OF_WEEK(insert_time)", null, "text"));
+                schema("DAY_OF_WEEK(insert_time)", null, "integer"));
 
         verifyDataRows(response,
                 rows(7),
@@ -187,7 +186,7 @@ public class TypeInformationIT extends SQLIntegTestCase {
         JSONObject response = executeJdbcRequest("SELECT YEAR(insert_time) FROM "
                 + TestsConstants.TEST_INDEX_ONLINE + " LIMIT 2");
 
-        verifySchema(response, schema("YEAR(insert_time)", null, "text"));
+        verifySchema(response, schema("YEAR(insert_time)", null, "integer"));
 
         verifyDataRows(response,
                 rows(2014),

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TypeInformationIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TypeInformationIT.java
@@ -1,0 +1,196 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.esintgtest;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.rows;
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.schema;
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.verifyDataRows;
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.verifySchema;
+
+public class TypeInformationIT extends SQLIntegTestCase {
+
+    @Override
+    protected void init() throws Exception {
+        loadIndex(Index.ACCOUNT);
+        loadIndex(Index.ONLINE);
+        loadIndex(Index.DATE);
+    }
+
+    /*
+    numberOperators
+     */
+    @Test
+    public void testAbsWithIntFieldReturnsInt() {
+        JSONObject response = executeJdbcRequest("SELECT ABS(age) FROM " + TestsConstants.TEST_INDEX_ACCOUNT +
+                " ORDER BY age LIMIT 5");
+
+        verifySchema(response, schema("ABS(age)", null, "long"));
+        verifyDataRows(response,
+                rows(20),
+                rows(20),
+                rows(20),
+                rows(20),
+                rows(20));
+    }
+
+    @Test
+    public void testCeilWithLongFieldReturnsLong() {
+        JSONObject response = executeJdbcRequest("SELECT CEIL(balance) FROM " + TestsConstants.TEST_INDEX_ACCOUNT +
+                " ORDER BY balance LIMIT 5");
+
+        verifySchema(response, schema("CEIL(balance)", null, "long"));
+        verifyDataRows(response,
+                rows(1011),
+                rows(1031),
+                rows(1110),
+                rows(1133),
+                rows(1172));
+    }
+
+    /*
+    stringOperators
+     */
+    @Test
+    public void testUpperWithStringFieldReturnsString() {
+        JSONObject response = executeJdbcRequest("SELECT UPPER(firstname) FROM " +
+                TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
+
+        verifySchema(response, schema("UPPER(firstname)", null, "text"));
+        verifyDataRows(response,
+                rows("ABBOTT"),
+                rows("ABIGAIL"));
+    }
+
+    @Test
+    public void testLowerWithTextFieldReturnsText() {
+        JSONObject response = executeJdbcRequest("SELECT LOWER(firstname) FROM " +
+                TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
+
+        verifySchema(response, schema("LOWER(firstname)", null, "text"));
+        verifyDataRows(response,
+                rows("abbott"),
+                rows("abigail"));
+    }
+
+    /*
+    stringFunctions
+     */
+    @Test
+    public void testLengthWithTextFieldReturnsInt() {
+        JSONObject response = executeJdbcRequest("SELECT length(firstname) FROM " +
+                TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
+
+        verifySchema(response, schema("length(firstname)", null, "integer"));
+        verifyDataRows(response,
+                rows(6),
+                rows(7));
+    }
+
+    /*
+    trigFunctions
+     */
+    @Test
+    public void testSinWithLongFieldReturnsLong() {
+        JSONObject response = executeJdbcRequest("SELECT sin(balance) FROM " +
+                TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
+
+        verifySchema(response, schema("sin(balance)", null, "long"));
+        verifyDataRows(response,
+                rows(0.544804964572613),
+                rows(0.5375391881734781));
+    }
+
+    @Test
+    public void testRadiansWithLongFieldReturnsLong() {
+        JSONObject response = executeJdbcRequest("SELECT radians(balance) FROM " +
+                TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
+
+        verifySchema(response, schema("radians(balance)", null, "long"));
+        verifyDataRows(response,
+                rows(192.2480171071754),
+                rows(235.23547658379573));
+    }
+
+    /*
+    binaryOperators
+     */
+
+    @Test
+    public void testAddWithIntReturnsInt() {
+        JSONObject response = executeJdbcRequest("SELECT (balance + 5) FROM " +
+                TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
+
+        verifySchema(response, schema("add(balance, 5)", null, "integer"));
+        verifyDataRows(response,
+                rows(11020),
+                rows(13483));
+    }
+
+    @Test
+    public void testSubtractWithLongReturnsLong() {
+        JSONObject response = executeJdbcRequest("SELECT (balance - balance) FROM " +
+                TestsConstants.TEST_INDEX_ACCOUNT + " ORDER BY firstname LIMIT 2");
+
+        verifySchema(response, schema("subtract(balance, balance)", null, "long"));
+        verifyDataRows(response,
+                rows(0),
+                rows(0));
+    }
+
+    /*
+    dateFunctions
+     */
+    @Test
+    public void testDayOfWeekWithKeywordReturnsText() {
+        JSONObject response = executeJdbcRequest("SELECT DAY_OF_WEEK(insert_time) FROM "
+                + TestsConstants.TEST_INDEX_ONLINE + " LIMIT 2");
+
+        verifySchema(response,
+                schema("DAY_OF_WEEK(insert_time)", null, "text"));
+
+        verifyDataRows(response,
+                rows(7),
+                rows(7));
+    }
+
+    @Test
+    public void testYearWithKeywordReturnsText() {
+        JSONObject response = executeJdbcRequest("SELECT YEAR(insert_time) FROM "
+                + TestsConstants.TEST_INDEX_ONLINE + " LIMIT 2");
+
+        verifySchema(response, schema("YEAR(insert_time)", null, "text"));
+
+        verifyDataRows(response,
+                rows(2014),
+                rows(2014));
+    }
+
+    /*
+    utilityFunctions
+     */
+    @Test
+    public void testAssign() {
+
+    }
+
+    private JSONObject executeJdbcRequest(String query) {
+        return new JSONObject(executeQuery(query, "jdbc"));
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/SQLFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/SQLFunctionsTest.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import org.elasticsearch.common.collect.Tuple;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -83,7 +84,8 @@ public class SQLFunctionsTest {
         field.setExpression(invokeExpr);
         ColumnTypeProvider columnTypeProvider = new ColumnTypeProvider(ESDataType.INTEGER);
 
-        final Schema.Type returnType = sqlFunctions.getScriptFunctionReturnType(0, field, columnTypeProvider);
+        Schema.Type resolvedType = columnTypeProvider.get(0);
+        final Schema.Type returnType = sqlFunctions.getScriptFunctionReturnType(field, resolvedType);
         Assert.assertEquals(returnType, Schema.Type.INTEGER);
     }
 
@@ -100,18 +102,8 @@ public class SQLFunctionsTest {
         field.setExpression(castExpr);
         ColumnTypeProvider columnTypeProvider = new ColumnTypeProvider(ESDataType.INTEGER);
 
-        final Schema.Type returnType = sqlFunctions.getScriptFunctionReturnType(0, field, columnTypeProvider);
+        Schema.Type resolvedType = columnTypeProvider.get(0);
+        final Schema.Type returnType = sqlFunctions.getScriptFunctionReturnType(field, resolvedType);
         Assert.assertEquals(returnType, Schema.Type.INTEGER);
-    }
-
-    @Test
-    public void testNullScriptReturnTypeThrowsException() throws UnsupportedOperationException {
-        exceptionRule.expect(UnsupportedOperationException.class);
-        exceptionRule.expectMessage("The following method is not supported in Schema: lo");
-
-        List<KVValue> params = new ArrayList<>();
-        MethodField field = new ScriptMethodField("LO", params, null, null);
-        ColumnTypeProvider columnTypeProvider = new ColumnTypeProvider(ESDataType.INTEGER);
-        final Schema.Type type = sqlFunctions.getScriptFunctionReturnType(0, field, columnTypeProvider);
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/SQLFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/SQLFunctionsTest.java
@@ -15,17 +15,47 @@
 
 package com.amazon.opendistroforelasticsearch.sql.unittest.utils;
 
+import com.alibaba.druid.sql.ast.SQLDataType;
+import com.alibaba.druid.sql.ast.SQLDataTypeImpl;
+import com.alibaba.druid.sql.ast.expr.SQLCastExpr;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
 import com.alibaba.druid.sql.ast.expr.SQLIntegerExpr;
+import com.alibaba.druid.sql.ast.expr.SQLMethodInvokeExpr;
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType;
+import com.amazon.opendistroforelasticsearch.sql.domain.ColumnTypeProvider;
 import com.amazon.opendistroforelasticsearch.sql.domain.KVValue;
+import com.amazon.opendistroforelasticsearch.sql.domain.MethodField;
+import com.amazon.opendistroforelasticsearch.sql.domain.ScriptMethodField;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
+import com.amazon.opendistroforelasticsearch.sql.executor.format.Schema;
+import com.amazon.opendistroforelasticsearch.sql.parser.FieldMaker;
 import com.amazon.opendistroforelasticsearch.sql.utils.SQLFunctions;
 import com.google.common.collect.ImmutableList;
 import org.elasticsearch.common.collect.Tuple;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
 public class SQLFunctionsTest {
+
+    private FieldMaker fieldMaker;
+    private SQLFunctions sqlFunctions;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Before
+    public void init() {
+        fieldMaker = new FieldMaker();
+    }
+    public void initSqlFunctions() { sqlFunctions = new SQLFunctions(); }
 
     @Test
     public void testAssign() throws SqlParseException {
@@ -39,5 +69,49 @@ public class SQLFunctionsTest {
 
         assertTrue(assign.v1().matches("assign_[0-9]+"));
         assertTrue(assign.v2().matches("def assign_[0-9]+ = 10;return assign_[0-9]+;"));
+    }
+
+    @Test
+    public void testAbsWithIntReturnType() {
+        final SQLIntegerExpr sqlIntegerExpr = new SQLIntegerExpr(6);
+
+        final SQLMethodInvokeExpr invokeExpr = new SQLMethodInvokeExpr("ABS");
+        invokeExpr.addParameter(sqlIntegerExpr);
+        List<KVValue> params = new ArrayList<>();
+
+        final MethodField field = new ScriptMethodField("ABS", params, null, null);
+        field.setExpression(invokeExpr);
+        ColumnTypeProvider columnTypeProvider = new ColumnTypeProvider(ESDataType.INTEGER);
+
+        final Schema.Type returnType = sqlFunctions.getScriptFunctionReturnType(0, field, columnTypeProvider);
+        Assert.assertEquals(returnType, Schema.Type.INTEGER);
+    }
+
+    @Test
+    public void testCastReturnType() {
+        final SQLIdentifierExpr identifierExpr = new SQLIdentifierExpr("int_type");
+        SQLDataType sqlDataType = new SQLDataTypeImpl("INT");
+        final SQLCastExpr castExpr = new SQLCastExpr();
+        castExpr.setExpr(identifierExpr);
+        castExpr.setDataType(sqlDataType);
+
+        List<KVValue> params = new ArrayList<>();
+        final MethodField field = new ScriptMethodField("CAST", params, null, null);
+        field.setExpression(castExpr);
+        ColumnTypeProvider columnTypeProvider = new ColumnTypeProvider(ESDataType.INTEGER);
+
+        final Schema.Type returnType = sqlFunctions.getScriptFunctionReturnType(0, field, columnTypeProvider);
+        Assert.assertEquals(returnType, Schema.Type.INTEGER);
+    }
+
+    @Test
+    public void testNullScriptReturnTypeThrowsException() throws UnsupportedOperationException {
+        exceptionRule.expect(UnsupportedOperationException.class);
+        exceptionRule.expectMessage("The following method is not supported in Schema: lo");
+
+        List<KVValue> params = new ArrayList<>();
+        MethodField field = new ScriptMethodField("LO", params, null, null);
+        ColumnTypeProvider columnTypeProvider = new ColumnTypeProvider(ESDataType.INTEGER);
+        final Schema.Type type = sqlFunctions.getScriptFunctionReturnType(0, field, columnTypeProvider);
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/SQLFunctionsTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/utils/SQLFunctionsTest.java
@@ -46,17 +46,10 @@ import static org.junit.Assert.assertTrue;
 
 public class SQLFunctionsTest {
 
-    private FieldMaker fieldMaker;
     private SQLFunctions sqlFunctions;
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
-
-    @Before
-    public void init() {
-        fieldMaker = new FieldMaker();
-    }
-    public void initSqlFunctions() { sqlFunctions = new SQLFunctions(); }
 
     @Test
     public void testAssign() throws SqlParseException {


### PR DESCRIPTION
*Issue #, if available:*
#316 
*Description of changes:*
Type Information for fields in JDBC format used to be hard-coded in, and would return consistently regardless of the field type itself for scripted fields (e.g `ABS(int_type)` would always return type `double`)

Now, JDBC type information returns correctly based on the field. Script fields in the `ORDER BY` clause are returned hard-coded, as we currently only return either `STRING` or `NUMBER`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
