### PR TITLE
Fix ANTLR grammar for negative integer and floating point number

### DIFF
--- a/src/main/antlr/OpenDistroSqlLexer.g4
+++ b/src/main/antlr/OpenDistroSqlLexer.g4
@@ -330,7 +330,7 @@ STRING_USER_NAME:                   (
 // Fragments for Literal primitives
 
 fragment EXPONENT_NUM_PART:         'E' [-+]? DEC_DIGIT+;
-fragment ID_LITERAL:                [A-Z_$0-9@]*?[A-Z_$\-]+?[A-Z_$\-0-9]*;
+fragment ID_LITERAL:                [A-Z_$0-9@]*?[A-Z_$]+?[A-Z_$\-0-9]*;
 fragment DQUOTA_STRING:             '"' ( '\\'. | '""' | ~('"'| '\\') )* '"';
 fragment SQUOTA_STRING:             '\'' ('\\'. | '\'\'' | ~('\'' | '\\'))* '\'';
 fragment BQUOTA_STRING:             '`' ( '\\'. | '``' | ~('`'|'\\'))* '`';

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerConstantTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/antlr/semantic/SemanticAnalyzerConstantTest.java
@@ -1,0 +1,33 @@
+/*
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.antlr.semantic;
+
+import org.junit.Test;
+
+public class SemanticAnalyzerConstantTest extends SemanticAnalyzerTestBase {
+
+    @Test
+    public void useNegativeIntegerShouldPass() {
+        validate("SELECT * FROM test WHERE age > -1");
+    }
+
+    @Test
+    public void useNegativeFloatingPointNumberShouldPass() {
+        validate("SELECT * FROM test WHERE balance > -1.23456");
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryAnalysisIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/sql/esintgtest/QueryAnalysisIT.java
@@ -20,14 +20,10 @@ import com.amazon.opendistroforelasticsearch.sql.antlr.syntax.SyntaxAnalysisExce
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlFeatureNotImplementedException;
 import com.amazon.opendistroforelasticsearch.sql.exception.SqlParseException;
 import com.amazon.opendistroforelasticsearch.sql.utils.StringUtils;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.client.RestClient;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -36,7 +32,6 @@ import java.io.IOException;
 import static com.amazon.opendistroforelasticsearch.sql.plugin.SqlSettings.QUERY_ANALYSIS_ENABLED;
 import static com.amazon.opendistroforelasticsearch.sql.plugin.SqlSettings.QUERY_ANALYSIS_SEMANTIC_SUGGESTION;
 import static com.amazon.opendistroforelasticsearch.sql.plugin.SqlSettings.QUERY_ANALYSIS_SEMANTIC_THRESHOLD;
-import static org.elasticsearch.common.xcontent.XContentType.JSON;
 import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.RestStatus.SERVICE_UNAVAILABLE;
@@ -248,6 +243,14 @@ public class QueryAnalysisIT extends SQLIntegTestCase {
         queryShouldThrowFeatureNotImplementedException(
                 "SELECT balance DIV age FROM elasticsearch-sql_test_index_bank",
                 "Operator [DIV] is not supported yet"
+        );
+    }
+
+    @Test
+    public void useNegativeNumberConstantShouldPass() {
+        queryShouldPassAnalysis(
+            "SELECT * FROM elasticsearch-sql_test_index_bank " +
+            "WHERE age > -1 AND balance < -123.456789"
         );
     }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/488

*Description of changes:* Fixed the wrong ANTLR grammar by removing dash from beginning of `ID` literal. This makes dash only be able to present in the middle of an identifier. So negative number started with dash won't be matched by `ID`.

Original MySQL grammar: https://github.com/antlr/grammars-v4/blob/master/sql/mysql/Positive-Technologies/MySqlLexer.g4#L1197

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
