### PR TITLE
[Bug] Support duplicated event for sort command

### DIFF
--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/SortOperator.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/SortOperator.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.PriorityQueue;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Singular;
@@ -76,11 +77,21 @@ public class SortOperator extends PhysicalPlan {
   @Override
   public void open() {
     super.open();
-    TreeMultiset<ExprValue> treeSet = TreeMultiset.create(sorter::compare);
+    PriorityQueue<ExprValue> sorted = new PriorityQueue<>(1, sorter::compare);
     while (input.hasNext()) {
-      treeSet.add(input.next());
+      sorted.add(input.next());
     }
-    iterator = Iterators.limit(treeSet.iterator(), count);
+    iterator = Iterators.limit(new Iterator<ExprValue>() {
+      @Override
+      public boolean hasNext() {
+        return !sorted.isEmpty();
+      }
+
+      @Override
+      public ExprValue next() {
+        return sorted.poll();
+      }
+    }, count);
   }
 
   @Override

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/utils/NullsFirstExprValueOrderingTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/utils/NullsFirstExprValueOrderingTest.java
@@ -20,6 +20,7 @@ import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtil
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.integerValue;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import org.junit.jupiter.api.Test;
 
 class NullsFirstExprValueOrderingTest {
@@ -35,5 +36,12 @@ class NullsFirstExprValueOrderingTest {
     ExprValueOrdering ordering = ExprValueOrdering.natural().nullsFirst().nullsLast();
     assertEquals(-1, ordering.compare(integerValue(5), LITERAL_NULL));
     assertEquals(-1, ordering.compare(integerValue(5), LITERAL_MISSING));
+  }
+
+  @Test
+  public void natural_null_first_compare_same_object() {
+    ExprValueOrdering ordering = ExprValueOrdering.natural().nullsFirst();
+    ExprValue exprValue = integerValue(5);
+    assertEquals(0, ordering.compare(exprValue, exprValue));
   }
 }

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/utils/NullsLastExprValueOrderingTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/utils/NullsLastExprValueOrderingTest.java
@@ -20,6 +20,7 @@ import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtil
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.integerValue;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import org.junit.jupiter.api.Test;
 
 class NullsLastExprValueOrderingTest {
@@ -35,5 +36,12 @@ class NullsLastExprValueOrderingTest {
     ExprValueOrdering ordering = ExprValueOrdering.natural().nullsLast().nullsFirst();
     assertEquals(1, ordering.compare(integerValue(5), LITERAL_NULL));
     assertEquals(1, ordering.compare(integerValue(5), LITERAL_MISSING));
+  }
+
+  @Test
+  public void natural_null_last_compare_same_object() {
+    ExprValueOrdering ordering = ExprValueOrdering.natural().nullsLast();
+    ExprValue exprValue = integerValue(5);
+    assertEquals(0, ordering.compare(exprValue, exprValue));
   }
 }


### PR DESCRIPTION
### Description of changes:
Fix the bug in sort command which will treat event with same sorted key as same event. e.g.
```
command: sort age

with input data
    [
      "Hattie",
      "Bond",
      36
    ],
    [
      "Elinor",
      "Ratliff",
      36
    ],
will generate out put data
    [
      "Hattie",
      "Bond",
      36
    ],
    [
      "Hattie",
      "Bond",
      36
    ],
```

Originally sort command use [TreeMultiSet](https://guava.dev/releases/19.0/api/docs/com/google/common/collect/Multiset.html) to store the sorted event. In TreeMultiSet, it declare support duplicate element, [but actuall it is not](https://github.com/google/guava/issues/3354).
The code change fix this bug by using the PriorityQueue instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
