### PR TITLE
Enhancement, add the field type conflict check in semantic check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ src/site-server/node_modules
 /out/
 .gradle/
 build/
+gen/
+*.tokens
 
 # various IDE files
 .vscode

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/scope/TypeSupplier.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/scope/TypeSupplier.java
@@ -1,0 +1,61 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.antlr.semantic.scope;
+
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.SemanticAnalysisException;
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.Type;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * The TypeSupplier is construct by the symbolName and symbolType.
+ * The TypeSupplier implement the {@link Supplier<Type>} interface to provide the {@link Type}.
+ * The TypeSupplier maintain types to track different {@link Type} definition for the same symbolName.
+ */
+public class TypeSupplier implements Supplier<Type> {
+    private final String symbolName;
+    private final Type symbolType;
+    private final Set<Type> types;
+
+    public TypeSupplier(String symbolName, Type symbolType) {
+        this.symbolName = symbolName;
+        this.symbolType = symbolType;
+        this.types = new HashSet<>();
+        this.types.add(symbolType);
+    }
+
+    public TypeSupplier add(Type type) {
+        types.add(type);
+        return this;
+    }
+
+    /**
+     * Get the {@link Type}
+     * Throw {@link SemanticAnalysisException} if conflict found.
+     * Currently, if the two type not equal, it been treated as conflict.
+     */
+    @Override
+    public Type get() {
+        if (types.size() > 1) {
+            throw new SemanticAnalysisException(
+                    String.format("Symbol [%s] have conflict type [%s]", symbolName, types));
+        } else {
+            return symbolType;
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/scope/TypeSupplier.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/scope/TypeSupplier.java
@@ -47,13 +47,13 @@ public class TypeSupplier implements Supplier<Type> {
     /**
      * Get the {@link Type}
      * Throw {@link SemanticAnalysisException} if conflict found.
-     * Currently, if the two type not equal, it been treated as conflict.
+     * Currently, if the two types not equal, they are treated as conflicting.
      */
     @Override
     public Type get() {
         if (types.size() > 1) {
             throw new SemanticAnalysisException(
-                    String.format("Symbol [%s] have conflict type [%s]", symbolName, types));
+                    String.format("Field [%s] have conflict type [%s]", symbolName, types));
         } else {
             return symbolType;
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/visitor/SemanticAnalyzer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/visitor/SemanticAnalyzer.java
@@ -62,6 +62,12 @@ public class SemanticAnalyzer implements GenericSqlParseTreeVisitor<Type> {
     }
 
     @Override
+    public Type visitSelectAllColumn() {
+        mappingLoader.visitSelectAllColumn();
+        return typeChecker.visitSelectAllColumn();
+    }
+
+    @Override
     public void visitAs(String alias, Type type) {
         mappingLoader.visitAs(unquoteSingleField(alias), type);
         typeChecker.visitAs(unquoteSingleField(alias), type);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/visitor/AntlrSqlParseTreeVisitor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/visitor/AntlrSqlParseTreeVisitor.java
@@ -199,7 +199,7 @@ public class AntlrSqlParseTreeVisitor<T extends Reducible> extends OpenDistroSql
 
     @Override
     public T visitTableNamePattern(TableNamePatternContext ctx) {
-        throw new EarlyExitAnalysisException("Exit when meeting index pattern");
+        return visitor.visitIndexName(ctx.getText());
     }
 
     @Override
@@ -244,6 +244,11 @@ public class AntlrSqlParseTreeVisitor<T extends Reducible> extends OpenDistroSql
                                        stream().
                                        map(this::visit).
                                        collect(Collectors.toList()));
+    }
+
+    @Override
+    public T visitSelectStarElement(OpenDistroSqlParser.SelectStarElementContext ctx) {
+        return visitor.visitSelectAllColumn();
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/visitor/GenericSqlParseTreeVisitor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/antlr/visitor/GenericSqlParseTreeVisitor.java
@@ -32,6 +32,10 @@ public interface GenericSqlParseTreeVisitor<T> {
         return defaultValue();
     }
 
+    default T visitSelectAllColumn() {
+        return defaultValue();
+    }
+
     default void visitAs(String alias, T type) {}
 
     default T visitIndexName(String indexName) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/matchtoterm/TermFieldScope.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/sql/rewriter/matchtoterm/TermFieldScope.java
@@ -17,9 +17,14 @@ package com.amazon.opendistroforelasticsearch.sql.rewriter.matchtoterm;
 
 import com.amazon.opendistroforelasticsearch.sql.esdomain.mapping.FieldMappings;
 import com.amazon.opendistroforelasticsearch.sql.esdomain.mapping.IndexMappings;
+import org.json.JSONObject;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Index Mapping information in current query being visited.
@@ -52,12 +57,28 @@ public class TermFieldScope {
         this.mapper = mapper;
     }
 
-    public FieldMappings getFinalMapping() {
-        return this.finalMapping;
+    public Optional<Map<String, Object>> resolveFieldMapping(String fieldName) {
+        Set<FieldMappings> indexMappings = mapper.allMappings().stream().
+                flatMap(typeMappings -> typeMappings.allMappings().stream()).
+                collect(Collectors.toSet());
+        Optional<Map<String, Object>> resolvedMapping =
+                indexMappings.stream()
+                        .filter(mapping -> mapping.has(fieldName))
+                        .map(mapping -> mapping.mapping(fieldName)).reduce((map1, map2) -> {
+                    if (!map1.equals(map2)) {
+                        // TODO: Merge mappings if they are compatible, for text and text/keyword to text/keyword.
+                        String exceptionReason = String.format(Locale.ROOT, "Different mappings are not allowed "
+                                        + "for the same field[%s]: found [%s] and [%s] ",
+                                fieldName, pretty(map1), pretty(map2));
+                        throw new VerificationException(exceptionReason);
+                    }
+                    return map1;
+                });
+        return resolvedMapping;
     }
 
-    public void setFinalMapping(FieldMappings finalMapping) {
-        this.finalMapping = finalMapping;
+    private static String pretty(Map<String, Object> mapping) {
+        return new JSONObject(mapping).toString().replaceAll("\"", "");
     }
 
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerFieldTypeTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerFieldTypeTest.java
@@ -1,0 +1,107 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.antlr.semantic;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.amazon.opendistroforelasticsearch.sql.util.MultipleIndexClusterUtils.mockMultipleIndexEnv;
+
+public class SemanticAnalyzerFieldTypeTest extends SemanticAnalyzerTestBase {
+    @Before
+    public void setup() {
+        mockMultipleIndexEnv();
+    }
+
+    /**
+     * id has same type in account1 and account2.
+     */
+    @Test
+    public void accessFieldTypeNotInQueryPassSemanticCheck() {
+        validate("SELECT id FROM account* WHERE id = 1");
+    }
+
+    /**
+     * address doesn't exist in account1.
+     */
+    @Test
+    public void accessFieldTypeOnlyInOneIndexPassSemanticCheck() {
+        validate("SELECT address FROM account* WHERE id = 30");
+    }
+
+    /**
+     * age has different type in account1 and account2.
+     */
+    @Test
+    public void accessConflictFieldTypeShouldFailSemanticCheck() {
+        expectValidationFailWithErrorMessages("SELECT age FROM account* WHERE age = 30",
+                "Symbol [age] have conflict type");
+    }
+
+    /**
+     * age has different type in account1 and account2.
+     */
+    @Test
+    public void mixNonConflictTypeAndConflictFieldTypeShouldFailSemanticCheck() {
+        expectValidationFailWithErrorMessages("SELECT id, age FROM account* WHERE id = 1",
+                "Symbol [age] have conflict type");
+    }
+
+    /**
+     * age has different type in account1 and account2.
+     */
+    @Test
+    public void ConflictFieldTypeWithAliasShouldFailSemanticCheck() {
+        expectValidationFailWithErrorMessages("SELECT a.age FROM account* as a",
+                "Symbol [a.age] have conflict type");
+    }
+
+    /**
+     * age has different type in account1 and account2.
+     * Todo, the error message is not accurate.
+     */
+    @Test
+    public void selectAllFieldTypeShouldFailSemanticCheck() {
+        expectValidationFailWithErrorMessages("SELECT * FROM account*",
+                "Symbol [account*.age] have conflict type");
+    }
+
+    /**
+     * age has different type in account1 and account2.
+     */
+    @Test
+    public void selectAllFieldTypeWithAliasShouldFailSemanticCheck() {
+        expectValidationFailWithErrorMessages("SELECT a.* FROM account* as a",
+                "Symbol [a.age] have conflict type");
+    }
+
+    /**
+     * a.projects.name has same type in account1 and account2.
+     */
+    @Test
+    public void selectNestedNoneConflictTypeShouldPassSemanticCheck() {
+        validate("SELECT a.projects.name FROM account* as a");
+    }
+
+    /**
+     * a.projects.started_year has conflict type in account1 and account2.
+     */
+    @Test
+    public void selectNestedConflictTypeShouldFailSemanticCheck() {
+        expectValidationFailWithErrorMessages("SELECT a.projects.started_year FROM account* as a",
+                "Symbol [a.projects.started_year] have conflict type");
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerFieldTypeTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerFieldTypeTest.java
@@ -48,7 +48,7 @@ public class SemanticAnalyzerFieldTypeTest extends SemanticAnalyzerTestBase {
     @Test
     public void accessConflictFieldTypeShouldFailSemanticCheck() {
         expectValidationFailWithErrorMessages("SELECT age FROM account* WHERE age = 30",
-                "Symbol [age] have conflict type");
+                "Field [age] have conflict type");
     }
 
     /**
@@ -57,16 +57,16 @@ public class SemanticAnalyzerFieldTypeTest extends SemanticAnalyzerTestBase {
     @Test
     public void mixNonConflictTypeAndConflictFieldTypeShouldFailSemanticCheck() {
         expectValidationFailWithErrorMessages("SELECT id, age FROM account* WHERE id = 1",
-                "Symbol [age] have conflict type");
+                "Field [age] have conflict type");
     }
 
     /**
      * age has different type in account1 and account2.
      */
     @Test
-    public void ConflictFieldTypeWithAliasShouldFailSemanticCheck() {
+    public void conflictFieldTypeWithAliasShouldFailSemanticCheck() {
         expectValidationFailWithErrorMessages("SELECT a.age FROM account* as a",
-                "Symbol [a.age] have conflict type");
+                "Field [a.age] have conflict type");
     }
 
     /**
@@ -76,7 +76,7 @@ public class SemanticAnalyzerFieldTypeTest extends SemanticAnalyzerTestBase {
     @Test
     public void selectAllFieldTypeShouldFailSemanticCheck() {
         expectValidationFailWithErrorMessages("SELECT * FROM account*",
-                "Symbol [account*.age] have conflict type");
+                "Field [account*.age] have conflict type");
     }
 
     /**
@@ -85,7 +85,7 @@ public class SemanticAnalyzerFieldTypeTest extends SemanticAnalyzerTestBase {
     @Test
     public void selectAllFieldTypeWithAliasShouldFailSemanticCheck() {
         expectValidationFailWithErrorMessages("SELECT a.* FROM account* as a",
-                "Symbol [a.age] have conflict type");
+                "Field [a.age] have conflict type");
     }
 
     /**
@@ -102,6 +102,6 @@ public class SemanticAnalyzerFieldTypeTest extends SemanticAnalyzerTestBase {
     @Test
     public void selectNestedConflictTypeShouldFailSemanticCheck() {
         expectValidationFailWithErrorMessages("SELECT a.projects.started_year FROM account* as a",
-                "Symbol [a.projects.started_year] have conflict type");
+                "Field [a.projects.started_year] have conflict type");
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerFromClauseTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerFromClauseTest.java
@@ -35,13 +35,21 @@ public class SemanticAnalyzerFromClauseTest extends SemanticAnalyzerTestBase {
     }
 
     @Test
-    public void useIndexPatternShouldSkipAllCheck() {
-        validate("SELECT abc FROM semant* WHERE def = 1");
+    public void useNotExistFieldInIndexPatternShouldFail() {
+        expectValidationFailWithErrorMessages(
+                "SELECT abc FROM semant* WHERE def = 1",
+                "Field [def] cannot be found or used here.",
+                "Did you mean [address]?"
+        );
     }
 
     @Test
-    public void useIndexAndIndexPatternShouldSkipAllCheck() {
-        validate("SELECT abc FROM semantics, semant* WHERE def = 1");
+    public void useNotExistFieldInIndexAndIndexPatternShouldFail() {
+        expectValidationFailWithErrorMessages(
+                "SELECT abc FROM semantics, semant* WHERE def = 1",
+                "Field [def] cannot be found or used here.",
+                "Did you mean [address]?"
+        );
     }
 
     /**

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/scope/TypeSupplierTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/scope/TypeSupplierTest.java
@@ -21,7 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class TypeSupplierTest {
     @Rule
@@ -48,7 +48,7 @@ public class TypeSupplierTest {
         age.add(ESDataType.TEXT);
 
         exception.expect(SemanticAnalysisException.class);
-        exception.expectMessage("Symbol [age] have conflict type");
+        exception.expectMessage("Field [age] have conflict type");
         age.get();
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/scope/TypeSupplierTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/scope/TypeSupplierTest.java
@@ -1,0 +1,54 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.antlr.semantic.scope;
+
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.SemanticAnalysisException;
+import com.amazon.opendistroforelasticsearch.sql.antlr.semantic.types.base.ESDataType;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.*;
+
+public class TypeSupplierTest {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void haveOneTypeShouldPass() {
+        TypeSupplier age = new TypeSupplier("age", ESDataType.INTEGER);
+
+        assertEquals(ESDataType.INTEGER, age.get());
+    }
+
+    @Test
+    public void addSameTypeShouldPass() {
+        TypeSupplier age = new TypeSupplier("age", ESDataType.INTEGER);
+        age.add(ESDataType.INTEGER);
+
+        assertEquals(ESDataType.INTEGER, age.get());
+    }
+
+    @Test
+    public void haveTwoTypesShouldThrowException() {
+        TypeSupplier age = new TypeSupplier("age", ESDataType.INTEGER);
+        age.add(ESDataType.TEXT);
+
+        exception.expect(SemanticAnalysisException.class);
+        exception.expectMessage("Symbol [age] have conflict type");
+        age.get();
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
@@ -109,7 +109,7 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
         } catch (ResponseException e) {
             assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.BAD_REQUEST.getStatus()));
             final String entity = TestUtils.getResponseBody(e.getResponse());
-            assertThat(entity, containsString("Symbol [holdersName] have conflict type"));
+            assertThat(entity, containsString("Field [holdersName] have conflict type"));
             assertThat(entity, containsString("\"type\": \"SemanticAnalysisException\""));
         }
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TermQueryExplainIT.java
@@ -71,8 +71,8 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
         } catch (ResponseException e) {
             assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.BAD_REQUEST.getStatus()));
             final String entity = TestUtils.getResponseBody(e.getResponse());
-            assertThat(entity, containsString("Unknown index"));
-            assertThat(entity, containsString("\"type\": \"VerificationException\""));
+            assertThat(entity, containsString("Field [firstname] cannot be found or used here."));
+            assertThat(entity, containsString("\"type\": \"SemanticAnalysisException\""));
         }
     }
 
@@ -109,11 +109,23 @@ public class TermQueryExplainIT extends SQLIntegTestCase {
         } catch (ResponseException e) {
             assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.BAD_REQUEST.getStatus()));
             final String entity = TestUtils.getResponseBody(e.getResponse());
-            assertThat(entity, containsString("dog_name"));
-            assertThat(entity, containsString("{type:text,fields:{keyword:{type:keyword,ignore_above:256}}}"));
-            assertThat(entity, containsString("{type:text,fielddata:true}"));
-            assertThat(entity, containsString("\"type\": \"VerificationException\""));
+            assertThat(entity, containsString("Symbol [holdersName] have conflict type"));
+            assertThat(entity, containsString("\"type\": \"SemanticAnalysisException\""));
         }
+    }
+
+    /**
+     * The dog_name field has same type in dog and dog2 index.
+     * But, the holdersName field has different type.
+     */
+    @Test
+    public void testNonCompatibleMappingsButTheFieldIsNotUsed() throws IOException {
+        String result = explainQuery(
+                "SELECT dog_name " +
+                        "FROM elasticsearch-sql_test_index_dog, elasticsearch-sql_test_index_dog2 WHERE dog_name = 'dog'");
+        System.out.println(result);
+        assertThat(result, containsString("dog_name"));
+        assertThat(result, containsString("_source"));
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/TestUtils.java
@@ -199,6 +199,10 @@ public class TestUtils {
     public static String getDogs2IndexMapping() {
         return "{  \"mappings\": {" +
                 " \"properties\": {\n" +
+                "          \"dog_name\": {\n" +
+                "            \"type\": \"text\",\n" +
+                "            \"fielddata\": true\n" +
+                "          },\n"+
                 "          \"holdersName\": {\n" +
                 "            \"type\": \"keyword\"\n" +
                 "          }"+

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/CheckScriptContents.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/CheckScriptContents.java
@@ -222,7 +222,7 @@ public class CheckScriptContents {
 
     }
 
-    private static XContentParser createParser(String mappings) throws IOException {
+    public static XContentParser createParser(String mappings) throws IOException {
         return XContentType.JSON.xContent().createParser(
             NamedXContentRegistry.EMPTY,
             DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
@@ -254,7 +254,7 @@ public class CheckScriptContents {
         return mockService;
     }
 
-    private static IndexNameExpressionResolver mockIndexNameExpressionResolver() {
+    public static IndexNameExpressionResolver mockIndexNameExpressionResolver() {
         IndexNameExpressionResolver mockResolver = mock(IndexNameExpressionResolver.class);
         when(mockResolver.concreteIndexNames(any(), any(), any())).thenAnswer(
             (Answer<String[]>) invocation -> {
@@ -269,7 +269,7 @@ public class CheckScriptContents {
         return mockResolver;
     }
 
-    private static SqlSettings mockSqlSettings() {
+    public static SqlSettings mockSqlSettings() {
         SqlSettings settings = spy(new SqlSettings());
 
         // Force return empty list to avoid ClusterSettings be invoked which is a final class and hard to mock.

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MultipleIndexClusterUtils.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MultipleIndexClusterUtils.java
@@ -1,0 +1,208 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.util;
+
+import com.amazon.opendistroforelasticsearch.sql.esdomain.LocalClusterState;
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents.createParser;
+import static com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents.mockIndexNameExpressionResolver;
+import static com.amazon.opendistroforelasticsearch.sql.util.CheckScriptContents.mockSqlSettings;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test Utility which provide the cluster have 2 indices.
+ */
+public class MultipleIndexClusterUtils {
+    public final static String INDEX_ACCOUNT_1 = "account1";
+    public final static String INDEX_ACCOUNT_2 = "account2";
+    public final static String INDEX_ACCOUNT_ALL = "account*";
+
+    public static String INDEX_ACCOUNT_1_MAPPING = "{\n" +
+            "  \"field_mappings\": {\n" +
+            "    \"mappings\": {\n" +
+            "      \"account1\": {\n" +
+            "        \"properties\": {\n" +
+            "          \"id\": {\n" +
+            "            \"type\": \"long\"\n" +
+            "          },\n" +
+            "          \"address\": {\n" +
+            "            \"type\": \"text\",\n" +
+            "            \"fields\": {\n" +
+            "              \"keyword\": {\n" +
+            "                \"type\": \"keyword\"\n" +
+            "              }\n" +
+            "            },\n" +
+            "            \"fielddata\": true\n" +
+            "          },\n" +
+            "          \"age\": {\n" +
+            "            \"type\": \"integer\"\n" +
+            "          },\n" +
+            "          \"projects\": {\n" +
+            "            \"type\": \"nested\",\n" +
+            "            \"properties\": {\n" +
+            "              \"name\": {\n" +
+            "                \"type\": \"text\",\n" +
+            "                \"fields\": {\n" +
+            "                  \"keyword\": {\n" +
+            "                    \"type\": \"keyword\"\n" +
+            "                  }\n" +
+            "                },\n" +
+            "                \"fielddata\": true\n" +
+            "              },\n" +
+            "              \"started_year\": {\n" +
+            "                \"type\": \"int\"\n" +
+            "              }\n" +
+            "            }\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "    },\n" +
+            "    \"settings\": {\n" +
+            "      \"index\": {\n" +
+            "        \"number_of_shards\": 1,\n" +
+            "        \"number_of_replicas\": 0,\n" +
+            "        \"version\": {\n" +
+            "          \"created\": \"6050399\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    },\n" +
+            "    \"mapping_version\": \"1\",\n" +
+            "    \"settings_version\": \"1\"\n" +
+            "  }\n" +
+            "}";
+
+    /**
+     * The difference with account1.
+     * 1. missing address.
+     * 2. age has different type.
+     * 3. projects.started_year has different type.
+     */
+    public static String INDEX_ACCOUNT_2_MAPPING = "{\n" +
+            "  \"field_mappings\": {\n" +
+            "    \"mappings\": {\n" +
+            "      \"account2\": {\n" +
+            "        \"properties\": {\n" +
+            "          \"id\": {\n" +
+            "            \"type\": \"long\"\n" +
+            "          },\n" +
+            "          \"age\": {\n" +
+            "            \"type\": \"long\"\n" +
+            "          },\n" +
+            "          \"projects\": {\n" +
+            "            \"type\": \"nested\",\n" +
+            "            \"properties\": {\n" +
+            "              \"name\": {\n" +
+            "                \"type\": \"text\",\n" +
+            "                \"fields\": {\n" +
+            "                  \"keyword\": {\n" +
+            "                    \"type\": \"keyword\"\n" +
+            "                  }\n" +
+            "                },\n" +
+            "                \"fielddata\": true\n" +
+            "              },\n" +
+            "              \"started_year\": {\n" +
+            "                \"type\": \"long\"\n" +
+            "              }\n" +
+            "            }\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "    },\n" +
+            "    \"settings\": {\n" +
+            "      \"index\": {\n" +
+            "        \"number_of_shards\": 1,\n" +
+            "        \"number_of_replicas\": 0,\n" +
+            "        \"version\": {\n" +
+            "          \"created\": \"6050399\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    },\n" +
+            "    \"mapping_version\": \"1\",\n" +
+            "    \"settings_version\": \"1\"\n" +
+            "  }\n" +
+            "}";
+
+    public static void mockMultipleIndexEnv() {
+        mockLocalClusterState(new ImmutableMap.Builder<String, ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>>>()
+                .put(INDEX_ACCOUNT_1, buildIndexMapping(INDEX_ACCOUNT_1, INDEX_ACCOUNT_1_MAPPING))
+                .put(INDEX_ACCOUNT_2, buildIndexMapping(INDEX_ACCOUNT_2, INDEX_ACCOUNT_2_MAPPING))
+                .put(INDEX_ACCOUNT_ALL, buildIndexMapping(new ImmutableMap.Builder<String, String>()
+                        .put(INDEX_ACCOUNT_1, INDEX_ACCOUNT_1_MAPPING)
+                        .put(INDEX_ACCOUNT_2, INDEX_ACCOUNT_2_MAPPING)
+                        .build()))
+                .build());
+    }
+
+    public static void mockLocalClusterState(Map<String, ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>>> indexMapping) {
+        LocalClusterState.state().setClusterService(mockClusterService(indexMapping));
+        LocalClusterState.state().setResolver(mockIndexNameExpressionResolver());
+        LocalClusterState.state().setSqlSettings(mockSqlSettings());
+    }
+
+
+    public static ClusterService mockClusterService(Map<String, ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>>> indexMapping) {
+        ClusterService mockService = mock(ClusterService.class);
+        ClusterState mockState = mock(ClusterState.class);
+        MetaData mockMetaData = mock(MetaData.class);
+
+        when(mockService.state()).thenReturn(mockState);
+        when(mockState.metaData()).thenReturn(mockMetaData);
+        try {
+            for (Map.Entry<String, ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>>> entry : indexMapping.entrySet()) {
+                when(mockMetaData.findMappings(eq(new String[]{entry.getKey()}), any(), any())).thenReturn(entry.getValue());
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return mockService;
+    }
+
+    private static ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> buildIndexMapping(Map<String, String> indexMapping) {
+        try {
+            ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> builder = ImmutableOpenMap.builder();
+            for (Map.Entry<String, String> entry : indexMapping.entrySet()) {
+                builder.put(entry.getKey(), IndexMetaData.fromXContent(createParser(entry.getValue())).getMappings());
+            }
+            return builder.build();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static ImmutableOpenMap<String, ImmutableOpenMap<String, MappingMetaData>> buildIndexMapping(String index,
+                                                                                                         String mapping) {
+        try {
+            ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetaData>> builder = ImmutableOpenMap.builder();
+            builder.put(index, IndexMetaData.fromXContent(createParser(mapping)).getMappings());
+            return builder.build();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #348, #445 

*Description of changes:*
* Add wildcard index handing in semantic. If the field is used in query have conflict type in wildcard index, semantic exception will be thrown.
* The mapping conflict resolver logic in the TermFieldRewriter has been refined to do the lazy evaluation only when the field is accessed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
