### PR TITLE
Move workbench down in kibana nav

### DIFF
--- a/sql-workbench/index.js
+++ b/sql-workbench/index.js
@@ -35,6 +35,7 @@ export default function (kibana) {
         description: 'SQL Workbench',
         main: 'plugins/' + PLUGIN_NAME + '/app',
         icon:'plugins/' + PLUGIN_NAME + '/icons/sql.svg',
+        order: 9050,
         category: DEFAULT_APP_CATEGORIES.kibana,
       },
       styleSheetPaths: [resolve(__dirname, 'public/app.scss')].find(p => existsSync(p))


### PR DESCRIPTION
*Issue #, if available:*
- #574 

*Description of changes:*
- Add `order: 9050` property to move workbench down in kibana nav (larger order means lower position, and `visualize` has order `8000`)
![image](https://user-images.githubusercontent.com/28062824/87593242-0211a800-c6a0-11ea-84f5-f8b00041929d.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
