### PR TITLE
[PPL] Add ES rest client to support standalone mode

### DIFF
--- a/elasticsearch/build.gradle
+++ b/elasticsearch/build.gradle
@@ -11,6 +11,7 @@ repositories {
 dependencies {
     compile project(':core')
     compile group: 'org.elasticsearch', name: 'elasticsearch', version: "${es_version}"
+    compile group: 'org.elasticsearch.client', name: 'elasticsearch-rest-high-level-client', version:"${es_version}"
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchClient.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchClient.java
@@ -43,6 +43,12 @@ public interface ElasticsearchClient {
     ElasticsearchResponse search(ElasticsearchRequest request);
 
     /**
+     * Clean up resources related to the search request, for example scroll context.
+     * @param request       search request
+     */
+    void cleanup(ElasticsearchRequest request);
+
+    /**
      * Schedule a task to run.
      * @param task      task
      */

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClient.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClient.java
@@ -113,9 +113,12 @@ public class ElasticsearchNodeClient implements ElasticsearchClient {
 
     @Override
     public void cleanup(ElasticsearchRequest request) {
-        client.prepareClearScroll().
-               addScrollId(request.getScrollId()).
-               get();
+        if (request.isScrollStarted()) {
+            client.prepareClearScroll().
+                   addScrollId(request.getScrollId()).
+                   get();
+            request.reset();
+        }
     }
 
     @Override

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClient.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClient.java
@@ -101,16 +101,21 @@ public class ElasticsearchNodeClient implements ElasticsearchClient {
             esResponse = client.searchScroll(request.scrollRequest()).actionGet();
         } else {
             esResponse = client.search(request.searchRequest()).actionGet();
-            request.setScrollId(esResponse.getScrollId());
         }
+        request.setScrollId(esResponse.getScrollId());
 
         ElasticsearchResponse response = new ElasticsearchResponse(esResponse);
         if (response.isEmpty()) {
-            client.prepareClearScroll().
-                   addScrollId(esResponse.getScrollId()).
-                   get();
+            cleanup(request);
         }
         return response;
+    }
+
+    @Override
+    public void cleanup(ElasticsearchRequest request) {
+        client.prepareClearScroll().
+               addScrollId(request.getScrollId()).
+               get();
     }
 
     @Override

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClient.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClient.java
@@ -104,11 +104,7 @@ public class ElasticsearchNodeClient implements ElasticsearchClient {
         }
         request.setScrollId(esResponse.getScrollId());
 
-        ElasticsearchResponse response = new ElasticsearchResponse(esResponse);
-        if (response.isEmpty()) {
-            cleanup(request);
-        }
-        return response;
+        return new ElasticsearchResponse(esResponse);
     }
 
     @Override

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClient.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClient.java
@@ -33,6 +33,8 @@ import java.util.stream.Collectors;
 
 /**
  * Elasticsearch REST client to support standalone mode that runs entire engine from remote.
+ *
+ * TODO: Support for authN and authZ with AWS Sigv4 or security plugin.
  */
 @RequiredArgsConstructor
 public class ElasticsearchRestClient implements ElasticsearchClient {

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClient.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClient.java
@@ -1,0 +1,93 @@
+/*
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.elasticsearch.client;
+
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.mapping.IndexMapping;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.request.ElasticsearchRequest;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.ElasticsearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Elasticsearch REST client to support standalone mode that runs entire engine from remote.
+ */
+@RequiredArgsConstructor
+public class ElasticsearchRestClient implements ElasticsearchClient {
+
+    /**
+     * Elasticsearch high level REST client
+     */
+    private final RestHighLevelClient client;
+
+
+    @Override
+    public Map<String, IndexMapping> getIndexMappings(String indexExpression) {
+        GetMappingsRequest request = new GetMappingsRequest().indices(indexExpression);
+        try {
+            GetMappingsResponse response = client.indices().getMapping(request, RequestOptions.DEFAULT);
+            return response.mappings().
+                            entrySet().
+                            stream().
+                            collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                e -> new IndexMapping(e.getValue()))
+                            );
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                "Failed to get index mappings for " + indexExpression, e);
+        }
+    }
+
+    @Override
+    public ElasticsearchResponse search(ElasticsearchRequest request) {
+        try {
+            SearchResponse esResponse;
+            if (request.isScrollStarted()) {
+                esResponse = client.scroll(request.scrollRequest(), RequestOptions.DEFAULT);
+            } else {
+                esResponse = client.search(request.searchRequest(), RequestOptions.DEFAULT);
+                request.setScrollId(esResponse.getScrollId());
+            }
+
+            ElasticsearchResponse response = new ElasticsearchResponse(esResponse);
+            if (response.isEmpty()) {
+                ClearScrollRequest clearRequest = new ClearScrollRequest();
+                clearRequest.addScrollId(esResponse.getScrollId());
+                client.clearScroll(clearRequest, RequestOptions.DEFAULT);
+            }
+            return response;
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                "Failed to perform search operation with request=" + request, e);
+        }
+    }
+
+    @Override
+    public void schedule(Runnable task) {
+        task.run();
+    }
+
+}

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClient.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClient.java
@@ -88,12 +88,18 @@ public class ElasticsearchRestClient implements ElasticsearchClient {
     @Override
     public void cleanup(ElasticsearchRequest request) {
         try {
+            if (!request.isScrollStarted()) {
+                return;
+            }
+
             ClearScrollRequest clearRequest = new ClearScrollRequest();
             clearRequest.addScrollId(request.getScrollId());
             client.clearScroll(clearRequest, RequestOptions.DEFAULT);
         } catch (IOException e) {
             throw new IllegalStateException(
                 "Failed to clean up resources for search request " + request, e);
+        } finally {
+            request.reset();
         }
     }
 

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClient.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClient.java
@@ -50,9 +50,7 @@ public class ElasticsearchRestClient implements ElasticsearchClient {
         GetMappingsRequest request = new GetMappingsRequest().indices(indexExpression);
         try {
             GetMappingsResponse response = client.indices().getMapping(request, RequestOptions.DEFAULT);
-            return response.mappings().
-                            entrySet().
-                            stream().
+            return response.mappings().entrySet().stream().
                             collect(Collectors.toMap(
                                 Map.Entry::getKey,
                                 e -> new IndexMapping(e.getValue()))
@@ -74,11 +72,7 @@ public class ElasticsearchRestClient implements ElasticsearchClient {
             }
             request.setScrollId(esResponse.getScrollId());
 
-            ElasticsearchResponse response = new ElasticsearchResponse(esResponse);
-            if (response.isEmpty()) {
-                cleanup(request);
-            }
-            return response;
+            return new ElasticsearchResponse(esResponse);
         } catch (IOException e) {
             throw new IllegalStateException(
                 "Failed to perform search operation with request " + request, e);

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchRequest.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchRequest.java
@@ -33,6 +33,7 @@ import java.util.Objects;
  */
 @EqualsAndHashCode
 @RequiredArgsConstructor
+@Getter
 @ToString
 public class ElasticsearchRequest {
 
@@ -56,7 +57,6 @@ public class ElasticsearchRequest {
     /**
      * Search request source builder.
      */
-    @Getter
     private final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
 
     /**

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchRequest.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchRequest.java
@@ -87,4 +87,11 @@ public class ElasticsearchRequest {
                                          scrollId(scrollId);
     }
 
+    /**
+     * Reset internal state
+     */
+    public void reset() {
+        scrollId = null;
+    }
+
 }

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchRequest.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchRequest.java
@@ -29,7 +29,10 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import java.util.Objects;
 
 /**
- * Elasticsearch search request
+ * Elasticsearch search request. This has to be stateful because it needs to:
+ *
+ *  1) Accumulate search source builder when visiting logical plan to push down operation
+ *  2) Maintain scroll ID between calls to client search method
  */
 @EqualsAndHashCode
 @RequiredArgsConstructor
@@ -88,7 +91,8 @@ public class ElasticsearchRequest {
     }
 
     /**
-     * Reset internal state
+     * Reset internal state in case any stale data. However, ideally the same instance
+     * is not supposed to be reused across different physical plan.
      */
     public void reset() {
         scrollId = null;

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScan.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScan.java
@@ -63,6 +63,8 @@ public class ElasticsearchIndexScan extends TableScanOperator {
 
     @Override
     public void open() {
+        super.open();
+
         // For now pull all results immediately once open
         List<ElasticsearchResponse> responses = new ArrayList<>();
         ElasticsearchResponse response = client.search(request);
@@ -81,6 +83,13 @@ public class ElasticsearchIndexScan extends TableScanOperator {
     @Override
     public ExprValue next() {
         return ExprValueUtils.fromObjectValue(hits.next().getSourceAsMap());
+    }
+
+    @Override
+    public void close() {
+        super.close();
+
+        client.cleanup(request);
     }
 
 }

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
@@ -178,9 +178,8 @@ class ElasticsearchNodeClientTest {
     void schedule() {
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.preserveContext(any())).then(invocation -> invocation.getArgument(0));
+        when(nodeClient.threadPool()).thenReturn(threadPool);
 
-        // Instantiate NodeClient because Mockito cannot mock final method threadPool()
-        nodeClient = new NodeClient(Settings.EMPTY, threadPool);
         doAnswer(invocation -> {
             Runnable task = invocation.getArgument(0);
             task.run();

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
@@ -62,6 +62,8 @@ import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -208,11 +210,22 @@ class ElasticsearchNodeClientTest {
         ElasticsearchRequest request = new ElasticsearchRequest("test");
         request.setScrollId("scroll123");
         client.cleanup(request);
+        assertFalse(request.isScrollStarted());
 
         InOrder inOrder = Mockito.inOrder(nodeClient, requestBuilder);
         inOrder.verify(nodeClient).prepareClearScroll();
         inOrder.verify(requestBuilder).addScrollId("scroll123");
         inOrder.verify(requestBuilder).get();
+    }
+
+    @Test
+    void cleanupAgain() {
+        ElasticsearchNodeClient client = new ElasticsearchNodeClient(mock(ClusterService.class),
+                                                                     nodeClient);
+
+        ElasticsearchRequest request = new ElasticsearchRequest("test");
+        client.cleanup(request);
+        verify(nodeClient, never()).prepareClearScroll();
     }
 
     private ElasticsearchNodeClient mockClient(String indexName, String mappings) {

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
@@ -160,9 +160,6 @@ class ElasticsearchNodeClientTest {
         when(scrollResponse.getScrollId()).thenReturn("scroll456");
         when(scrollResponse.getHits()).thenReturn(SearchHits.empty());
 
-        // Mock clear scroll request
-        when(nodeClient.prepareClearScroll().addScrollId("scroll456").get()).thenReturn(null);
-
         // Verify response for first scroll request
         ElasticsearchRequest request = new ElasticsearchRequest("test");
         ElasticsearchResponse response1 = client.search(request);

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
@@ -216,7 +216,7 @@ class ElasticsearchNodeClientTest {
     }
 
     @Test
-    void cleanupAgain() {
+    void cleanupWithoutScrollId() {
         ElasticsearchNodeClient client = new ElasticsearchNodeClient(mock(ClusterService.class),
                                                                      nodeClient);
 

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
@@ -1,0 +1,73 @@
+/*
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.elasticsearch.client;
+
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.mapping.IndexMapping;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.GetFieldMappingsRequest;
+import org.elasticsearch.client.indices.GetFieldMappingsResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.elasticsearch.client.indices.GetFieldMappingsResponse.*;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ElasticsearchRestClientTest {
+
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    private RestHighLevelClient restClient;
+
+    private ElasticsearchRestClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = new ElasticsearchRestClient(restClient);
+    }
+
+    @Test
+    void getIndexMappings() throws IOException {
+        String indexName = "test";
+        Map<String, Map<String, FieldMappingMetaData>> indexMappings = new HashMap<>();
+        Map<String, FieldMappingMetaData> fieldMappings = new HashMap<>();
+
+
+        indexMappings.put(indexName, fieldMappings);
+
+        GetFieldMappingsResponse response = mock(GetFieldMappingsResponse.class);
+        when(response.mappings()).thenReturn(indexMappings);
+        when(restClient.indices().getFieldMapping(
+            any(GetFieldMappingsRequest.class), any())).thenReturn(response);
+
+        Map<String, IndexMapping> actual = client.getIndexMappings(indexName);
+    }
+
+    @Test
+    void search() {
+    }
+
+    @Test
+    void schedule() {
+    }
+}

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
@@ -54,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -170,6 +171,14 @@ class ElasticsearchRestClientTest {
         request.setScrollId("scroll123");
         client.cleanup(request);
         verify(restClient).clearScroll(any(), any());
+        assertFalse(request.isScrollStarted());
+    }
+
+    @Test
+    void cleanupAgain() throws IOException {
+        ElasticsearchRequest request = new ElasticsearchRequest("test");
+        client.cleanup(request);
+        verify(restClient, never()).clearScroll(any(), any());
     }
 
     @Test

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
@@ -54,6 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -161,6 +162,23 @@ class ElasticsearchRestClientTest {
             isRun.set(true);
         });
         assertTrue(isRun.get());
+    }
+
+    @Test
+    void cleanup() throws IOException {
+        ElasticsearchRequest request = new ElasticsearchRequest("test");
+        request.setScrollId("scroll123");
+        client.cleanup(request);
+        verify(restClient).clearScroll(any(), any());
+    }
+
+    @Test
+    void cleanupWithIOException() throws IOException {
+        when(restClient.clearScroll(any(), any())).thenThrow(new IOException());
+
+        ElasticsearchRequest request = new ElasticsearchRequest("test");
+        request.setScrollId("scroll123");
+        assertThrows(IllegalStateException.class, () -> client.cleanup(request));
     }
 
     private Map<String, MappingMetaData> mockFieldMappings(String indexName, String mappings) throws IOException {

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
@@ -132,9 +132,6 @@ class ElasticsearchRestClientTest {
         when(scrollResponse.getScrollId()).thenReturn("scroll456");
         when(scrollResponse.getHits()).thenReturn(SearchHits.empty());
 
-        // Mock clear scroll request
-        when(restClient.clearScroll(any(), any())).thenReturn(null);
-
         // Verify response for first scroll request
         ElasticsearchRequest request = new ElasticsearchRequest("test");
         ElasticsearchResponse response1 = client.search(request);

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
@@ -172,7 +172,7 @@ class ElasticsearchRestClientTest {
     }
 
     @Test
-    void cleanupAgain() throws IOException {
+    void cleanupWithoutScrollId() throws IOException {
         ElasticsearchRequest request = new ElasticsearchRequest("test");
         client.cleanup(request);
         verify(restClient, never()).clearScroll(any(), any());

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/executor/ElasticsearchExecutionEngineTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/executor/ElasticsearchExecutionEngineTest.java
@@ -21,6 +21,7 @@ import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
 import com.amazon.opendistroforelasticsearch.sql.planner.physical.PhysicalPlan;
 import com.amazon.opendistroforelasticsearch.sql.storage.TableScanOperator;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,10 +38,12 @@ import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtil
 import static com.amazon.opendistroforelasticsearch.sql.executor.ExecutionEngine.QueryResponse;
 import static com.google.common.collect.ImmutableMap.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,7 +68,7 @@ class ElasticsearchExecutionEngineTest {
             tupleValue(of("name", "John", "age", 20)),
             tupleValue(of("name", "Allen", "age", 30))
         );
-        PhysicalPlan plan = mockPlan(expected);
+        FakePhysicalPlan plan = new FakePhysicalPlan(expected.iterator());
 
         ElasticsearchExecutionEngine executor = new ElasticsearchExecutionEngine(client);
         List<ExprValue> actual = new ArrayList<>();
@@ -80,7 +83,10 @@ class ElasticsearchExecutionEngineTest {
                 fail("Error occurred during execution", e);
             }
         });
+
+        assertTrue(plan.hasOpen);
         assertEquals(expected, actual);
+        assertTrue(plan.hasClosed);
     }
 
     @Test
@@ -103,22 +109,36 @@ class ElasticsearchExecutionEngineTest {
             }
         });
         assertEquals(expected, actual.get());
+        verify(plan).close();
     }
 
-    private PhysicalPlan mockPlan(List<ExprValue> values) {
-        return new TableScanOperator() {
-            private final Iterator<ExprValue> it = values.iterator();
+    @RequiredArgsConstructor
+    private static class FakePhysicalPlan extends TableScanOperator {
+        private final Iterator<ExprValue> it;
+        private boolean hasOpen;
+        private boolean hasClosed;
 
-            @Override
-            public boolean hasNext() {
-                return it.hasNext();
-            }
+        @Override
+        public void open() {
+            super.open();
+            hasOpen = true;
+        }
 
-            @Override
-            public ExprValue next() {
-                return it.next();
-            }
-        };
+        @Override
+        public void close() {
+            super.close();
+            hasClosed = true;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return it.hasNext();
+        }
+
+        @Override
+        public ExprValue next() {
+            return it.next();
+        }
     }
 
 }

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/ElasticsearchResponseTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/ElasticsearchResponseTest.java
@@ -57,6 +57,11 @@ class ElasticsearchResponseTest {
         when(esResponse.getHits()).thenReturn(SearchHits.empty());
         ElasticsearchResponse response2 = new ElasticsearchResponse(esResponse);
         assertTrue(response2.isEmpty());
+
+        when(esResponse.getHits()).thenReturn(
+            new SearchHits(null, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0));
+        ElasticsearchResponse response3 = new ElasticsearchResponse(esResponse);
+        assertTrue(response3.isEmpty());
     }
 
     @Test

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScanTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScanTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,6 +53,7 @@ class ElasticsearchIndexScanTest {
             indexScan.open();
             assertFalse(indexScan.hasNext());
         }
+        verify(client).cleanup(any());
     }
 
     @Test
@@ -80,6 +82,7 @@ class ElasticsearchIndexScanTest {
 
             assertFalse(indexScan.hasNext());
         }
+        verify(client).cleanup(any());
     }
 
     private void mockResponse(SearchHit[]... searchHitBatches) {

--- a/elasticsearch/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/elasticsearch/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.amazon.opendistroforelasticsearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
 
 /**
- * Run PPL with query engine outside Elasticsearch cluster.
+ * Run PPL with query engine outside Elasticsearch cluster. This IT doesn't require out plugin installed actually.
  * The client application, ex. JDBC driver, needs to initialize all components itself required by ppl service.
  */
 public class StandaloneIT extends PPLIntegTestCase {

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
@@ -1,0 +1,115 @@
+/*
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.ppl;
+
+import com.amazon.opendistroforelasticsearch.sql.common.response.ResponseListener;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchRestClient;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.executor.ElasticsearchExecutionEngine;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage.ElasticsearchStorageEngine;
+import com.amazon.opendistroforelasticsearch.sql.executor.ExecutionEngine;
+import com.amazon.opendistroforelasticsearch.sql.executor.ExecutionEngine.QueryResponse;
+import com.amazon.opendistroforelasticsearch.sql.ppl.antlr.PPLSyntaxParser;
+import com.amazon.opendistroforelasticsearch.sql.ppl.domain.PPLQueryRequest;
+import com.amazon.opendistroforelasticsearch.sql.protocol.response.QueryResult;
+import com.amazon.opendistroforelasticsearch.sql.protocol.response.format.SimpleJsonResponseFormatter;
+import com.amazon.opendistroforelasticsearch.sql.storage.StorageEngine;
+import org.elasticsearch.client.Node;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.amazon.opendistroforelasticsearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
+
+/**
+ * Run PPL with query engine outside Elasticsearch cluster.
+ * The client application, ex. JDBC driver, needs to initialize all components itself required by ppl service.
+ */
+public class StandaloneIT extends PPLIntegTestCase {
+
+    private RestHighLevelClient restClient;
+
+    private PPLService pplService;
+
+    @Override
+    public void init() {
+        restClient = new RestHighLevelClient(
+            RestClient.builder(client().getNodes().toArray(new Node[0])));
+
+        ElasticsearchClient client = new ElasticsearchRestClient(restClient);
+        StorageEngine storageEngine = new ElasticsearchStorageEngine(client);
+        ExecutionEngine executionEngine = new ElasticsearchExecutionEngine(client);
+        pplService = new PPLService(new PPLSyntaxParser(), storageEngine, executionEngine);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        restClient.close();
+        super.tearDown();
+    }
+
+    @Test
+    public void testSourceFieldQuery() throws IOException {
+        Request request1 = new Request("PUT", "/test/_doc/1?refresh=true");
+        request1.setJsonEntity("{\"name\": \"hello\", \"age\": 20}");
+        client().performRequest(request1);
+        Request request2 = new Request("PUT", "/test/_doc/2?refresh=true");
+        request2.setJsonEntity("{\"name\": \"world\", \"age\": 30}");
+        client().performRequest(request2);
+
+        AtomicReference<String> actual = new AtomicReference<>();
+        pplService.execute(
+            new PPLQueryRequest("source=test | fields name", null),
+            new ResponseListener<QueryResponse>() {
+
+            @Override
+            public void onResponse(QueryResponse response) {
+                QueryResult result = new QueryResult(response.getResults());
+                String json = new SimpleJsonResponseFormatter(PRETTY).format(result);
+                actual.set(json);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new IllegalStateException("Exception happened during execution", e);
+            }
+        });
+
+        assertNotNull(actual.get());
+        assertEquals(
+            "{\n" +
+            "  \"schema\": [{\n" +
+            "    \"name\": \"name\",\n" +
+            "    \"type\": \"string\"\n" +
+            "  }],\n" +
+            "  \"total\": 2,\n" +
+            "  \"datarows\": [\n" +
+            "    {\"row\": [\"hello\"]},\n" +
+            "    {\"row\": [\"world\"]}\n" +
+            "  ],\n" +
+            "  \"size\": 2\n" +
+            "}",
+            actual.get()
+        );
+    }
+
+}

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
@@ -76,25 +76,7 @@ public class StandaloneIT extends PPLIntegTestCase {
         request2.setJsonEntity("{\"name\": \"world\", \"age\": 30}");
         client().performRequest(request2);
 
-        AtomicReference<String> actual = new AtomicReference<>();
-        pplService.execute(
-            new PPLQueryRequest("source=test | fields name", null),
-            new ResponseListener<QueryResponse>() {
-
-            @Override
-            public void onResponse(QueryResponse response) {
-                QueryResult result = new QueryResult(response.getResults());
-                String json = new SimpleJsonResponseFormatter(PRETTY).format(result);
-                actual.set(json);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                throw new IllegalStateException("Exception happened during execution", e);
-            }
-        });
-
-        assertNotNull(actual.get());
+        String actual = executeByStandaloneQueryEngine("source=test | fields name");
         assertEquals(
             "{\n" +
             "  \"schema\": [{\n" +
@@ -108,8 +90,29 @@ public class StandaloneIT extends PPLIntegTestCase {
             "  ],\n" +
             "  \"size\": 2\n" +
             "}",
-            actual.get()
+            actual
         );
+    }
+
+    private String executeByStandaloneQueryEngine(String query) {
+        AtomicReference<String> actual = new AtomicReference<>();
+        pplService.execute(
+            new PPLQueryRequest(query, null),
+            new ResponseListener<QueryResponse>() {
+
+                @Override
+                public void onResponse(QueryResponse response) {
+                    QueryResult result = new QueryResult(response.getResults());
+                    String json = new SimpleJsonResponseFormatter(PRETTY).format(result);
+                    actual.set(json);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new IllegalStateException("Exception happened during execution", e);
+                }
+            });
+        return actual.get();
     }
 
 }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.amazon.opendistroforelasticsearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
 
 /**
- * Run PPL with query engine outside Elasticsearch cluster. This IT doesn't require out plugin installed actually.
+ * Run PPL with query engine outside Elasticsearch cluster. This IT doesn't require our plugin installed actually.
  * The client application, ex. JDBC driver, needs to initialize all components itself required by ppl service.
  */
 public class StandaloneIT extends PPLIntegTestCase {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/360

*Description of changes:* In this PR, a new implementation of our `ElasticsearchClient` is added to support running query engine outside Elasticsearch cluster. Meanwhile, a `cleanup` method is added to client so we can make sure resources related to a search, for example scroll context, is released if any exception.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
