### PR TITLE
Fix json formatter for consistency with SQL

### DIFF
--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLPluginIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLPluginIT.java
@@ -52,7 +52,7 @@ public class PPLPluginIT extends PPLIntegTestCase {
             "    \"type\": \"string\"\n" +
             "  }],\n" +
             "  \"total\": 1,\n" +
-            "  \"datarows\": [{\"row\": [\"hello\"]}],\n" +
+            "  \"datarows\": [[\"hello\"]],\n" +
             "  \"size\": 1\n" +
             "}\n",
             response

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
@@ -90,8 +90,8 @@ public class StandaloneIT extends PPLIntegTestCase {
             "  }],\n" +
             "  \"total\": 2,\n" +
             "  \"datarows\": [\n" +
-            "    {\"row\": [\"hello\"]},\n" +
-            "    {\"row\": [\"world\"]}\n" +
+            "    [\"hello\"],\n" +
+            "    [\"world\"]\n" +
             "  ],\n" +
             "  \"size\": 2\n" +
             "}",

--- a/protocol/src/main/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/SimpleJsonResponseFormatter.java
+++ b/protocol/src/main/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/SimpleJsonResponseFormatter.java
@@ -59,10 +59,17 @@ public class SimpleJsonResponseFormatter extends JsonResponseFormatter<QueryResu
 
         response.columnNameTypes().forEach((name, type) -> json.column(new Column(name, type)));
 
-        for (Object[] values : response) {
-            json.row(new DataRow(values));
-        }
+        json.datarows(fetchDataRows(response));
         return json.build();
+    }
+
+    private Object[][] fetchDataRows(QueryResult response) {
+        Object[][] rows = new Object[response.size()][];
+        int i = 0;
+        for (Object[] values : response) {
+            rows[i++] = values;
+        }
+        return rows;
     }
 
     /**
@@ -74,8 +81,7 @@ public class SimpleJsonResponseFormatter extends JsonResponseFormatter<QueryResu
         @Singular("column")
         private final List<Column> schema;
 
-        @Singular("row")
-        private final List<DataRow> datarows;
+        private final Object[][] datarows;
 
         private long total;
         private long size;
@@ -86,12 +92,6 @@ public class SimpleJsonResponseFormatter extends JsonResponseFormatter<QueryResu
     public static class Column {
         private final String name;
         private final String type;
-    }
-
-    @RequiredArgsConstructor
-    @Getter
-    public static class DataRow {
-        private final Object[] row;
     }
 
 }

--- a/protocol/src/test/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/SimpleJsonResponseFormatterTest.java
+++ b/protocol/src/test/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/SimpleJsonResponseFormatterTest.java
@@ -39,7 +39,7 @@ class SimpleJsonResponseFormatterTest {
         SimpleJsonResponseFormatter formatter = new SimpleJsonResponseFormatter(COMPACT);
         assertEquals(
             "{\"schema\":[{\"name\":\"firstname\",\"type\":\"string\"},{\"name\":\"age\",\"type\":\"integer\"}]," +
-                "\"total\":2,\"datarows\":[{\"row\":[\"John\",20]},{\"row\":[\"Smith\",30]}],\"size\":2}",
+                "\"total\":2,\"datarows\":[[\"John\",20],[\"Smith\",30]],\"size\":2}",
             formatter.format(response)
         );
     }
@@ -65,14 +65,14 @@ class SimpleJsonResponseFormatterTest {
             "  ],\n" +
             "  \"total\": 2,\n" +
             "  \"datarows\": [\n" +
-            "    {\"row\": [\n" +
+            "    [\n" +
             "      \"John\",\n" +
             "      20\n" +
-            "    ]},\n" +
-            "    {\"row\": [\n" +
+            "    ],\n" +
+            "    [\n" +
             "      \"Smith\",\n" +
             "      30\n" +
-            "    ]}\n" +
+            "    ]\n" +
             "  ],\n" +
             "  \"size\": 2\n" +
             "}",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The JSON response format was slightly different from SQL's in the `datarows` field (with one more layer `row`). This PR is to fix the inconsistency so existing client such as SQL CLI can handle both response in the same way.

Example with this fix:

```
~ curl -H 'Content-Type: application/json' -XPOST "http://localhost:9200/_opendistro/_ppl" -d'
{
   "query": "source=accounts | fields id"
}'
{
  "schema": [{
    "name": "id",
    "type": "integer"
  }],
  "total": 2,
  "datarows": [
    [4],
    [5]
  ],
  "size": 2
}
```

Previously without fix:

```
~ curl -H 'Content-Type: application/json' -XPOST "http://localhost:9200/_opendistro/_ppl" -d'
{
   "query": "source=accounts | fields id"
}'
{
  "schema": [{
    "name": "id",
    "type": "integer"
  }],
  "total": 2,
  "datarows": [
    {"row": [4]},
    {"row": [5]}
  ],
  "size": 2
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
