### PR TITLE
ODBC: Build driver files in parallel

### DIFF
--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -26,26 +26,16 @@ jobs:
         brew install curl
         brew install cmake
         brew install libiodbc
-    - name: aws-sdk-cpp-setup
+    - name: configure-and-build-driver
       run: |
-        sh aws_sdk_cpp_setup.sh
-    - name: configure
-      run: |
-        prefix_path=$(pwd)
-        mkdir cmake-build
-        cd cmake-build
-        cmake ../src -DCMAKE_INSTALL_PREFIX=$prefix_path/AWSSDK/ -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY="core" -DCUSTOM_MEMORY_MANAGEMENT="OFF" -DENABLE_RTTI="OFF" -DENABLE_TESTING="OFF"
-        cd ..
-    - name: build-driver
-      run: |
-        cmake --build cmake-build
+        .\build_mac_release64.ps1
     #- name: test
     #  run: | 
     #    bash ./run_test_runner.sh
     - name: build-installer
       if: success()
       run: |
-        cd cmake-build
+        cd cmake-build64
         cmake ../src 
         make
         cpack .
@@ -59,7 +49,7 @@ jobs:
         cp ./lib64/*.dylib build
         cp ./lib64/*.a build
         cp $(ls -d bin64/* | grep -v "\.") build
-        cp ./cmake-build/*.pkg installer
+        cp ./cmake-build64/*.pkg installer
     #    cp ./bin64/*.html test-output
     #    cp ./bin64/*.log test-output
     - name: upload-build

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -28,7 +28,7 @@ jobs:
         brew install libiodbc
     - name: configure-and-build-driver
       run: |
-        .\build_mac_release64.ps1
+        ./build_mac_release64.sh
     #- name: test
     #  run: | 
     #    bash ./run_test_runner.sh

--- a/sql-odbc/build_mac_debug64.sh
+++ b/sql-odbc/build_mac_debug64.sh
@@ -1,0 +1,14 @@
+# Build AWS SDK
+# $BITNESS=64
+
+cd src
+git clone -b "1.7.329" "https://github.com/aws/aws-sdk-cpp.git"
+cd ..
+
+PREFIX_PATH=$(pwd)
+mkdir cmake-build64
+cd cmake-build64
+cmake ../src -DCMAKE_INSTALL_PREFIX=${PREFIX_PATH}/AWSSDK/ -DCMAKE_BUILD_TYPE=Debug -DBUILD_ONLY="core" -DCUSTOM_MEMORY_MANAGEMENT="OFF" -DENABLE_RTTI="OFF" -DENABLE_TESTING="OFF"
+cd ..
+
+cmake --build cmake-build64 -- -j 4

--- a/sql-odbc/build_mac_release64.sh
+++ b/sql-odbc/build_mac_release64.sh
@@ -1,0 +1,14 @@
+# Build AWS SDK
+# $BITNESS=64
+
+cd src
+git clone -b "1.7.329" "https://github.com/aws/aws-sdk-cpp.git"
+cd ..
+
+PREFIX_PATH=$(pwd)
+mkdir cmake-build64
+cd cmake-build64
+cmake ../src -DCMAKE_INSTALL_PREFIX=${PREFIX_PATH}/AWSSDK/ -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY="core" -DCUSTOM_MEMORY_MANAGEMENT="OFF" -DENABLE_RTTI="OFF" -DENABLE_TESTING="OFF"
+cd ..
+
+cmake --build cmake-build64 -- -j 4

--- a/sql-odbc/build_win_debug32.ps1
+++ b/sql-odbc/build_win_debug32.ps1
@@ -12,8 +12,8 @@ git clone "https://github.com/aws/aws-sdk-cpp.git"
 $prefix_path = (pwd).path
 cmake .\aws-sdk-cpp -A Win32 -D CMAKE_INSTALL_PREFIX=${prefix_path}\AWSSDK\ -D CMAKE_BUILD_TYPE=Debug -D BUILD_ONLY="core" -D CUSTOM_MEMORY_MANAGEMENT="OFF" -D ENABLE_RTTI="OFF" -D ENABLE_TESTING="OFF"
 
-msbuild ALL_BUILD.vcxproj /p:Configuration=Debug
-msbuild INSTALL.vcxproj /p:Configuration=Debug
+msbuild ALL_BUILD.vcxproj /m /p:Configuration=Debug
+msbuild INSTALL.vcxproj /m /p:Configuration=Debug
 
 cd ..
 
@@ -21,6 +21,7 @@ cd ..
 cmake -S src -B cmake-build${BITNESS} -A Win32 -D CMAKE_INSTALL_PREFIX=sdk-build${BITNESS}\AWSSDK\ -D BUILD_WITH_TESTS=ON
 
 # # Build Project
-cmake --build .\cmake-build${BITNESS} --config Debug 
+cmake --build .\cmake-build${BITNESS} --config Debug --parallel 4
 
-msbuild cmake-build32\PACKAGE.vcxproj -p:Configuration=Debug
+cp .\sdk-build32\bin\Debug\* .\bin32\Debug
+cp .\cmake-build32\bin\Debug\* .\bin32\Debug

--- a/sql-odbc/build_win_debug64.ps1
+++ b/sql-odbc/build_win_debug64.ps1
@@ -12,8 +12,8 @@ git clone "https://github.com/aws/aws-sdk-cpp.git"
 $prefix_path = (pwd).path
 cmake .\aws-sdk-cpp -A x64 -D CMAKE_INSTALL_PREFIX=${prefix_path}\AWSSDK\ -D CMAKE_BUILD_TYPE=Debug -D BUILD_ONLY="core" -D CUSTOM_MEMORY_MANAGEMENT="OFF" -D ENABLE_RTTI="OFF" -D ENABLE_TESTING="OFF"
 
-msbuild ALL_BUILD.vcxproj /p:Configuration=Debug
-msbuild INSTALL.vcxproj /p:Configuration=Debug
+msbuild ALL_BUILD.vcxproj /m /p:Configuration=Debug
+msbuild INSTALL.vcxproj /m /p:Configuration=Debug
 
 cd ..
 
@@ -21,6 +21,7 @@ cd ..
 cmake -S src -B cmake-build${BITNESS} -A x64 -D CMAKE_INSTALL_PREFIX=sdk-build${BITNESS}\AWSSDK\ -D BUILD_WITH_TESTS=ON
 
 # # Build Project
-cmake --build .\cmake-build${BITNESS} --config Debug 
+cmake --build .\cmake-build${BITNESS} --config Debug --parallel 4 
 
 cp .\sdk-build64\bin\Debug\* .\bin64\Debug
+cp .\cmake-build64\bin\Debug\* .\bin64\Debug

--- a/sql-odbc/build_win_release32.ps1
+++ b/sql-odbc/build_win_release32.ps1
@@ -12,8 +12,8 @@ git clone "https://github.com/aws/aws-sdk-cpp.git"
 $prefix_path = (pwd).path
 cmake .\aws-sdk-cpp -A Win32 -D CMAKE_INSTALL_PREFIX=${prefix_path}\AWSSDK\ -D CMAKE_BUILD_TYPE=Release -D BUILD_ONLY="core" -D CUSTOM_MEMORY_MANAGEMENT="OFF" -D ENABLE_RTTI="OFF" -D ENABLE_TESTING="OFF"
 
-msbuild ALL_BUILD.vcxproj /p:Configuration=Release
-msbuild INSTALL.vcxproj /p:Configuration=Release
+msbuild ALL_BUILD.vcxproj /m /p:Configuration=Release
+msbuild INSTALL.vcxproj /m /p:Configuration=Release
 
 cd ..
 
@@ -21,4 +21,7 @@ cd ..
 cmake -S src -B cmake-build${BITNESS} -A Win32 -D CMAKE_INSTALL_PREFIX=sdk-build${BITNESS}\AWSSDK\ -D BUILD_WITH_TESTS=ON
 
 # # Build Project
-cmake --build .\cmake-build${BITNESS} --config Release 
+cmake --build .\cmake-build${BITNESS} --config Release --parallel 4
+
+cp .\sdk-build32\bin\Release\* .\bin32\Release
+cp .\cmake-build32\bin\Release\* .\bin32\Release

--- a/sql-odbc/build_win_release64.ps1
+++ b/sql-odbc/build_win_release64.ps1
@@ -12,8 +12,8 @@ git clone "https://github.com/aws/aws-sdk-cpp.git"
 $prefix_path = (pwd).path
 cmake .\aws-sdk-cpp -A x64 -D CMAKE_INSTALL_PREFIX=${prefix_path}\AWSSDK\ -D CMAKE_BUILD_TYPE=Release -D BUILD_ONLY="core" -D CUSTOM_MEMORY_MANAGEMENT="OFF" -D ENABLE_RTTI="OFF" -D ENABLE_TESTING="OFF"
 
-msbuild ALL_BUILD.vcxproj /p:Configuration=Release
-msbuild INSTALL.vcxproj /p:Configuration=Release
+msbuild ALL_BUILD.vcxproj /m /p:Configuration=Release
+msbuild INSTALL.vcxproj /m /p:Configuration=Release
 
 cd ..
 
@@ -21,6 +21,7 @@ cd ..
 cmake -S src -B cmake-build64 -A x64 -D CMAKE_INSTALL_PREFIX=sdk-build64\AWSSDK\ -D BUILD_WITH_TESTS=ON
 
 # # Build Project
-cmake --build .\cmake-build64 --config Release 
+cmake --build .\cmake-build64 --config Release --parallel 4 
 
 cp .\sdk-build64\bin\Release\* .\bin64\Release
+cp .\cmake-build64\bin\Release\* .\bin64\Release


### PR DESCRIPTION
*Issue #, if available:* #569 

*Description of changes:*
update build scripts to build driver files in parallel
- add build scripts for Mac 64-bit
- update GitHub workflow script used for Mac64 builds

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
