### PR TITLE
Bug fix, return object type for field which has implicit object datatype when describe the table

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/DescribeResultSet.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/format/DescribeResultSet.java
@@ -36,6 +36,12 @@ public class DescribeResultSet extends ResultSet {
     private static final int DEFAULT_NUM_PREC_RADIX = 10;
     private static final String IS_AUTOINCREMENT = "NO";
 
+    /**
+     * You are not required to set the field type to object explicitly, as this is the default value.
+     * https://www.elastic.co/guide/en/elasticsearch/reference/current/object.html
+     */
+    private static final String DEFAULT_OBJECT_DATATYPE = "object";
+
     private IndexStatement statement;
     private Object queryResult;
 
@@ -159,7 +165,7 @@ public class DescribeResultSet extends ResultSet {
             Map<String, Object> metaData = (Map<String, Object>) entry.getValue();
 
             String fullPath = addToPath(currPath, entry.getKey());
-            flattenedMapping.put(fullPath, (String) metaData.get("type"));
+            flattenedMapping.put(fullPath, (String) metaData.getOrDefault("type", DEFAULT_OBJECT_DATATYPE));
             if (metaData.containsKey("properties")) {
                 flattenedMapping = flattenMappingMetaData(metaData, fullPath, flattenedMapping);
             }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MetaDataQueriesIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/MetaDataQueriesIT.java
@@ -291,6 +291,34 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
     }
 
     @Test
+    public void describeSingleIndexWithObjectFieldShouldPass() throws IOException {
+        JSONObject response =
+                executeQuery(String.format("DESCRIBE TABLES LIKE %s", TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+
+        // Schema for DESCRIBE is filled with a lot of fields that aren't used so only the important
+        // ones are checked for here
+        String[] fields = {"TABLE_NAME", "COLUMN_NAME", "TYPE_NAME"};
+        checkContainsColumns(getSchema(response), fields);
+
+        JSONArray dataRows = getDataRows(response);
+        assertThat(dataRows.length(), greaterThan(0));
+        assertThat(dataRows.getJSONArray(0).length(), equalTo(DESCRIBE_FIELD_LENGTH));
+
+        /*
+         * Assumed indices of fields in dataRows based on "schema" output for DESCRIBE given above:
+         * "TABLE_NAME"  : 2
+         * "COLUMN_NAME" : 3
+         * "TYPE_NAME"   : 5
+         */
+        for (int i = 0; i < dataRows.length(); i++) {
+            JSONArray row = dataRows.getJSONArray(i);
+            assertThat(row.get(2), equalTo(TestsConstants.TEST_INDEX_GAME_OF_THRONES));
+            assertThat(row.get(3), not(equalTo(JSONObject.NULL)));
+            assertThat(row.get(5), not(equalTo(JSONObject.NULL)));
+        }
+    }
+
+    @Test
     public void describeCaseSensitivityCheck() throws IOException {
         JSONObject response = executeQuery(String.format("describe tables like %s", TestsConstants.TEST_INDEX_ACCOUNT));
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
@@ -34,9 +34,9 @@ import java.util.function.Function;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
@@ -146,6 +146,17 @@ public class MatcherUtils {
         array.iterator().forEachRemaining(o -> objects.add((T) o));
         assertEquals(matchers.length, objects.size());
         assertThat(objects, containsInAnyOrder(matchers));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> void verifySome(JSONArray array, Matcher<T>... matchers) {
+        List<T> objects = new ArrayList<>();
+        array.iterator().forEachRemaining(o -> objects.add((T) o));
+
+        assertThat(matchers.length, greaterThan(0));
+        for (Matcher<T> matcher : matchers) {
+            assertThat(objects, hasItems(matcher));
+        }
     }
 
     public static TypeSafeMatcher<JSONObject> schema(String expectedName, String expectedAlias, String expectedType) {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql-jdbc/issues/57

*Description of changes:*
Return the object as type when field use implicit object datatype.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
