### PR TITLE
[Bug Fix] Remove the GET request description in the SQL doc

### DIFF
--- a/docs/user/interfaces/endpoint.rst
+++ b/docs/user/interfaces/endpoint.rst
@@ -14,7 +14,7 @@ Endpoint
 Introduction
 ============
 
-To send query request to SQL plugin, you can either use a request parameter in HTTP GET or request body by HTTP POST request. POST request is recommended because it doesn't have length limitation and allows for other parameters passed to plugin for other functionality such as prepared statement. And also the explain endpoint is used very often for query translation and troubleshooting.
+To send query request to SQL plugin, you MUST use HTTP POST request. POST request doesn't have length limitation and allows for other parameters passed to plugin for other functionality such as prepared statement. And also the explain endpoint is used very often for query translation and troubleshooting.
 
 POST
 ====


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The GET endpoint already been disabled on https://github.com/opendistro-for-elasticsearch/sql/pull/414, but the document is not refreshed completely. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
