### PR TITLE
[PPL] Support expression in syntax

### DIFF
--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StatsCommandIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StatsCommandIT.java
@@ -15,11 +15,10 @@
 
 package com.amazon.opendistroforelasticsearch.sql.ppl;
 
-import org.junit.jupiter.api.Test;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 
 import java.io.IOException;
-
-import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
+import org.junit.jupiter.api.Test;
 
 public class StatsCommandIT extends PPLIntegTestCase {
 
@@ -81,4 +80,22 @@ public class StatsCommandIT extends PPLIntegTestCase {
   }
 
   // TODO: each stats aggregate function should be tested here when implemented
+
+  @Test
+  public void testStatsNested() throws IOException {
+    String result =
+        executeQueryToString(
+            String.format("source=%s | stats avg(abs(age)*2) as AGE", TEST_INDEX_ACCOUNT));
+    assertEquals(
+        "{\n"
+            + "  \"schema\": [{\n"
+            + "    \"name\": \"AGE\",\n"
+            + "    \"type\": \"double\"\n"
+            + "  }],\n"
+            + "  \"total\": 1,\n"
+            + "  \"datarows\": [[60.342]],\n"
+            + "  \"size\": 1\n"
+            + "}\n",
+        result);
+  }
 }

--- a/ppl/src/main/antlr/OpenDistroPPLParser.g4
+++ b/ppl/src/main/antlr/OpenDistroPPLParser.g4
@@ -72,7 +72,7 @@ sortCommand
     ;
 
 evalCommand
-    : EVAL evalExpression (COMMA evalExpression)*
+    : EVAL evalClause (COMMA evalClause)*
     ;
 
 /** clauses */
@@ -93,6 +93,10 @@ sortbyClause
     : sortField (COMMA sortField)*
     ;
 
+evalClause
+    : fieldExpression EQUAL expression
+    ;
+
 /** aggregation terms */
 statsAggTerm
     : statsFunction (AS alias=wcFieldExpression)?
@@ -100,7 +104,7 @@ statsAggTerm
 
 /** aggregation functions */
 statsFunction
-    : statsFunctionName LT_PRTHS fieldExpression RT_PRTHS           #statsFunctionCall
+    : statsFunctionName LT_PRTHS valueExpression RT_PRTHS           #statsFunctionCall
     | percentileAggFunction                                         #percentileAggFunctionCall
     ;
 
@@ -124,32 +128,32 @@ percentileAggFunction
 expression
     : logicalExpression
     | comparisonExpression
-    | evalFunctionCall
-    | binaryArithmetic
+    | valueExpression
     ;
 
 logicalExpression
     : comparisonExpression                                          #comparsion
-    | evalExpression                                                #eval
     | NOT logicalExpression                                         #logicalNot
     | left=logicalExpression OR right=logicalExpression             #logicalOr
     | left=logicalExpression (AND)? right=logicalExpression         #logicalAnd
     ;
 
-evalExpression
-    : fieldExpression EQUAL expression
-    ;
-
 comparisonExpression
-    : left=fieldExpression comparisonOperator
-    (field=fieldExpression | literal=literalValue)                  #compareExpr
-    | fieldExpression IN valueList                                  #inExpr
+    : left=valueExpression comparisonOperator right=valueExpression #compareExpr
+    | valueExpression IN valueList                                  #inExpr
     ;
 
-binaryArithmetic
-    : (leftField=fieldExpression | leftValue=literalValue) binaryOperator
-    (rightField=fieldExpression | rightValue=literalValue)
-    | LT_PRTHS binaryArithmetic RT_PRTHS
+valueExpression
+    : left=valueExpression binaryOperator right=valueExpression     #binaryArithmetic
+    | LT_PRTHS left=valueExpression binaryOperator
+    right=valueExpression RT_PRTHS                                  #parentheticBinaryArithmetic
+    | primaryExpression                                             #valueExpressionDefault
+    ;
+
+primaryExpression
+    : evalFunctionCall
+    | fieldExpression
+    | literalValue
     ;
 
 /** tables */
@@ -186,35 +190,15 @@ wcFieldExpression
     : wcQualifiedName
     ;
 
-
 /** functions */
 evalFunctionCall
     : evalFunctionName LT_PRTHS functionArgs RT_PRTHS
     ;
 
 evalFunctionName
-    : basicFunctionNameBase | esFunctionNameBase
-    ;
-
-basicFunctionNameBase
-    : ABS | ACOS | ADD | ASCII | ASIN | ATAN | ATAN2 | CBRT | CEIL | CONCAT | CONCAT_WS
-    | COS | COSH | COT | CURDATE | DATE | DATE_FORMAT | DAYOFMONTH | DEGREES
-    | E | EXP | EXPM1 | FLOOR | IF | IFNULL | ISNULL | LEFT | LENGTH | LN | LOCATE | LOG
-    | LOG10 | LOG2 | LOWER | LTRIM | MAKETIME | MODULUS | MONTH | MONTHNAME | MULTIPLY
-    | NOW | PI | POW | POWER | RADIANS | RAND | REPLACE | RIGHT | RINT | ROUND | RTRIM
-    | SIGN | SIGNUM | SIN | SINH | SQRT | SUBSTRING | SUBTRACT | TAN | TIMESTAMP | TRIM
-    | UPPER | YEAR | ADDDATE | ADDTIME | GREATEST | LEAST
-    ;
-
-esFunctionNameBase
-    : DATE_HISTOGRAM | DAY_OF_MONTH | DAY_OF_YEAR | DAY_OF_WEEK | EXCLUDE
-    | EXTENDED_STATS | FILTER | GEO_BOUNDING_BOX | GEO_CELL | GEO_DISTANCE | GEO_DISTANCE_RANGE | GEO_INTERSECTS
-    | GEO_POLYGON | INCLUDE | IN_TERMS | HISTOGRAM | HOUR_OF_DAY
-    | MATCHPHRASE | MATCH_PHRASE | MATCHQUERY | MATCH_QUERY | MINUTE_OF_DAY
-    | MINUTE_OF_HOUR | MISSING | MONTH_OF_YEAR | MULTIMATCH | MULTI_MATCH | NESTED
-    | PERCENTILES | QUERY | RANGE | REGEXP_QUERY | REVERSE_NESTED | SCORE
-    | SECOND_OF_MINUTE | STATS | TERM | TERMS | TOPHITS
-    | WEEK_OF_YEAR | WILDCARDQUERY | WILDCARD_QUERY
+    : mathematicalFunctionBase
+    | dateAndTimeFunctionBase
+    | textFunctionBase
     ;
 
 functionArgs
@@ -222,7 +206,19 @@ functionArgs
     ;
 
 functionArg
-    : expression | fieldExpression | literalValue
+    : valueExpression
+    ;
+
+mathematicalFunctionBase
+    : ABS
+    ;
+
+dateAndTimeFunctionBase
+    :
+    ;
+
+textFunctionBase
+    :
     ;
 
 /** operators */

--- a/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilder.java
@@ -190,7 +190,7 @@ public class AstBuilder extends OpenDistroPPLParserBaseVisitor<UnresolvedPlan> {
   @Override
   public UnresolvedPlan visitEvalCommand(EvalCommandContext ctx) {
     return new Eval(
-        ctx.evalExpression()
+        ctx.evalClause()
             .stream()
             .map(ct -> (Let) visitExpression(ct))
             .collect(Collectors.toList())

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilderTest.java
@@ -200,6 +200,39 @@ public class AstBuilderTest {
   }
 
   @Test
+  public void testStatsCommandWithNestedFunctions() {
+    assertEqual("source=t | stats sum(a+b)",
+        agg(
+            relation("t"),
+            exprList(
+                aggregate(
+                    "sum",
+                    function("+", field("a"), field("b"))
+                )),
+            emptyList(),
+            emptyList(),
+            defaultStatsArgs()
+        ));
+    assertEqual("source=t | stats sum(abs(a)/2)",
+        agg(
+            relation("t"),
+            exprList(
+                aggregate(
+                    "sum",
+                    function(
+                        "/",
+                        function("abs", field("a")),
+                        intLiteral(2)
+                    )
+                )
+            ),
+            emptyList(),
+            emptyList(),
+            defaultStatsArgs()
+        ));
+  }
+
+  @Test
   public void testDedupCommand() {
     assertEqual("source=t | dedup f1, f2",
         dedupe(

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -134,6 +134,14 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
                 function("+", field("a"), field("b"))
             )
         ));
+    assertEqual("source=t | eval f=(a+b)",
+        eval(
+            relation("t"),
+            let(
+                field("f"),
+                function("+", field("a"), field("b"))
+            )
+        ));
   }
 
   @Test


### PR DESCRIPTION
*Issue #, if available:*

* #515 

*Description of changes:*

**Support nested `valueExpression` in syntax and parser**
In our grammar file, the related nested expressions are structured as follows:
```
└─ expression
   |— logicalExpression
   |— comparisonExpression
      |— compareExpr ( := left=valueExpression comparisonOperator right=valueExpression )
      └─ inExpr ( := valueExpression IN valueList )
   └─ valueExpression
      |— binaryArithmetic ( := left=valueExpression binaryOperator right=valueExpression )
      └─ primaryExpression
         |— evalFunctionCall ( := evalFunctionName '(' valueExpression... ')' )
         |— fieldExpression
         └─ literalValue

└─ statsFunction ( := statsFunctionName '(' valueExpression ')' )
```
(Note: Left recursion can be avoid by tagging the context with custom name)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
