### PR TITLE
Using UTC as default timezone for date_format function if not provided

### DIFF
--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/DateFormatIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/DateFormatIT.java
@@ -117,6 +117,17 @@ public class DateFormatIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void andWithoutUTCParameter() throws SqlParseException {
+    assertThat(
+        dateQuery(SELECT_FROM +
+                "WHERE date_format(insert_time, 'yyyy-MM-dd HH:mm:ss') >= '2014-08-17 16:13:12' " +
+                "AND date_format(insert_time, 'yyyy-MM-dd HH:mm:ss') <= '2014-08-17 16:13:13'",
+            "yyyy-MM-dd HH:mm:ss"),
+        contains("2014-08-17 16:13:12")
+    );
+  }
+
+  @Test
   public void or() throws SqlParseException {
     assertThat(
         dateQuery(SELECT_FROM +
@@ -209,17 +220,19 @@ public class DateFormatIT extends SQLIntegTestCase {
   }
 
   private Set<Object> dateQuery(String sql) throws SqlParseException {
+    return dateQuery(sql, TestsConstants.SIMPLE_DATE_FORMAT);
+  }
+
+  private Set<Object> dateQuery(String sql, String format) throws SqlParseException {
     try {
       JSONObject response = executeQuery(sql);
-      return getResult(response, "insert_time");
+      return getResult(response, "insert_time", DateTimeFormat.forPattern(format));
     } catch (IOException e) {
       throw new SqlParseException(String.format("Unable to process query '%s'", sql));
     }
   }
 
-  private Set<Object> getResult(JSONObject response, String fieldName) {
-    DateTimeFormatter formatter = DateTimeFormat.forPattern(TestsConstants.SIMPLE_DATE_FORMAT);
-
+  private Set<Object> getResult(JSONObject response, String fieldName, DateTimeFormatter formatter) {
     JSONArray hits = getHits(response);
     Set<Object> result = new TreeSet<>(); // Using TreeSet so order is maintained
     for (int i = 0; i < hits.length(); i++) {

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/DateFormatIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/DateFormatIT.java
@@ -16,6 +16,10 @@
 
 package com.amazon.opendistroforelasticsearch.sql.legacy;
 
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.rows;
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.schema;
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.verifyDataRows;
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.verifySchema;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/DateFormatIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/DateFormatIT.java
@@ -117,7 +117,7 @@ public class DateFormatIT extends SQLIntegTestCase {
   }
 
   @Test
-  public void andWithoutUTCParameter() throws SqlParseException {
+  public void andWithDefaultTimeZone() throws SqlParseException {
     assertThat(
         dateQuery(SELECT_FROM +
                 "WHERE date_format(insert_time, 'yyyy-MM-dd HH:mm:ss') >= '2014-08-17 16:13:12' " +
@@ -166,6 +166,17 @@ public class DateFormatIT extends SQLIntegTestCase {
 
     assertThat(new DateTime(getSource(hits.getJSONObject(0)).get("insert_time"), DateTimeZone.UTC),
         is(new DateTime("2014-08-24T00:00:41.221Z", DateTimeZone.UTC)));
+  }
+
+  @Test
+  public void selectDateTimeWithDefaultTimeZone() throws SqlParseException {
+    JSONObject response = executeJdbcRequest("SELECT date_format(insert_time, 'yyyy-MM-dd') as date " +
+            " FROM " + TestsConstants.TEST_INDEX_ONLINE +
+            " WHERE date_format(insert_time, 'yyyy-MM-dd HH:mm:ss') >= '2014-08-17 16:13:12' " +
+            " AND date_format(insert_time, 'yyyy-MM-dd HH:mm:ss') <= '2014-08-17 16:13:13'");
+
+    verifySchema(response, schema("date", "", "text"));
+    verifyDataRows(response, rows("2014-08-17"));
   }
 
   @Test
@@ -254,5 +265,9 @@ public class DateFormatIT extends SQLIntegTestCase {
         .findFirst()
         .orElseThrow(() -> new RuntimeException(
             "Can't find key" + prefix + " in aggregation " + aggregation));
+  }
+
+  private JSONObject executeJdbcRequest(String query) {
+    return new JSONObject(executeQuery(query, "jdbc"));
   }
 }

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/query/maker/Maker.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/query/maker/Maker.java
@@ -76,6 +76,11 @@ import static com.amazon.opendistroforelasticsearch.sql.legacy.parser.WhereParse
 
 public abstract class Maker {
 
+    /**
+     * UTC.
+     */
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
     public static final Object NONE = new Object();
 
     public static final Set<String> queryFunctions = Sets.newHashSet(
@@ -409,7 +414,8 @@ public abstract class Maker {
         if (params.size() > 2) {
             zoneId = ZoneId.of(removeSingleQuote(params.get(2).toString())).toString();
         } else {
-            zoneId = ZoneId.systemDefault().toString();
+            // Using UTC, if there is no Zone provided.
+            zoneId = UTC.getId();
         }
 
         RangeQueryBuilder rangeQuery = QueryBuilders.rangeQuery(field).format(format).timeZone(zoneId);

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/utils/SQLFunctions.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/utils/SQLFunctions.java
@@ -527,7 +527,7 @@ public class SQLFunctions {
         String name = nextId("date_format");
         if (valueName == null) {
             return new Tuple<>(name, "def " + name + " = DateTimeFormatter.ofPattern('" + pattern + "').withZone("
-                    + (zoneId != null ? "ZoneId.of('" + zoneId + "')" : "ZoneId.systemDefault()")
+                    + (zoneId != null ? "ZoneId.of('" + zoneId + "')" : "ZoneId.of(\"UTC\")")
                     + ").format(Instant.ofEpochMilli(" + getPropertyOrValue(field) + ".toInstant().toEpochMilli()))");
         } else {
             return new Tuple<>(name, exprString(field) + "; "


### PR DESCRIPTION
*Issue #, if available:* #580 

*Description of changes:*
1. Using UTC as default timezone for date_format function if not provided.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
