### PR TITLE
Add ElasticsearchExprValueFactory in StorageEngine

### DIFF
--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprBooleanValue.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprBooleanValue.java
@@ -20,8 +20,8 @@ import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode
 public class ExprBooleanValue implements ExprValue {
-  private static final ExprValue TRUE = new ExprBooleanValue(true);
-  private static final ExprValue FALSE = new ExprBooleanValue(false);
+  private static final ExprBooleanValue TRUE = new ExprBooleanValue(true);
+  private static final ExprBooleanValue FALSE = new ExprBooleanValue(false);
 
   private final Boolean value;
 
@@ -29,12 +29,8 @@ public class ExprBooleanValue implements ExprValue {
     this.value = value;
   }
 
-  public static ExprValue ofTrue() {
-    return TRUE;
-  }
-
-  public static ExprValue ofFalse() {
-    return FALSE;
+  public static ExprBooleanValue of(Boolean value) {
+    return value ? TRUE : FALSE;
   }
 
   @Override

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprValueUtils.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprValueUtils.java
@@ -35,8 +35,8 @@ import lombok.experimental.UtilityClass;
  */
 @UtilityClass
 public class ExprValueUtils {
-  public static final ExprValue LITERAL_TRUE = ExprBooleanValue.ofTrue();
-  public static final ExprValue LITERAL_FALSE = ExprBooleanValue.ofFalse();
+  public static final ExprValue LITERAL_TRUE = ExprBooleanValue.of(true);
+  public static final ExprValue LITERAL_FALSE = ExprBooleanValue.of(false);
   public static final ExprValue LITERAL_NULL = ExprNullValue.of();
   public static final ExprValue LITERAL_MISSING = ExprMissingValue.of();
 

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/DefaultImplementorTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/DefaultImplementorTest.java
@@ -62,7 +62,7 @@ class DefaultImplementorTest {
     ReferenceExpression include = ref("age", INTEGER);
     ReferenceExpression exclude = ref("name", STRING);
     ReferenceExpression dedupeField = ref("name", STRING);
-    Expression filterExpr = literal(ExprBooleanValue.ofTrue());
+    Expression filterExpr = literal(ExprBooleanValue.of(true));
     List<Expression> groupByExprs = Arrays.asList(ref("age", INTEGER));
     List<Aggregator> aggregators =
         Arrays.asList(new AvgAggregator(groupByExprs, ExprCoreType.DOUBLE));

--- a/docs/experiment/ppl/cmd/search.rst
+++ b/docs/experiment/ppl/cmd/search.rst
@@ -32,14 +32,14 @@ PPL query::
 
     od> source=accounts;
     fetched rows / total rows = 4/4
-    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
-    | account_number   | firstname   | address              | balance   | gender   | city   | employer   | state   | age   | email                 | lastname   |
-    |------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------|
-    | 1                | Amber       | 880 Holmes Lane      | 39225     | M        | Brogan | Pyrami     | IL      | 32    | amberduke@pyrami.com  | Duke       |
-    | 6                | Hattie      | 671 Bristol Street   | 5686      | M        | Dante  | Netagy     | TN      | 36    | hattiebond@netagy.com | Bond       |
-    | 13               | Nanette     | 789 Madison Street   | 32838     | F        | Nogal  | Quility    | VA      | 28    | null                  | Bates      |
-    | 18               | Dale        | 467 Hutchinson Court | 4180      | M        | Orick  | null       | MD      | 33    | daleadams@boink.com   | Adams      |
-    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
+    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
+    | account_number   | balance   | firstname   | lastname   | age   | gender   | address              | employer   | email                 | city   | state   |
+    |------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------|
+    | 1                | 39225     | Amber       | Duke       | 32    | M        | 880 Holmes Lane      | Pyrami     | amberduke@pyrami.com  | Brogan | IL      |
+    | 6                | 5686      | Hattie      | Bond       | 36    | M        | 671 Bristol Street   | Netagy     | hattiebond@netagy.com | Dante  | TN      |
+    | 13               | 32838     | Nanette     | Bates      | 28    | F        | 789 Madison Street   | Quility    | null                  | Nogal  | VA      |
+    | 18               | 4180      | Dale        | Adams      | 33    | M        | 467 Hutchinson Court | null       | daleadams@boink.com   | Orick  | MD      |
+    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
 
 Example 2: Fetch data with condition
 ====================================
@@ -50,10 +50,10 @@ PPL query::
 
     od> source=accounts account_number=1 or gender="F";
     fetched rows / total rows = 2/2
-    +------------------+-------------+--------------------+-----------+----------+--------+------------+---------+-------+----------------------+------------+
-    | account_number   | firstname   | address            | balance   | gender   | city   | employer   | state   | age   | email                | lastname   |
-    |------------------+-------------+--------------------+-----------+----------+--------+------------+---------+-------+----------------------+------------|
-    | 1                | Amber       | 880 Holmes Lane    | 39225     | M        | Brogan | Pyrami     | IL      | 32    | amberduke@pyrami.com | Duke       |
-    | 13               | Nanette     | 789 Madison Street | 32838     | F        | Nogal  | Quility    | VA      | 28    | null                 | Bates      |
-    +------------------+-------------+--------------------+-----------+----------+--------+------------+---------+-------+----------------------+------------+
+    +------------------+-----------+-------------+------------+-------+----------+--------------------+------------+----------------------+--------+---------+
+    | account_number   | balance   | firstname   | lastname   | age   | gender   | address            | employer   | email                | city   | state   |
+    |------------------+-----------+-------------+------------+-------+----------+--------------------+------------+----------------------+--------+---------|
+    | 1                | 39225     | Amber       | Duke       | 32    | M        | 880 Holmes Lane    | Pyrami     | amberduke@pyrami.com | Brogan | IL      |
+    | 13               | 32838     | Nanette     | Bates      | 28    | F        | 789 Madison Street | Quility    | null                 | Nogal  | VA      |
+    +------------------+-----------+-------------+------------+-------+----------+--------------------+------------+----------------------+--------+---------+
 

--- a/docs/experiment/ppl/cmd/where.rst
+++ b/docs/experiment/ppl/cmd/where.rst
@@ -27,12 +27,12 @@ The example show fetch all the document from accounts index with .
 
 PPL query::
 
-    od> source=accounts | where account_number=1 or gender="F";
+    od> source=accounts | where account_number=1 or gender="F" | fields account_number, gender;
     fetched rows / total rows = 2/2
-    +------------------+-------------+--------------------+-----------+----------+--------+------------+---------+-------+----------------------+------------+
-    | account_number   | firstname   | address            | balance   | gender   | city   | employer   | state   | age   | email                | lastname   |
-    |------------------+-------------+--------------------+-----------+----------+--------+------------+---------+-------+----------------------+------------|
-    | 1                | Amber       | 880 Holmes Lane    | 39225     | M        | Brogan | Pyrami     | IL      | 32    | amberduke@pyrami.com | Duke       |
-    | 13               | Nanette     | 789 Madison Street | 32838     | F        | Nogal  | Quility    | VA      | 28    | null                 | Bates      |
-    +------------------+-------------+--------------------+-----------+----------+--------+------------+---------+-------+----------------------+------------+
+    +------------------+----------+
+    | account_number   | gender   |
+    |------------------+----------|
+    | 1                | M        |
+    | 13               | F        |
+    +------------------+----------+
 

--- a/docs/user/general/identifiers.rst
+++ b/docs/user/general/identifiers.rst
@@ -40,14 +40,14 @@ Here are examples for using index pattern directly without quotes::
 
     od> SELECT * FROM *cc*nt*;
     fetched rows / total rows = 4/4
-    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
-    | account_number   | firstname   | address              | balance   | gender   | city   | employer   | state   | age   | email                 | lastname   |
-    |------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------|
-    | 1                | Amber       | 880 Holmes Lane      | 39225     | M        | Brogan | Pyrami     | IL      | 32    | amberduke@pyrami.com  | Duke       |
-    | 6                | Hattie      | 671 Bristol Street   | 5686      | M        | Dante  | Netagy     | TN      | 36    | hattiebond@netagy.com | Bond       |
-    | 13               | Nanette     | 789 Madison Street   | 32838     | F        | Nogal  | Quility    | VA      | 28    | null                  | Bates      |
-    | 18               | Dale        | 467 Hutchinson Court | 4180      | M        | Orick  | null       | MD      | 33    | daleadams@boink.com   | Adams      |
-    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
+    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
+    | account_number   | balance   | firstname   | lastname   | age   | gender   | address              | employer   | email                 | city   | state   |
+    |------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------|
+    | 1                | 39225     | Amber       | Duke       | 32    | M        | 880 Holmes Lane      | Pyrami     | amberduke@pyrami.com  | Brogan | IL      |
+    | 6                | 5686      | Hattie      | Bond       | 36    | M        | 671 Bristol Street   | Netagy     | hattiebond@netagy.com | Dante  | TN      |
+    | 13               | 32838     | Nanette     | Bates      | 28    | F        | 789 Madison Street   | Quility    | null                  | Nogal  | VA      |
+    | 18               | 4180      | Dale        | Adams      | 33    | M        | 467 Hutchinson Court | null       | daleadams@boink.com   | Orick  | MD      |
+    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
 
 
 Delimited Identifiers
@@ -76,14 +76,14 @@ Here are examples for quoting an index name by back ticks::
 
     od> SELECT * FROM `accounts`;
     fetched rows / total rows = 4/4
-    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
-    | account_number   | firstname   | address              | balance   | gender   | city   | employer   | state   | age   | email                 | lastname   |
-    |------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------|
-    | 1                | Amber       | 880 Holmes Lane      | 39225     | M        | Brogan | Pyrami     | IL      | 32    | amberduke@pyrami.com  | Duke       |
-    | 6                | Hattie      | 671 Bristol Street   | 5686      | M        | Dante  | Netagy     | TN      | 36    | hattiebond@netagy.com | Bond       |
-    | 13               | Nanette     | 789 Madison Street   | 32838     | F        | Nogal  | Quility    | VA      | 28    | null                  | Bates      |
-    | 18               | Dale        | 467 Hutchinson Court | 4180      | M        | Orick  | null       | MD      | 33    | daleadams@boink.com   | Adams      |
-    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
+    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
+    | account_number   | balance   | firstname   | lastname   | age   | gender   | address              | employer   | email                 | city   | state   |
+    |------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------|
+    | 1                | 39225     | Amber       | Duke       | 32    | M        | 880 Holmes Lane      | Pyrami     | amberduke@pyrami.com  | Brogan | IL      |
+    | 6                | 5686      | Hattie      | Bond       | 36    | M        | 671 Bristol Street   | Netagy     | hattiebond@netagy.com | Dante  | TN      |
+    | 13               | 32838     | Nanette     | Bates      | 28    | F        | 789 Madison Street   | Quility    | null                  | Nogal  | VA      |
+    | 18               | 4180      | Dale        | Adams      | 33    | M        | 467 Hutchinson Court | null       | daleadams@boink.com   | Orick  | MD      |
+    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
 
 
 Case Sensitivity

--- a/elasticsearch/build.gradle
+++ b/elasticsearch/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     compile group: 'org.elasticsearch', name: 'elasticsearch', version: "${es_version}"
     compile group: 'org.elasticsearch.client', name: 'elasticsearch-rest-high-level-client', version: "${es_version}"
     compile "io.github.resilience4j:resilience4j-retry:1.5.0"
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.4'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.4'
 
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchDateFormatters.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchDateFormatters.java
@@ -1,0 +1,97 @@
+/*
+ *
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
+import java.util.Locale;
+import lombok.experimental.UtilityClass;
+
+/**
+ * DateTimeFormatter.
+ * Reference org.elasticsearch.common.time.DateFormatters.
+ */
+@UtilityClass
+public class ElasticsearchDateFormatters {
+
+  public static final DateTimeFormatter TIME_ZONE_FORMATTER_NO_COLON =
+      new DateTimeFormatterBuilder()
+          .appendOffset("+HHmm", "Z")
+          .toFormatter(Locale.ROOT)
+          .withResolverStyle(ResolverStyle.STRICT);
+
+  public static final DateTimeFormatter STRICT_YEAR_MONTH_DAY_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+          .optionalStart()
+          .appendLiteral("-")
+          .appendValue(MONTH_OF_YEAR, 2, 2, SignStyle.NOT_NEGATIVE)
+          .optionalStart()
+          .appendLiteral('-')
+          .appendValue(DAY_OF_MONTH, 2, 2, SignStyle.NOT_NEGATIVE)
+          .optionalEnd()
+          .optionalEnd()
+          .toFormatter(Locale.ROOT)
+          .withResolverStyle(ResolverStyle.STRICT);
+
+  public static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .append(STRICT_YEAR_MONTH_DAY_FORMATTER)
+          .optionalStart()
+          .appendLiteral('T')
+          .optionalStart()
+          .appendValue(HOUR_OF_DAY, 2, 2, SignStyle.NOT_NEGATIVE)
+          .optionalStart()
+          .appendLiteral(':')
+          .appendValue(MINUTE_OF_HOUR, 2, 2, SignStyle.NOT_NEGATIVE)
+          .optionalStart()
+          .appendLiteral(':')
+          .appendValue(SECOND_OF_MINUTE, 2, 2, SignStyle.NOT_NEGATIVE)
+          .optionalStart()
+          .appendFraction(NANO_OF_SECOND, 1, 9, true)
+          .optionalEnd()
+          .optionalStart()
+          .appendLiteral(',')
+          .appendFraction(NANO_OF_SECOND, 1, 9, false)
+          .optionalEnd()
+          .optionalEnd()
+          .optionalEnd()
+          .optionalStart()
+          .appendZoneOrOffsetId()
+          .optionalEnd()
+          .optionalStart()
+          .append(TIME_ZONE_FORMATTER_NO_COLON)
+          .optionalEnd()
+          .optionalEnd()
+          .optionalEnd()
+          .toFormatter(Locale.ROOT)
+          .withResolverStyle(ResolverStyle.STRICT);
+
+  public static final DateTimeFormatter SQL_LITERAL_DATE_TIME_FORMAT = DateTimeFormatter
+          .ofPattern("yyyy-MM-dd HH:mm:ss");
+}

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactory.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactory.java
@@ -1,0 +1,228 @@
+/*
+ *
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value;
+
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.nullValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.ARRAY;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.BOOLEAN;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.DOUBLE;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.FLOAT;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.LONG;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRING;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRUCT;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.TIMESTAMP;
+
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprBooleanValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprCollectionValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprDoubleValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprFloatValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprIntegerValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprLongValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprStringValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprTimestampValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprTupleValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
+import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Construct ExprValue from Elasticsearch response.
+ */
+@RequiredArgsConstructor
+public class ElasticsearchExprValueFactory {
+  /**
+   * The Mapping of Field and ExprType.
+   */
+  private final Map<String, ExprType> typeMapping;
+  /**
+   * The default timezone is UTC.
+   */
+  private static final ZoneId ZONE = ZoneId.of("UTC");
+
+  private static final DateTimeFormatter DATE_OPTIONAL_TIME =
+      new DateTimeFormatterBuilder()
+          .appendPattern("yyyy-MM-dd")
+          .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+          .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+          .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+          .toFormatter();
+  private static final DateTimeFormatter STRICT_DATE_OPTIONAL_TIME =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+  private static final DateTimeFormatter STRICT_DATE_TIME_OFFSET =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX");
+  private static final DateTimeFormatter DATE_TIME =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+  private static final String TOP_PATH = "";
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  /**
+   * The struct construction has the following assumption. 1. The field has Elasticsearch Object
+   * data type. https://www.elastic.co/guide/en/elasticsearch/reference/current/object.html 2. The
+   * deeper field is flattened in the typeMapping. e.g. {"employ", "STRUCT"} {"employ.id",
+   * "INTEGER"} {"employ.state", "STRING"}
+   */
+  public ExprTupleValue construct(String jsonString) {
+    try {
+      return constructStruct(OBJECT_MAPPER.readTree(jsonString), TOP_PATH);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(
+          String.format("invalid json: %s.", jsonString), e);
+    }
+  }
+
+  /**
+   * Construct ExprValue from field and value pair.
+   */
+  private ExprValue construct(String field, JsonNode value) {
+    if (value.isNull()) {
+      return nullValue();
+    }
+
+    ExprType type = type(field);
+    if (type.equals(INTEGER)) {
+      return constructInteger(value);
+    } else if (type.equals(LONG)) {
+      return constructLong(value);
+    } else if (type.equals(FLOAT)) {
+      return constructFloat(value);
+    } else if (type.equals(DOUBLE)) {
+      return constructDouble(value);
+    } else if (type.equals(STRING)) {
+      return constructString(value);
+    } else if (type.equals(BOOLEAN)) {
+      return constructBoolean(value);
+    } else if (type.equals(STRUCT)) {
+      return constructStruct(value, field);
+    } else if (type.equals(ARRAY)) {
+      return constructArray(value, field);
+    } else if (type.equals(TIMESTAMP)) {
+      return constructTimestamp(value);
+    } else {
+      throw new IllegalStateException(
+          String.format(
+              "Unsupported type: %s for field: %s, value: %s.", type.typeName(), field, value));
+    }
+  }
+
+  private ExprType type(String field) {
+    if (typeMapping.containsKey(field)) {
+      return typeMapping.get(field);
+    } else {
+      throw new IllegalStateException(String.format("No type found for field: %s.", field));
+    }
+  }
+
+  private ExprIntegerValue constructInteger(JsonNode value) {
+    return new ExprIntegerValue(value.intValue());
+  }
+
+  private ExprLongValue constructLong(JsonNode value) {
+    return new ExprLongValue(value.longValue());
+  }
+
+  private ExprFloatValue constructFloat(JsonNode value) {
+    return new ExprFloatValue(value.floatValue());
+  }
+
+  private ExprDoubleValue constructDouble(JsonNode value) {
+    return new ExprDoubleValue(value.doubleValue());
+  }
+
+  private ExprStringValue constructString(JsonNode value) {
+    return new ExprStringValue(value.textValue());
+  }
+
+  private ExprBooleanValue constructBoolean(JsonNode value) {
+    return ExprBooleanValue.of(value.booleanValue());
+  }
+
+  /**
+   * Todo, Only default DATE_TIME_FORMAT is supported.
+   */
+  private ExprValue constructTimestamp(JsonNode value) {
+    try {
+      if (value.getNodeType().equals(JsonNodeType.NUMBER)) {
+        return new ExprTimestampValue(Instant.ofEpochMilli(value.asLong()));
+      } else {
+        DateTimeFormatter formatter =
+            new DateTimeFormatterBuilder()
+                .appendOptional(STRICT_DATE_OPTIONAL_TIME)
+                .appendOptional(STRICT_DATE_TIME_OFFSET)
+                .appendOptional(DATE_TIME)
+                .appendOptional(DATE_OPTIONAL_TIME)
+                .toFormatter();
+        return new ExprTimestampValue(
+            LocalDateTime.parse(value.asText(), formatter).atZone(ZONE).toInstant());
+      }
+    } catch (DateTimeParseException e) {
+      throw new IllegalStateException(
+          String.format(
+              "Construct ExprTimestampValue from %s failed, unsupported date format.", value),
+          e);
+    }
+  }
+
+  private ExprTupleValue constructStruct(JsonNode value, String path) {
+    LinkedHashMap<String, ExprValue> map = new LinkedHashMap<>();
+    value
+        .fieldNames()
+        .forEachRemaining(
+            field ->
+                map.put(
+                    field,
+                    construct(
+                        makeField(path, field),
+                        value.get(field))));
+    return new ExprTupleValue(map);
+  }
+
+  /**
+   * Todo. ARRAY is not support now. In Elasticsearch, there is no dedicated array data type.
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/array.html. The similar data
+   * type is nested, but it can only allow a list of objects.
+   */
+  private ExprCollectionValue constructArray(JsonNode value, String path) {
+    List<ExprValue> list = new ArrayList<>();
+    value.elements().forEachRemaining(node -> {
+      list.add(constructStruct(node, path));
+    });
+    return new ExprCollectionValue(list);
+  }
+
+  private String makeField(String path, String field) {
+    return path.equalsIgnoreCase(TOP_PATH) ? field : String.join(".", path, field);
+  }
+}

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndex.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndex.java
@@ -19,6 +19,7 @@ package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage;
 import com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType;
 import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value.ElasticsearchExprValueFactory;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.mapping.IndexMapping;
 import com.amazon.opendistroforelasticsearch.sql.planner.DefaultImplementor;
 import com.amazon.opendistroforelasticsearch.sql.planner.logical.LogicalPlan;
@@ -49,6 +50,7 @@ public class ElasticsearchIndex implements Table {
           .put("boolean", ExprCoreType.BOOLEAN)
           .put("nested", ExprCoreType.ARRAY)
           .put("object", ExprCoreType.STRUCT)
+          .put("date", ExprCoreType.TIMESTAMP)
           .build();
 
   /** Elasticsearch client connection. */
@@ -75,7 +77,8 @@ public class ElasticsearchIndex implements Table {
   /** TODO: Push down operations to index scan operator as much as possible in future. */
   @Override
   public PhysicalPlan implement(LogicalPlan plan) {
-    ElasticsearchIndexScan indexScan = new ElasticsearchIndexScan(client, indexName);
+    ElasticsearchIndexScan indexScan = new ElasticsearchIndexScan(client, indexName,
+        new ElasticsearchExprValueFactory(getFieldTypes()));
 
     /*
      * Visit logical plan with index scan as context so logical operators visited, such as

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScan.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScan.java
@@ -17,8 +17,8 @@
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage;
 
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
-import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value.ElasticsearchExprValueFactory;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.request.ElasticsearchRequest;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.ElasticsearchResponse;
 import com.amazon.opendistroforelasticsearch.sql.storage.TableScanOperator;
@@ -38,15 +38,24 @@ public class ElasticsearchIndexScan extends TableScanOperator {
   /** Elasticsearch client. */
   private final ElasticsearchClient client;
 
+  private final ElasticsearchExprValueFactory exprValueFactory;
+
   /** Search request. */
-  @EqualsAndHashCode.Include @ToString.Include private final ElasticsearchRequest request;
+  @EqualsAndHashCode.Include
+  @ToString.Include
+  private final ElasticsearchRequest request;
 
   /** Search response for current batch. */
   private Iterator<SearchHit> hits;
 
-  public ElasticsearchIndexScan(ElasticsearchClient client, String indexName) {
+  /**
+   * Todo.
+   */
+  public ElasticsearchIndexScan(ElasticsearchClient client, String indexName,
+                                ElasticsearchExprValueFactory exprValueFactory) {
     this.client = client;
     this.request = new ElasticsearchRequest(indexName);
+    this.exprValueFactory = exprValueFactory;
   }
 
   @Override
@@ -70,7 +79,7 @@ public class ElasticsearchIndexScan extends TableScanOperator {
 
   @Override
   public ExprValue next() {
-    return ExprValueUtils.fromObjectValue(hits.next().getSourceAsMap());
+    return exprValueFactory.construct(hits.next().getSourceAsString());
   }
 
   @Override

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactoryTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactoryTest.java
@@ -116,7 +116,10 @@ class ElasticsearchExprValueFactoryTest {
         tupleValue("{\"dateV\":\"2015-01-01T12:10:30Z\"}").get("dateV"));
     assertEquals(
         new ExprTimestampValue("2015-01-01 12:10:30"),
-        tupleValue("{\"dateV\":\"2015-01-01 12:10:30\"}").get("dateV"));
+        tupleValue("{\"dateV\":\"2015-01-01T12:10:30\"}").get("dateV"));
+    assertEquals(
+            new ExprTimestampValue("2015-01-01 12:10:30"),
+            tupleValue("{\"dateV\":\"2015-01-01 12:10:30\"}").get("dateV"));
     assertEquals(
         new ExprTimestampValue(Instant.ofEpochMilli(1420070400001L)),
         tupleValue("{\"dateV\":1420070400001}").get("dateV"));

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactoryTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactoryTest.java
@@ -1,0 +1,198 @@
+/*
+ *
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value;
+
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.booleanValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.doubleValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.floatValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.integerValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.longValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.nullValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.stringValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.ARRAY;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.BOOLEAN;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.DOUBLE;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.FLOAT;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.LONG;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRING;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRUCT;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.TIMESTAMP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprCollectionValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprTimestampValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprTupleValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
+import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.junit.jupiter.api.Test;
+
+class ElasticsearchExprValueFactoryTest {
+
+  private static final Map<String, ExprType> MAPPING =
+      new ImmutableMap.Builder<String, ExprType>()
+          .put("intV", INTEGER)
+          .put("longV", LONG)
+          .put("floatV", FLOAT)
+          .put("doubleV", DOUBLE)
+          .put("stringV", STRING)
+          .put("dateV", TIMESTAMP)
+          .put("boolV", BOOLEAN)
+          .put("structV", STRUCT)
+          .put("structV.id", INTEGER)
+          .put("structV.state", STRING)
+          .put("arrayV", ARRAY)
+          .put("arrayV.info", STRING)
+          .put("arrayV.author", STRING)
+          .build();
+  private ElasticsearchExprValueFactory exprValueFactory =
+      new ElasticsearchExprValueFactory(MAPPING);
+
+  @Test
+  public void constructNullValue() {
+    assertEquals(nullValue(), tupleValue("{\"intV\":null}").get("intV"));
+  }
+
+  @Test
+  public void constructInteger() {
+    assertEquals(integerValue(1), tupleValue("{\"intV\":1}").get("intV"));
+  }
+
+  @Test
+  public void constructLong() {
+    assertEquals(longValue(1L), tupleValue("{\"longV\":1}").get("longV"));
+  }
+
+  @Test
+  public void constructFloat() {
+    assertEquals(floatValue(1f), tupleValue("{\"floatV\":1.0}").get("floatV"));
+  }
+
+  @Test
+  public void constructDouble() {
+    assertEquals(doubleValue(1d), tupleValue("{\"doubleV\":1.0}").get("doubleV"));
+  }
+
+  @Test
+  public void constructString() {
+    assertEquals(stringValue("text"), tupleValue("{\"stringV\":\"text\"}").get("stringV"));
+  }
+
+  @Test
+  public void constructBoolean() {
+    assertEquals(booleanValue(true), tupleValue("{\"boolV\":true}").get("boolV"));
+  }
+
+  @Test
+  public void constructDate() {
+    assertEquals(
+        new ExprTimestampValue("2015-01-01 00:00:00"),
+        tupleValue("{\"dateV\":\"2015-01-01\"}").get("dateV"));
+    assertEquals(
+        new ExprTimestampValue("2015-01-01 12:10:30"),
+        tupleValue("{\"dateV\":\"2015-01-01T12:10:30Z\"}").get("dateV"));
+    assertEquals(
+        new ExprTimestampValue("2015-01-01 12:10:30"),
+        tupleValue("{\"dateV\":\"2015-01-01 12:10:30\"}").get("dateV"));
+    assertEquals(
+        new ExprTimestampValue(Instant.ofEpochMilli(1420070400001L)),
+        tupleValue("{\"dateV\":1420070400001}").get("dateV"));
+  }
+
+  @Test
+  public void constructDateFromUnsupportedFormatThrowException() {
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class, () -> tupleValue("{\"dateV\":\"2015-01-01 12:10\"}"));
+    assertEquals(
+        "Construct ExprTimestampValue from \"2015-01-01 12:10\" failed, "
+            + "unsupported date format.",
+        exception.getMessage());
+  }
+
+  @Test
+  public void constructArray() {
+    assertEquals(
+        new ExprCollectionValue(ImmutableList.of(new ExprTupleValue(
+            new LinkedHashMap<String, ExprValue>() {
+              {
+                put("info", stringValue("zz"));
+                put("author", stringValue("au"));
+              }
+            }))),
+        tupleValue("{\"arrayV\":[{\"info\":\"zz\",\"author\":\"au\"}]}").get("arrayV"));
+  }
+
+  @Test
+  public void constructStruct() {
+    assertEquals(
+        new ExprTupleValue(
+            new LinkedHashMap<String, ExprValue>() {
+              {
+                put("id", integerValue(1));
+                put("state", stringValue("WA"));
+              }
+            }),
+        tupleValue("{\"structV\":{\"id\":1,\"state\":\"WA\"}}").get("structV"));
+  }
+
+  @Test
+  public void constructFromInvalidJsonThrowException() {
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> tupleValue("{\"invalid_json:1}"));
+    assertEquals("invalid json: {\"invalid_json:1}.", exception.getMessage());
+  }
+
+  @Test
+  public void noTypeFoundForMappingThrowException() {
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> tupleValue("{\"not_exist\":1}"));
+    assertEquals("No type found for field: not_exist.", exception.getMessage());
+  }
+
+  @Test
+  public void constructUnsupportedTypeThrowException() {
+    ElasticsearchExprValueFactory exprValueFactory =
+        new ElasticsearchExprValueFactory(ImmutableMap.of("type", new TestType()));
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> exprValueFactory.construct("{\"type\":1}"));
+    assertEquals("Unsupported type: TEST_TYPE for field: type, value: 1.", exception.getMessage());
+  }
+
+  public Map<String, ExprValue> tupleValue(String jsonString) {
+    return (Map<String, ExprValue>) exprValueFactory.construct(jsonString).value();
+  }
+
+  @EqualsAndHashCode
+  @ToString
+  private static class TestType implements ExprType {
+
+    @Override
+    public String typeName() {
+      return "TEST_TYPE";
+    }
+  }
+}

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScanTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScanTest.java
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage;
 
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,7 +29,9 @@ import static org.mockito.Mockito.when;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value.ElasticsearchExprValueFactory;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.ElasticsearchResponse;
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.search.SearchHit;
@@ -42,12 +45,17 @@ import org.mockito.stubbing.Answer;
 @ExtendWith(MockitoExtension.class)
 class ElasticsearchIndexScanTest {
 
-  @Mock private ElasticsearchClient client;
+  @Mock
+  private ElasticsearchClient client;
+
+  private ElasticsearchExprValueFactory exprValueFactory = new ElasticsearchExprValueFactory(
+          ImmutableMap.of("name", STRING, "department", STRING));
 
   @Test
   void queryEmptyResult() {
     mockResponse();
-    try (ElasticsearchIndexScan indexScan = new ElasticsearchIndexScan(client, "test")) {
+    try (ElasticsearchIndexScan indexScan =
+             new ElasticsearchIndexScan(client, "test", exprValueFactory)) {
       indexScan.open();
       assertFalse(indexScan.hasNext());
     }
@@ -57,10 +65,11 @@ class ElasticsearchIndexScanTest {
   @Test
   void queryAllResults() {
     mockResponse(
-        new SearchHit[] {employee(1, "John", "IT"), employee(2, "Smith", "HR")},
-        new SearchHit[] {employee(3, "Allen", "IT")});
+        new SearchHit[]{employee(1, "John", "IT"), employee(2, "Smith", "HR")},
+        new SearchHit[]{employee(3, "Allen", "IT")});
 
-    try (ElasticsearchIndexScan indexScan = new ElasticsearchIndexScan(client, "employees")) {
+    try (ElasticsearchIndexScan indexScan =
+             new ElasticsearchIndexScan(client, "employees", exprValueFactory)) {
       indexScan.open();
 
       assertTrue(indexScan.hasNext());

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexTest.java
@@ -37,11 +37,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.Sort;
-import com.amazon.opendistroforelasticsearch.sql.ast.tree.Sort.SortOption;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprBooleanValue;
 import com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType;
 import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value.ElasticsearchExprValueFactory;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.mapping.IndexMapping;
 import com.amazon.opendistroforelasticsearch.sql.expression.Expression;
 import com.amazon.opendistroforelasticsearch.sql.expression.ReferenceExpression;
@@ -65,7 +65,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ElasticsearchIndexTest {
 
-  @Mock private ElasticsearchClient client;
+  @Mock
+  private ElasticsearchClient client;
+
+  @Mock
+  private ElasticsearchExprValueFactory exprValueFactory;
 
   @Test
   void getFieldTypes() {
@@ -102,7 +106,7 @@ class ElasticsearchIndexTest {
             hasEntry("gender", ExprCoreType.BOOLEAN),
             hasEntry("family", ExprCoreType.ARRAY),
             hasEntry("employer", ExprCoreType.STRUCT),
-            hasEntry("birthday", ExprCoreType.UNKNOWN)));
+            hasEntry("birthday", ExprCoreType.TIMESTAMP)));
   }
 
   @Test
@@ -110,7 +114,8 @@ class ElasticsearchIndexTest {
     String indexName = "test";
     LogicalPlan plan = relation(indexName);
     Table index = new ElasticsearchIndex(client, indexName);
-    assertEquals(new ElasticsearchIndexScan(client, indexName), index.implement(plan));
+    assertEquals(
+        new ElasticsearchIndexScan(client, indexName, exprValueFactory), index.implement(plan));
   }
 
   @Test
@@ -119,7 +124,7 @@ class ElasticsearchIndexTest {
     ReferenceExpression include = ref("age", INTEGER);
     ReferenceExpression exclude = ref("name", STRING);
     ReferenceExpression dedupeField = ref("name", STRING);
-    Expression filterExpr = literal(ExprBooleanValue.ofTrue());
+    Expression filterExpr = literal(ExprBooleanValue.of(true));
     List<Expression> groupByExprs = Arrays.asList(ref("age", INTEGER));
     List<Aggregator> aggregators = Arrays.asList(new AvgAggregator(groupByExprs, DOUBLE));
     Map<ReferenceExpression, ReferenceExpression> mappings =
@@ -158,10 +163,12 @@ class ElasticsearchIndexTest {
                         PhysicalPlanDSL.remove(
                             PhysicalPlanDSL.rename(
                                 PhysicalPlanDSL.agg(
-                                    PhysicalPlanDSL.filter(
-                                        new ElasticsearchIndexScan(client, indexName), filterExpr),
-                                    aggregators,
-                                    groupByExprs),
+                                        PhysicalPlanDSL.filter(
+                                                new ElasticsearchIndexScan(
+                                                        client, indexName, exprValueFactory),
+                                                filterExpr),
+                                        aggregators,
+                                        groupByExprs),
                                 mappings),
                             exclude),
                         newEvalField),

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/FieldsCommandIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/FieldsCommandIT.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.columnName;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.columnPattern;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.verifyColumn;
@@ -31,6 +32,7 @@ public class FieldsCommandIT extends PPLIntegTestCase {
   @Override
   public void init() throws IOException {
     loadIndex(Index.ACCOUNT);
+    loadIndex(Index.BANK);
   }
 
   @Test
@@ -53,5 +55,31 @@ public class FieldsCommandIT extends PPLIntegTestCase {
     JSONObject result =
         executeQuery(String.format("source=%s | fields ", TEST_INDEX_ACCOUNT) + "firstnam%");
     verifyColumn(result, columnPattern("^firstnam.*"));
+  }
+
+  @Test
+  public void testSelectDateTypeField() throws IOException {
+    String result =
+            executeQueryToString(
+                    String.format("source=%s | fields birthdate", TEST_INDEX_BANK));
+    assertEquals(
+        "{\n"
+            + "  \"schema\": [{\n"
+            + "    \"name\": \"birthdate\",\n"
+            + "    \"type\": \"timestamp\"\n"
+            + "  }],\n"
+            + "  \"total\": 7,\n"
+            + "  \"datarows\": [\n"
+            + "    [\"2017-10-23 00:00:00\"],\n"
+            + "    [\"2017-11-20 00:00:00\"],\n"
+            + "    [\"2018-06-23 00:00:00\"],\n"
+            + "    [\"2018-11-13 23:33:20\"],\n"
+            + "    [\"2018-06-27 00:00:00\"],\n"
+            + "    [\"2018-08-19 00:00:00\"],\n"
+            + "    [\"2018-08-11 00:00:00\"]\n"
+            + "  ],\n"
+            + "  \"size\": 7\n"
+            + "}\n",
+        result);
   }
 }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/IdentifierIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/IdentifierIT.java
@@ -61,7 +61,7 @@ public class IdentifierIT extends SQLIntegTestCase {
         "{\n"
             + "  \"schema\": [{\n"
             + "    \"name\": \"age\",\n"
-            + "    \"type\": \"integer\"\n"
+            + "    \"type\": \"long\"\n"
             + "  }],\n"
             + "  \"total\": 1,\n"
             + "  \"datarows\": [[30]],\n"

--- a/integ-test/src/test/resources/bank.json
+++ b/integ-test/src/test/resources/bank.json
@@ -5,7 +5,7 @@
 {"index":{"_id":"13"}}
 {"account_number":13,"balance":32838,"firstname":"Nanette","lastname":"Bates","age":28,"gender":"F","address":"789 Madison Street","employer":"Quility","email":"nanettebates@quility.com","city":"Nogal","state":"VA", "male" : false, "birthdate" : "2018-06-23"}
 {"index":{"_id":"18"}}
-{"account_number":18,"balance":4180,"firstname":"Dale","lastname":"Adams","age":33,"gender":"M","address":"467 Hutchinson Court","employer":"Boink","email":"daleadams@boink.com","city":"Orick","state":"MD","male" : true, "birthdate" : "1542152000"}
+{"account_number":18,"balance":4180,"firstname":"Dale","lastname":"Adams","age":33,"gender":"M","address":"467 Hutchinson Court","employer":"Boink","email":"daleadams@boink.com","city":"Orick","state":"MD","male" : true, "birthdate" : 1542152000000}
 {"index":{"_id":"20"}}
 {"account_number":20,"balance":16418,"firstname":"Elinor","lastname":"Ratliff","age":36,"gender":"M","address":"282 Kings Place","employer":"Scentric","email":"elinorratliff@scentric.com","city":"Ribera","state":"WA", "male" : true, "birthdate" : "2018-06-27"}
 {"index":{"_id":"25"}}


### PR DESCRIPTION
## Description of changes
The ElasticsearchExprValueFactory is used construct ExprValue from Elasticsearch JSON response. Internally, it use index field mapping meta data to deserialized JSON source data.

##  To Reviewers
The change in the doctest is becase we are using Jackson to parse Json data now, the column order is different.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
