### PR TITLE
[BugFix] mock LocalClusterState settings in QueryPlanner base test class

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/unittest/planner/QueryPlannerTest.java
@@ -21,9 +21,11 @@ import com.alibaba.druid.sql.parser.ParserException;
 import com.alibaba.druid.sql.parser.SQLExprParser;
 import com.alibaba.druid.sql.parser.Token;
 import com.amazon.opendistroforelasticsearch.sql.domain.JoinSelect;
+import com.amazon.opendistroforelasticsearch.sql.esdomain.LocalClusterState;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.parser.ElasticSqlExprParser;
 import com.amazon.opendistroforelasticsearch.sql.parser.SqlParser;
+import com.amazon.opendistroforelasticsearch.sql.plugin.SqlSettings;
 import com.amazon.opendistroforelasticsearch.sql.query.QueryAction;
 import com.amazon.opendistroforelasticsearch.sql.query.SqlElasticRequestBuilder;
 import com.amazon.opendistroforelasticsearch.sql.query.join.ESJoinQueryActionFactory;
@@ -61,11 +63,13 @@ import org.mockito.stubbing.Answer;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory.newConfigurationBuilder;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -109,6 +113,12 @@ public abstract class QueryPlannerTest {
     @Before
     public void init() {
         MockitoAnnotations.initMocks(this);
+
+        SqlSettings settings = spy(new SqlSettings());
+        // Force return empty list to avoid ClusterSettings be invoked which is a final class and hard to mock.
+        // In this case, default value in Setting will be returned all the time.
+        doReturn(emptyList()).when(settings).getSettings();
+        LocalClusterState.state().setSqlSettings(settings);
 
         ActionFuture mockFuture = mock(ActionFuture.class);
         when(client.execute(any(), any())).thenReturn(mockFuture);


### PR DESCRIPTION
*Issue #, if available:*
#443 
*Description of changes:*
Initialize mock `LocalClusterState.sqlSettings` in base test class for all query planner tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
