### PR TITLE
Escape comma for CSV header and all queries

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResultsExtractor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResultsExtractor.java
@@ -331,20 +331,13 @@ public class CSVResultsExtractor {
                     return "";
                 }
             }
-            return quoteValueIfRequired(innerDoc.toString(), separator);
+            return innerDoc.toString();
         } else {
             if (doc.containsKey(header)) {
-                return quoteValueIfRequired(String.valueOf(doc.get(header)), separator);
+                return String.valueOf(doc.get(header));
             }
         }
         return "";
-    }
-
-    private String quoteValueIfRequired(final String input, final String separator) {
-        final String quote = "\"";
-
-        return input.contains(separator)
-                ? quote + input.replaceAll("\"", "\"\"") + quote : input;
     }
 
     private void mergeHeaders(Set<String> headers, Map<String, Object> doc, boolean flat) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/CsvFormatResponseIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/CsvFormatResponseIT.java
@@ -94,7 +94,7 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
         final String result = executeQueryWithStringOutput(query);
 
         final String[] unexpectedPercentiles = {"1.0", "5.0", "25.0", "50.0", "75.0", "95.0", "99.0"};
-        final String expectedHeaders = "PERCENTILES(age,10,49.0).10.0,PERCENTILES(age,10,49.0).49.0";
+        final String expectedHeaders = "\"PERCENTILES(age,10,49.0).10.0\",\"PERCENTILES(age,10,49.0).49.0\"";
         Assert.assertThat(result, containsString(expectedHeaders));
         for (final String unexpectedPercentile : unexpectedPercentiles) {
             Assert.assertThat(result, not(containsString("PERCENTILES(age,10,49.0)." + unexpectedPercentile)));
@@ -632,6 +632,32 @@ public class CsvFormatResponseIT extends SQLIntegTestCase {
         Assert.assertEquals(1, lines.size());
         Assert.assertTrue(lines.get(0).contains("'+cmd|' /C notepad'!_xlbgnm.A1"));
         Assert.assertTrue(lines.get(0).contains("'@cmd|' /C notepad'!_xlbgnm.A1"));
+    }
+
+    @Test
+    public void sensitiveCharacterSanitizeAndQuotedTest() throws IOException {
+        String requestBody =
+            "{" +
+            "  \"=cmd|' /C notepad'!_xlbgnm.A1,,\": \",+cmd|' /C notepad'!_xlbgnm.A1\",\n" +
+            "  \",@cmd|' /C notepad'!_xlbgnm.A1\": \"+cmd|' /C notepad,,'!_xlbgnm.A1\",\n" +
+            "  \"-cmd|' /C notepad,,'!_xlbgnm.A1\": \",,,@cmd|' /C notepad'!_xlbgnm.A1\"\n" +
+            "}";
+
+        Request request = new Request("PUT", "/userdata2/_doc/1?refresh=true");
+        request.setJsonEntity(requestBody);
+        TestUtils.performRequest(client(), request);
+
+        CSVResult csvResult = executeCsvRequest("SELECT * FROM userdata2", false, false, false, false);
+        String headers = String.join(",", csvResult.getHeaders());
+        Assert.assertTrue(headers.contains("\"'=cmd|' /C notepad'!_xlbgnm.A1,,\""));
+        Assert.assertTrue(headers.contains("\",@cmd|' /C notepad'!_xlbgnm.A1\""));
+        Assert.assertTrue(headers.contains("\"'-cmd|' /C notepad,,'!_xlbgnm.A1\""));
+
+        List<String> lines = csvResult.getLines();
+        Assert.assertEquals(1, lines.size());
+        Assert.assertTrue(lines.get(0).contains("\",+cmd|' /C notepad'!_xlbgnm.A1\""));
+        Assert.assertTrue(lines.get(0).contains("\"'+cmd|' /C notepad,,'!_xlbgnm.A1\""));
+        Assert.assertTrue(lines.get(0).contains("\",,,@cmd|' /C notepad'!_xlbgnm.A1\""));
     }
 
     private void verifyFieldOrder(final String[] expectedFields) throws IOException {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResultTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/executor/csv/CSVResultTest.java
@@ -66,6 +66,60 @@ public class CSVResultTest {
         );
     }
 
+    @Test
+    public void getHeadersShouldReturnHeadersQuotedIfRequired() {
+        CSVResult csv = csv(headers("na,me", ",,age"), lines(line("John", "30")));
+        assertEquals(
+            headers("\"na,me\"", "\",,age\""),
+            csv.getHeaders()
+        );
+    }
+
+    @Test
+    public void getLinesShouldReturnLinesQuotedIfRequired() {
+        CSVResult csv = csv(headers("name", "age"), lines(line("John,Smith", "30,,,")));
+        assertEquals(
+            line("\"John,Smith\",\"30,,,\""),
+            csv.getLines()
+        );
+    }
+
+    @Test
+    public void getHeadersShouldReturnHeadersBothSanitizedAndQuotedIfRequired() {
+        CSVResult csv = csv(headers("na,+me", ",,,=age", "=city,"), lines(line("John", "30", "Seattle")));
+        assertEquals(
+            headers("\"na,+me\"", "\",,,=age\"", "\"'=city,\""),
+            csv.getHeaders()
+        );
+    }
+
+    @Test
+    public void getLinesShouldReturnLinesBothSanitizedAndQuotedIfRequired() {
+        CSVResult csv = csv(
+            headers("name", "city"),
+            lines(
+                line("John", "Seattle"),
+                line("John", "=Seattle"),
+                line("John", "+Sea,ttle"),
+                line(",-John", "Seattle"),
+                line(",,,@John", "Seattle"),
+                line("John", "Seattle=")
+            )
+        );
+
+        assertEquals(
+            line(
+                "John,Seattle",
+                "John,'=Seattle",
+                "John,\"'+Sea,ttle\"",
+                "\",-John\",Seattle",
+                "\",,,@John\",Seattle",
+                "John,Seattle="
+            ),
+            csv.getLines()
+        );
+    }
+
     private CSVResult csv(List<String> headers, List<List<String>> lines) {
         return new CSVResult(SEPARATOR, headers, lines);
     }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/455

*Description of changes:* We escape comma in a cell by double quote. However this is only applied to result for simple query. This PR is to apply the comma escape logic to CSV header and all queries.

*Code changes*: Enforce quote and sanitize action in final `CSVResult` to make sure anything generated to CSV would be handle.

*Test*: Passed all UT and IT. Added new UT and IT. Import CSV to Excel to manual check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
