### PR TITLE
[BugFix] Enforce AVG return double data type

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/AggregateFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/types/function/AggregateFunction.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.function;
 import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.Type;
 import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.TypeExpression;
 
+import static com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType.DOUBLE;
 import static com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType.ES_TYPE;
 import static com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType.INTEGER;
 import static com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType.NUMBER;
@@ -33,7 +34,7 @@ public enum AggregateFunction implements TypeExpression {
     ),
     MAX(func(T(NUMBER)).to(T)),
     MIN(func(T(NUMBER)).to(T)),
-    AVG(func(T(NUMBER)).to(T)),
+    AVG(func(T(NUMBER)).to(DOUBLE)),
     SUM(func(T(NUMBER)).to(T));
 
     private TypeExpressionSpec[] specifications;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerAggregateFunctionTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerAggregateFunctionTest.java
@@ -91,7 +91,7 @@ public class SemanticAnalyzerAggregateFunctionTest extends SemanticAnalyzerTestB
         expectValidationFailWithErrorMessages(
             "SELECT AVG(p.active) FROM semantics s, s.projects p",
             "Function [AVG] cannot work with [BOOLEAN].",
-            "Usage: AVG(NUMBER T) -> T"
+            "Usage: AVG(NUMBER T) -> DOUBLE"
         );
     }
 
@@ -152,7 +152,7 @@ public class SemanticAnalyzerAggregateFunctionTest extends SemanticAnalyzerTestB
         expectValidationFailWithErrorMessages(
             "SELECT city FROM semantics GROUP BY city HAVING AVG(address) > 10",
             "Function [AVG] cannot work with [TEXT].",
-            "Usage: AVG(NUMBER T) -> T"
+            "Usage: AVG(NUMBER T) -> DOUBLE"
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/AggregationExpressionIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/AggregationExpressionIT.java
@@ -74,7 +74,7 @@ public class AggregationExpressionIT extends SQLIntegTestCase {
                         "FROM %s",
                 Index.BANK.getName()));
 
-        verifySchema(response, schema("avg", "avg", "integer"));
+        verifySchema(response, schema("avg", "avg", "double"));
         verifyDataRows(response, rows(34));
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/AggregationExpressionIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/AggregationExpressionIT.java
@@ -29,6 +29,7 @@ public class AggregationExpressionIT extends SQLIntegTestCase {
     @Override
     protected void init() throws Exception {
         loadIndex(Index.ACCOUNT);
+        loadIndex(Index.BANK);
     }
 
     @Test
@@ -64,6 +65,34 @@ public class AggregationExpressionIT extends SQLIntegTestCase {
 
         verifySchema(response, schema("add", "add", "long"));
         verifyDataRows(response, rows(41));
+    }
+
+    @Test
+    public void noGroupKeyAvgOnIntegerShouldPass() {
+        JSONObject response = executeJdbcRequest(String.format(
+                "SELECT AVG(age) as avg " +
+                        "FROM %s",
+                Index.BANK.getName()));
+
+        verifySchema(response, schema("avg", "avg", "integer"));
+        verifyDataRows(response, rows(34));
+    }
+
+
+    @Test
+    public void hasGroupKeyAvgOnIntegerShouldPass() {
+        JSONObject response = executeJdbcRequest(String.format(
+                "SELECT gender, AVG(age) as avg " +
+                "FROM %s " +
+                "GROUP BY gender",
+                Index.BANK.getName()));
+
+        verifySchema(response,
+                schema("gender", null, "text"),
+                schema("avg", "avg", "double"));
+        verifyDataRows(response,
+                rows("m", 34.25),
+                rows("f", 33.666666666666664d));
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/AggregationExpressionIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/AggregationExpressionIT.java
@@ -78,7 +78,6 @@ public class AggregationExpressionIT extends SQLIntegTestCase {
         verifyDataRows(response, rows(34));
     }
 
-
     @Test
     public void hasGroupKeyAvgOnIntegerShouldPass() {
         JSONObject response = executeJdbcRequest(String.format(

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -499,8 +499,9 @@ public class TestUtils {
                 "        \"type\": \"text\"\n" +
                 "      },\n" +
                 "      \"gender\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
+                "        \"type\": \"text\",\n" +
+                "        \"fielddata\": true\n" +
+                "      }," +
                 "      \"lastname\": {\n" +
                 "        \"type\": \"keyword\"\n" +
                 "      },\n" +

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerBatchTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerBatchTest.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.sql.unittest.planner;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.hamcrest.Matcher;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -38,6 +39,7 @@ import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kv;
  */
 @SuppressWarnings("unchecked")
 @RunWith(Parameterized.class)
+@Ignore
 public class QueryPlannerBatchTest extends QueryPlannerTest {
 
     private static final String TEST_SQL1 =

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerBatchTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerBatchTest.java
@@ -18,7 +18,6 @@ package com.amazon.opendistroforelasticsearch.sql.unittest.planner;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.hamcrest.Matcher;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -39,7 +38,6 @@ import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.kv;
  */
 @SuppressWarnings("unchecked")
 @RunWith(Parameterized.class)
-@Ignore
 public class QueryPlannerBatchTest extends QueryPlannerTest {
 
     private static final String TEST_SQL1 =


### PR DESCRIPTION
*Issue #, if available:*
#408 
*Description of changes:*
- Enforce `AVG()` to return `double` data type
- Fixed UT
- Added IT with/without `GROUP BY`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
