### PR TITLE
Fix CSV injection issue

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResult.java
@@ -15,25 +15,79 @@
 
 package com.amazon.opendistroforelasticsearch.sql.executor.csv;
 
+import com.google.common.collect.ImmutableSet;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Created by Eliran on 27/12/2015.
  */
 public class CSVResult {
+
+    private static final Set<String> SENSITIVE_CHAR = ImmutableSet.of("=", "+", "-", "@");
+
     private final List<String> headers;
     private final List<String> lines;
 
+    /**
+     * Skip sanitizing if appended lines provided.
+     */
     public CSVResult(List<String> headers, List<String> lines) {
         this.headers = headers;
         this.lines = lines;
     }
 
+    public CSVResult(String separator, List<String> headers, List<List<String>> lines) {
+        this.headers = sanitizeHeaders(headers);
+        this.lines = sanitizeLines(separator, lines);
+    }
+
+    /**
+     * Return CSV header names which are sanitized too just in case Elasticsearch allows
+     * sensitive character present in field name.
+     * @return  CSV header name list after sanitized
+     */
     public List<String> getHeaders() {
         return headers;
     }
 
+    /**
+     * Return CSV lines in which each cell is sanitized to avoid CSV injection.
+     * @return  CSV lines after sanitized
+     */
     public List<String> getLines() {
         return lines;
     }
+
+    private List<String> sanitizeHeaders(List<String> headers) {
+        return headers.stream().
+                       map(this::sanitizeCell).
+                       collect(Collectors.toList());
+    }
+
+    private List<String> sanitizeLines(String separator, List<List<String>> lines) {
+        List<String> result = new ArrayList<>();
+        for (List<String> line : lines) {
+            result.add(line.stream().
+                            map(this::sanitizeCell).
+                            collect(Collectors.joining(separator)));
+        }
+        return result;
+    }
+
+    private String sanitizeCell(String cell) {
+        if (isStartWithSensitiveChar(cell)) {
+            return "'" + cell;
+        }
+        return cell;
+    }
+
+    private boolean isStartWithSensitiveChar(String cell) {
+        return SENSITIVE_CHAR.stream().
+                              anyMatch(cell::startsWith);
+    }
+
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResult.java
@@ -33,7 +33,8 @@ public class CSVResult {
     private final List<String> lines;
 
     /**
-     * Skip sanitizing if appended lines provided.
+     * Skip sanitizing if string line provided. This constructor is basically used by
+     * assertion in test code.
      */
     public CSVResult(List<String> headers, List<String> lines) {
         this.headers = headers;
@@ -46,8 +47,8 @@ public class CSVResult {
     }
 
     /**
-     * Return CSV header names which are sanitized too just in case Elasticsearch allows
-     * sensitive character present in field name.
+     * Return CSV header names which are sanitized because Elasticsearch allows
+     * special character present in field name too.
      * @return  CSV header name list after sanitized
      */
     public List<String> getHeaders() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -100,7 +100,7 @@ public class TestUtils {
         try {
             Response response = client.performRequest(request);
             int status = response.getStatusLine().getStatusCode();
-            if (status != 200) {
+            if (status >= 400) {
                 throw new IllegalStateException("Failed to perform request. Error code: " + status);
             }
             return response;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResultTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResultTest.java
@@ -1,0 +1,86 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.executor.csv;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for {@link CSVResult}
+ */
+public class CSVResultTest {
+
+    private static final String SEPARATOR = ",";
+
+    @Test
+    public void getHeadersShouldReturnHeadersSanitized() {
+        CSVResult csv = csv(headers("name", "=age"), lines(line("John", "30")));
+        assertEquals(
+            headers("name", "'=age"),
+            csv.getHeaders()
+        );
+    }
+
+    @Test
+    public void getLinesShouldReturnLinesSanitized() {
+        CSVResult csv = csv(
+            headers("name", "city"),
+            lines(
+                line("John", "Seattle"),
+                line("John", "=Seattle"),
+                line("John", "+Seattle"),
+                line("-John", "Seattle"),
+                line("@John", "Seattle"),
+                line("John", "Seattle=")
+            )
+        );
+
+        assertEquals(
+            line(
+                "John,Seattle",
+                "John,'=Seattle",
+                "John,'+Seattle",
+                "'-John,Seattle",
+                "'@John,Seattle",
+                "John,Seattle="
+            ),
+            csv.getLines()
+        );
+    }
+
+    private CSVResult csv(List<String> headers, List<List<String>> lines) {
+        return new CSVResult(SEPARATOR, headers, lines);
+    }
+
+    private List<String> headers(String... headers) {
+        return Arrays.stream(headers).collect(Collectors.toList());
+    }
+
+    private List<String> line(String... line) {
+        return Arrays.stream(line).collect(Collectors.toList());
+    }
+
+    @SafeVarargs
+    private final List<List<String>> lines(List<String>... lines) {
+        return Arrays.stream(lines).collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:* Will create later.

*Description of changes:* In CSV, cell prefixed with "=" is treated as formula which is executable. Attacker can upload document with this kind of field value to Elasticsearch. Victim downloads the CSV file and injected code may be executed after open.

*Mitigation*: https://www.we45.com/blog/2017/02/14/csv-injection-theres-devil-in-the-detail. "A strategy to mitigate Formula Injection would be to prefix a single quote (') for every formula which begins with the following symbols:

 1. Equals to ("=")
 2. Plus ("+")
 3. Minus ("-")
 4. At ("@")"

*Verification*:

Without the fix:

<img width="856" alt="Screen Shot 2020-04-28 at 10 01 52 PM" src="https://user-images.githubusercontent.com/46505291/80562587-f8c84780-899c-11ea-9f59-64de1d23d3dc.png">

With the fix:

<img width="723" alt="Screen Shot 2020-04-28 at 10 01 25 PM" src="https://user-images.githubusercontent.com/46505291/80562526-dd5d3c80-899c-11ea-9047-5eb6db7aaf7c.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
