### PR TITLE
Sql CI/CD

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,42 @@
+name: Release SQL Artifacts
+on:
+  push:
+    branches:
+      - opendistro-*
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [12]
+
+    name: Build and Release SQL Plugin
+    runs-on: [ubuntu-16.04]
+
+    steps:
+      - name: Checkout SQL
+        uses: actions/checkout@v1
+      
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+        
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      
+      - name: Run build
+        run: |
+          ./gradlew buildPackages --refresh-dependencies --console=plain -Dbuild.snapshot=false
+          artifact=`ls build/distributions/*.zip`
+          rpm_artifact=`ls build/distributions/*.rpm`
+          deb_artifact=`ls build/distributions/*.deb`
+          
+          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-sql/
+          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-sql/
+          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-sql/
+          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,63 @@
+name: Build and Test SQL
+on:
+  push:
+    branches:
+      - master
+      - opendistro-*
+
+jobs:
+  Build-SQL:
+    strategy:
+      matrix:
+        java: [12]
+
+    name: Build and Test SQL Plugin
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout SQL
+        uses: actions/checkout@v1
+        
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      
+      - name: Run build
+        run: |
+          ./gradlew build
+          ls -ltr
+          
+      - name: Build Packages to Test
+        run: |
+          ./gradlew buildPackages --refresh-dependencies --console=plain -Dbuild.snapshot=false
+          
+      - name: Pull and Run Docker
+        run: |
+          plugin=`ls build/distributions/*.zip`
+          version=`echo $plugin|awk -F- '{print $2}'| cut -d. -f 1-3`
+          plugin_version=`echo $plugin|awk -F- '{print $2}'| cut -d. -f 1-4`
+          echo $version
+          cd ..
+          
+          if docker pull opendistroforelasticsearch/opendistroforelasticsearch:$version
+          then
+            echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$version" >> Dockerfile
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_security ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security; fi" >> Dockerfile
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_sql ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_sql; fi" >> Dockerfile
+            echo "ADD sql/build/distributions/opendistro_sql-$plugin_version.zip /tmp/" >> Dockerfile
+            echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:/tmp/opendistro_sql-$plugin_version.zip" >> Dockerfile
+            
+            docker build -t odfe-sql:test .
+          fi
+          
+      - name: Run Docker Image
+        run: |
+          cd ..
+          docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" odfe-sql:test
+          sleep 15
+          curl -XGET http://localhost:9200/_cat/plugins
+          
+      - name: Run SQL Test
+        run: |
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200


### PR DESCRIPTION
###CI.yml

This job will trigger on every code checkin in master and opendistro branches which then will build the SQL plugin and run integration tests against the respective version of opendistro staging docker image.
Before running the test the job will first remove SQL plugin, if available, then it will re-install the built plugin.

###CD.yml
This job will trigger whenever a code checkin is made on an opendistro branch or a new opendistro branch is cut. It will build all the artifacts and then upload to respective S3 paths.

Assumption: the new opendistro branch is cut only when the plugin is ready to be released.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
