### PR TITLE
Add SonarCloud analysis on push/pull requests

### DIFF
--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -16,11 +16,10 @@ jobs:
         java-version: 1.14
 
     - name: SonarCloud Analysis
-      uses: sonarsource/sonarcloud-github-action@master
+      run: ./gradlew sonarqube
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}   
-
+        SONARCLOUD_LOGIN: ${{ secrets.SONARCLOUD_LOGIN }}
+    
     - name: Build with Gradle
       run: ./gradlew build assemble
 

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -18,7 +18,7 @@ jobs:
     - name: SonarCloud Analysis
       run: ./gradlew sonarqube
       env:
-        SONARCLOUD_LOGIN: ${{ secrets.SONARCLOUD_LOGIN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     
     - name: Build with Gradle
       run: ./gradlew build assemble

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -14,6 +14,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.14
+
+    - name: SonarCloud Analysis
+      run: ./gradlew sonarqube
+      env:
+        SONARCLOUD_LOGIN: ${{ secrets.SONARCLOUD_LOGIN }}
     
     - name: Build with Gradle
       run: ./gradlew build assemble

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -16,10 +16,11 @@ jobs:
         java-version: 1.14
 
     - name: SonarCloud Analysis
-      run: ./gradlew sonarqube
+      uses: sonarsource/sonarcloud-github-action@master
       env:
-        SONARCLOUD_LOGIN: ${{ secrets.SONARCLOUD_LOGIN }}
-    
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}   
+
     - name: Build with Gradle
       run: ./gradlew build assemble
 

--- a/.github/workflows/sql-test-and-build-workflow.yml
+++ b/.github/workflows/sql-test-and-build-workflow.yml
@@ -18,6 +18,7 @@ jobs:
     - name: SonarCloud Analysis
       run: ./gradlew sonarqube
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     
     - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -35,16 +35,6 @@ plugins {
     id 'checkstyle'
     id "io.freefair.lombok" version "5.0.0-rc4"
     id 'jacoco'
-    id "org.sonarqube" version "2.8"
-}
-
-sonarqube {
-  properties {
-    property "sonar.projectKey", "odfe_sql"
-    property "sonar.organization", "opendistro-sql"
-    property "sonar.host.url", "https://sonarcloud.io"
-    property "sonar.login", System.getenv("SONARCLOUD_LOGIN")
-  }
 }
 
 // Repository on root level is for dependencies that project code depends on. And this block must be placed after plugins{}

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ sonarqube {
     property "sonar.projectKey", "odfe_sql"
     property "sonar.organization", "opendistro-sql"
     property "sonar.host.url", "https://sonarcloud.io"
-    property "sonar.login", System.getenv("SONARCLOUD_LOGIN")
+    property "sonar.login", System.getenv("SONAR_TOKEN")
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ sonarqube {
     property "sonar.organization", "opendistro-sql"
     property "sonar.host.url", "https://sonarcloud.io"
     property "sonar.login", System.getenv("SONAR_TOKEN")
+    property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/jacoco/reports.xml"
   }
 }
 
@@ -91,7 +92,8 @@ jacoco {
 }
 jacocoTestReport {
     reports {
-        xml.enabled false
+        xml.enabled true
+        xml.destination file("${buildDir}/jacoco/reports.xml")
         csv.enabled false
     }
     afterEvaluate {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,16 @@ plugins {
     id 'checkstyle'
     id "io.freefair.lombok" version "5.0.0-rc4"
     id 'jacoco'
+    id "org.sonarqube" version "2.8"
+}
+
+sonarqube {
+  properties {
+    property "sonar.projectKey", "odfe_sql"
+    property "sonar.organization", "opendistro-sql"
+    property "sonar.host.url", "https://sonarcloud.io"
+    property "sonar.login", System.getenv("SONARCLOUD_LOGIN")
+  }
 }
 
 // Repository on root level is for dependencies that project code depends on. And this block must be placed after plugins{}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,3 @@
+sonar.organization=opendistro-sql
+sonar.projectKey=odfe_sql
+sonar.sources=.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,0 @@
-sonar.organization=opendistro-sql
-sonar.projectKey=odfe_sql
-sonar.sources=.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add sonarcloud analysis on push/pull requests for SQL, results will be at [sonarcloud.io](https://sonarcloud.io/dashboard?id=odfe_sql)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
