### PR TITLE
Add workflow to draft release on push

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -1,0 +1,35 @@
+# The overall template of the release notes
+template: |
+  Open Distro for Elasticsearch Version $RESOLVED_VERSION
+  $CHANGES
+
+# Setting the formatting and sorting for the release notes body
+name-template: Version $RESOLVED_VERSION
+change-template: "- $TITLE (PR [#$NUMBER](https://github.com/opendistro-for-elasticsearch/sql/pull/$NUMBER))"
+sort-by: merged_at
+sort-direction: ascending
+
+# Organizing the tagged PRs into categories
+categories:
+  - title: "Version Upgrades"
+    labels:
+      - "version compatibility"
+  - title: "Documentation"
+    labels:
+      - "documentation"
+  - title: "SQL"
+    labels:
+      - "SQL"
+      - "PPL"
+  - title: "CLI"
+    labels:
+      - "CLI"
+  - title: "SQL JDBC"
+    labels:
+      - "JDBC"
+  - title: "SQL ODBC"
+    labels:
+      - "ODBC"
+  - title: "SQL Workbench"
+    labels:
+      - "Workbench"

--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -14,14 +14,26 @@ categories:
   - title: "Version Upgrades"
     labels:
       - "version compatibility"
+  - title: "Features"
+    labels:
+      - "feature"
+  - title: "Enhancements"
+    labels:
+      - "enhancement"
+  - title: "Maintenance"
+    labels:
+      - "maintenance"
+  - title: "Bug Fixes"
+    labels:
+      - "bug"
   - title: "Documentation"
     labels:
       - "documentation"
-  - title: "SQL"
+  - title: "SQL and PPL"
     labels:
       - "SQL"
       - "PPL"
-  - title: "CLI"
+  - title: "SQL CLI"
     labels:
       - "CLI"
   - title: "SQL JDBC"

--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -14,21 +14,6 @@ categories:
   - title: "Version Upgrades"
     labels:
       - "version compatibility"
-  - title: "Features"
-    labels:
-      - "feature"
-  - title: "Enhancements"
-    labels:
-      - "enhancement"
-  - title: "Maintenance"
-    labels:
-      - "maintenance"
-  - title: "Bug Fixes"
-    labels:
-      - "bug"
-  - title: "Documentation"
-    labels:
-      - "documentation"
   - title: "SQL and PPL"
     labels:
       - "SQL"
@@ -45,3 +30,13 @@ categories:
   - title: "SQL Workbench"
     labels:
       - "Workbench"
+  - title: "Enhancements"
+    labels:
+      - "enhancement"
+      - "maintenance"
+  - title: "Bug Fixes"
+    labels:
+      - "bug"
+  - title: "Documentation"
+    labels:
+      - "documentation"

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -1,0 +1,20 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    name: Update draft release notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update draft release notes
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: draft-release-notes-config.yml
+          tag: (None)
+          version: 1.9.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -10,6 +10,7 @@ jobs:
     name: Update draft release notes
     runs-on: ubuntu-latest
     steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Update draft release notes
         uses: release-drafter/release-drafter@v5
         with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Use [release-drafter](https://github.com/release-drafter/release-drafter) to automatically create/update release draft on each push to master. Release draft will be generated from merged pr and categorized by labels. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.