### PR TITLE
Revert "bump opendistroVersion to 1.6.1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 }
 
 ext {
-    opendistroVersion = '1.6.1'
+    opendistroVersion = '1.6.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 

--- a/opendistro-elasticsearch-sql.release-notes.md
+++ b/opendistro-elasticsearch-sql.release-notes.md
@@ -14,7 +14,6 @@
 * Change [#419](https://github.com/opendistro-for-elasticsearch/sql/pull/419): Anonymize sensitive data in queries exposed to RestSqlAction logs. (issue: [#97](https://github.com/opendistro-for-elasticsearch/sql/issues/97))
 
 ### Bugfixes
-* Bugfix [#446](https://github.com/opendistro-for-elasticsearch/sql/pull/446): Mock LocalClusterState settings in QueryPlanner base test class. (issue: [#443](https://github.com/opendistro-for-elasticsearch/sql/issues/443))
 * Bugfix [#442](https://github.com/opendistro-for-elasticsearch/sql/pull/442): Count(distinct field) should translate to cardinality aggregation. (issue: [#439](https://github.com/opendistro-for-elasticsearch/sql/issues/439))
 * Bugfix [#437](https://github.com/opendistro-for-elasticsearch/sql/pull/437): Enforce AVG return double data type. (issue: [#408](https://github.com/opendistro-for-elasticsearch/sql/issues/408))
 * Bugfix [#425](https://github.com/opendistro-for-elasticsearch/sql/pull/425): Ignore the term query rewrite if there is no index found. (issue: [#355](https://github.com/opendistro-for-elasticsearch/sql/issues/355))


### PR DESCRIPTION
Reverts opendistro-for-elasticsearch/sql#451 the opendistroforelasticsearch/opendistroforelasticsearch:1.6.1 image is not ready yet, we should hold on the merge.