### PR TITLE
Support Integration Tests for Security enabled ODFE cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ integTest.runner {
         testLogging.showStandardStreams true
 
         // Pass down system properties to IT class
-            systemProperty "esHost", System.getProperty("esHost")
+        systemProperty "esHost", System.getProperty("esHost")
         systemProperty "dbUrl", System.getProperty("dbUrl")
         systemProperty "otherDbUrls", System.getProperty("otherDbUrls")
         systemProperty "queries", System.getProperty("queries")

--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,10 @@ integTest.runner {
     // allows integration test classes to access test resource from project root path
     systemProperty('project.root', project.rootDir.absolutePath)
 
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
     // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
     // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
     doFirst { systemProperty 'cluster.debug', getDebug()}
@@ -151,7 +155,7 @@ integTest.runner {
         testLogging.showStandardStreams true
 
         // Pass down system properties to IT class
-        systemProperty "esHost", System.getProperty("esHost")
+            systemProperty "esHost", System.getProperty("esHost")
         systemProperty "dbUrl", System.getProperty("dbUrl")
         systemProperty "otherDbUrls", System.getProperty("otherDbUrls")
         systemProperty "queries", System.getProperty("queries")

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/FGACEnabledODFETestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/FGACEnabledODFETestCase.java
@@ -1,0 +1,120 @@
+package com.amazon.opendistroforelasticsearch.sql.esintgtest;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.common.io.PathUtils;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Map;
+
+public abstract class FGACEnabledODFETestCase extends ESRestTestCase {
+    protected String getProtocol() {
+        return "https";
+    }
+
+
+    protected RestClient buildClient(Settings settings, HttpHost[] hosts) throws IOException {
+        RestClientBuilder builder = RestClient.builder(hosts);
+        configureCustomClient(builder, settings);
+        builder.setStrictDeprecationMode(true);
+        return builder.build();
+    }
+
+    protected static void wipeAllODFEIndices() throws IOException {
+        Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json"));
+        JSONArray jsonArray = new JSONArray(EntityUtils.toString(response.getEntity(), "UTF-8"));
+        for (Object object : jsonArray) {
+            JSONObject jsonObject = (JSONObject)object;
+            String indexName = jsonObject.getString("index");
+            if (!".opendistro_security".equals(indexName)) {
+                client().performRequest(new Request("DELETE", "/" + indexName));
+            }
+        }
+    }
+    protected static void configureCustomClient(RestClientBuilder builder, Settings settings) throws IOException {
+        Map<String, String> headers = ThreadContext.buildDefaultHeaders(settings);
+        Header[] defaultHeaders = new Header[headers.size()];
+        int i = 0;
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            defaultHeaders[i++] = new BasicHeader(entry.getKey(), entry.getValue());
+        }
+        builder.setDefaultHeaders(defaultHeaders);
+        builder.setHttpClientConfigCallback(httpClientBuilder -> {
+            SSLContext sslcontext = null;
+            try {
+                sslcontext = SSLContext.getInstance("TLS");
+                try {
+                    sslcontext.init(
+                            null, new TrustManager[]{
+                                new X509TrustManager(){
+
+                                    @Override
+                                    public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+
+                                    }
+
+                                    @Override
+                                    public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+
+                                    }
+
+                                    @Override
+                                    public X509Certificate[] getAcceptedIssuers() {
+                                        return new X509Certificate[0];
+                                    }
+                                }
+                            }
+                            ,
+                            null);
+                } catch (KeyManagementException e) {
+                    e.printStackTrace();
+                }
+            } catch (NoSuchAlgorithmException e) {
+                e.printStackTrace();
+            }
+            SSLIOSessionStrategy sessionStrategy = new SSLIOSessionStrategy(sslcontext);
+
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials("admin", "admin"));
+            return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
+                    .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                    .setSSLStrategy(sessionStrategy);
+        });
+
+        final String socketTimeoutString = settings.get(CLIENT_SOCKET_TIMEOUT);
+        final TimeValue socketTimeout =
+                TimeValue.parseTimeValue(socketTimeoutString == null ? "60s" : socketTimeoutString, CLIENT_SOCKET_TIMEOUT);
+        builder.setRequestConfigCallback(conf -> conf.setSocketTimeout(Math.toIntExact(socketTimeout.getMillis())));
+        if (settings.hasValue(CLIENT_PATH_PREFIX)) {
+            builder.setPathPrefix(settings.get(CLIENT_PATH_PREFIX));
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ODFERestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ODFERestTestCase.java
@@ -25,6 +25,9 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * ODFE integration test base class to support both security disabled and enabled ODFE cluster.
+ */
 public abstract class ODFERestTestCase extends ESRestTestCase {
 
     protected boolean isHttps() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ODFERestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/ODFERestTestCase.java
@@ -1,3 +1,18 @@
+/*
+ *   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
 package com.amazon.opendistroforelasticsearch.sql.esintgtest;
 
 import org.apache.http.Header;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
@@ -78,7 +78,7 @@ import static com.amazon.opendistroforelasticsearch.sql.plugin.RestSqlAction.CUR
  *                                \                      \
  *   XXXTIT:                  3) init()             5) init()
  */
-public abstract class SQLIntegTestCase extends ESRestTestCase {
+public abstract class SQLIntegTestCase extends FGACEnabledODFETestCase {
 
     public static final String PERSISTENT = "persistent";
     public static final String TRANSIENT = "transient";
@@ -141,7 +141,7 @@ public abstract class SQLIntegTestCase extends ESRestTestCase {
      */
     @AfterClass
     public static void cleanUpIndices() throws IOException {
-        wipeAllIndices();
+        wipeAllODFEIndices();
         wipeAllClusterSettings();
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/SQLIntegTestCase.java
@@ -19,7 +19,6 @@ import com.google.common.base.Strings;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.test.rest.ESRestTestCase;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.AfterClass;
@@ -78,7 +77,7 @@ import static com.amazon.opendistroforelasticsearch.sql.plugin.RestSqlAction.CUR
  *                                \                      \
  *   XXXTIT:                  3) init()             5) init()
  */
-public abstract class SQLIntegTestCase extends FGACEnabledODFETestCase {
+public abstract class SQLIntegTestCase extends ODFERestTestCase {
 
     public static final String PERSISTENT = "persistent";
     public static final String TRANSIENT = "transient";


### PR DESCRIPTION
*Issue #, if available:*
Support to run integration test cases with security enabled cluster. 
*Description of changes:*

-  create new ODFERestTestCase to support both of normal and security enabled clusters
- update SQLIntegTestCase 

*Testing:*
run it with following 3 cases succesfully:
* ./gradlew integTest  
* ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200
* ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dhttps=true -Duser=admin -Dpassword=admin


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
