### PR TITLE
Support NULL and MISSING value in response

### DIFF
--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/Analyzer.java
@@ -15,8 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.sql.analysis;
 
-import static com.amazon.opendistroforelasticsearch.sql.expression.DSL.named;
-
 import com.amazon.opendistroforelasticsearch.sql.analysis.symbol.Namespace;
 import com.amazon.opendistroforelasticsearch.sql.analysis.symbol.Symbol;
 import com.amazon.opendistroforelasticsearch.sql.ast.AbstractNodeVisitor;
@@ -65,7 +63,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -73,10 +70,24 @@ import org.apache.commons.lang3.tuple.Pair;
  * Analyze the {@link UnresolvedPlan} in the {@link AnalysisContext} to construct the {@link
  * LogicalPlan}.
  */
-@RequiredArgsConstructor
 public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> {
+
   private final ExpressionAnalyzer expressionAnalyzer;
+
+  private final SelectExpressionAnalyzer selectExpressionAnalyzer;
+
   private final StorageEngine storageEngine;
+
+  /**
+   * Constructor.
+   */
+  public Analyzer(
+      ExpressionAnalyzer expressionAnalyzer,
+      StorageEngine storageEngine) {
+    this.expressionAnalyzer = expressionAnalyzer;
+    this.storageEngine = storageEngine;
+    this.selectExpressionAnalyzer = new SelectExpressionAnalyzer(expressionAnalyzer);
+  }
 
   public LogicalPlan analyze(UnresolvedPlan unresolved, AnalysisContext context) {
     return unresolved.accept(this, context);
@@ -113,8 +124,11 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
         ReferenceExpression target =
             new ReferenceExpression(((Field) renameMap.getTarget()).getField().toString(),
                 origin.type());
-        context.peek().define(target);
-        renameMapBuilder.put(DSL.ref(origin.toString(), origin.type()), target);
+        ReferenceExpression originExpr = DSL.ref(origin.toString(), origin.type());
+        TypeEnvironment curEnv = context.peek();
+        curEnv.remove(originExpr);
+        curEnv.define(target);
+        renameMapBuilder.put(originExpr, target);
       } else {
         throw new SemanticCheckException(
             String.format("the target expected to be field, but is %s", renameMap.getTarget()));
@@ -129,17 +143,27 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
    */
   @Override
   public LogicalPlan visitAggregation(Aggregation node, AnalysisContext context) {
-    LogicalPlan child = node.getChild().get(0).accept(this, context);
+    final LogicalPlan child = node.getChild().get(0).accept(this, context);
     ImmutableList.Builder<Aggregator> aggregatorBuilder = new ImmutableList.Builder<>();
     for (UnresolvedExpression expr : node.getAggExprList()) {
       aggregatorBuilder.add((Aggregator) expressionAnalyzer.analyze(expr, context));
     }
+    ImmutableList<Aggregator> aggregators = aggregatorBuilder.build();
 
     ImmutableList.Builder<Expression> groupbyBuilder = new ImmutableList.Builder<>();
     for (UnresolvedExpression expr : node.getGroupExprList()) {
       groupbyBuilder.add(expressionAnalyzer.analyze(expr, context));
     }
-    return new LogicalAggregation(child, aggregatorBuilder.build(), groupbyBuilder.build());
+    ImmutableList<Expression> groupBys = groupbyBuilder.build();
+
+    // new context
+    context.push();
+    TypeEnvironment newEnv = context.peek();
+    aggregators.forEach(aggregator -> newEnv.define(new Symbol(Namespace.FIELD_NAME,
+        aggregator.toString()), aggregator.type()));
+    groupBys.forEach(group -> newEnv.define(new Symbol(Namespace.FIELD_NAME,
+        group.toString()), group.type()));
+    return new LogicalAggregation(child, aggregators, groupBys);
   }
 
   /**
@@ -161,18 +185,24 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
       Argument argument = node.getArgExprList().get(0);
       Boolean exclude = (Boolean) argument.getValue().getValue();
       if (exclude) {
+        TypeEnvironment curEnv = context.peek();
         List<ReferenceExpression> referenceExpressions =
             node.getProjectList().stream()
                 .map(expr -> (ReferenceExpression) expressionAnalyzer.analyze(expr, context))
                 .collect(Collectors.toList());
+        referenceExpressions.forEach(ref -> curEnv.remove(ref));
         return new LogicalRemove(child, ImmutableSet.copyOf(referenceExpressions));
       }
     }
 
-    List<NamedExpression> expressions = node.getProjectList().stream()
-        .map(expr -> named(expressionAnalyzer.analyze(expr, context)))
-        .collect(Collectors.toList());
-    return new LogicalProject(child, expressions);
+    List<NamedExpression> namedExpressions =
+        selectExpressionAnalyzer.analyze(node.getProjectList(), context);
+    // new context
+    context.push();
+    TypeEnvironment newEnv = context.peek();
+    namedExpressions.forEach(expr -> newEnv.define(new Symbol(Namespace.FIELD_NAME,
+        expr.getName()), expr.type()));
+    return new LogicalProject(child, namedExpressions);
   }
 
   /**

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzer.java
@@ -164,13 +164,6 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
     return visitIdentifier(node.toString(), context);
   }
 
-  @Override
-  public Expression visitAlias(Alias node, AnalysisContext context) {
-    return DSL.named(node.getName(),
-                     node.getDelegated().accept(this, context),
-                     node.getAlias());
-  }
-
   private Expression visitIdentifier(String ident, AnalysisContext context) {
     TypeEnvironment typeEnv = context.peek();
     ReferenceExpression ref = DSL.ref(ident,

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/TypeEnvironment.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/TypeEnvironment.java
@@ -23,6 +23,8 @@ import com.amazon.opendistroforelasticsearch.sql.exception.SemanticCheckExceptio
 import com.amazon.opendistroforelasticsearch.sql.expression.Expression;
 import com.amazon.opendistroforelasticsearch.sql.expression.ReferenceExpression;
 import com.amazon.opendistroforelasticsearch.sql.expression.env.Environment;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import lombok.Getter;
 
@@ -63,6 +65,17 @@ public class TypeEnvironment implements Environment<Symbol, ExprType> {
   }
 
   /**
+   * Resolve all fields in the current environment.
+   * @param namespace     a namespace
+   * @return              all symbols in the namespace
+   */
+  public Map<String, ExprType> lookupAllFields(Namespace namespace) {
+    Map<String, ExprType> result = new HashMap<>();
+    symbolTable.lookupAllFields(namespace).forEach(result::putIfAbsent);
+    return result;
+  }
+
+  /**
    * Define symbol with the type.
    *
    * @param symbol symbol to define
@@ -81,4 +94,14 @@ public class TypeEnvironment implements Environment<Symbol, ExprType> {
     define(new Symbol(Namespace.FIELD_NAME, ref.getAttr()), ref.type());
   }
 
+  public void remove(Symbol symbol) {
+    symbolTable.remove(symbol);
+  }
+
+  /**
+   * Remove ref.
+   */
+  public void remove(ReferenceExpression ref) {
+    remove(new Symbol(Namespace.FIELD_NAME, ref.getAttr()));
+  }
 }

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/symbol/SymbolTable.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/symbol/SymbolTable.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 /**
  * Symbol table for symbol definition and resolution.
@@ -47,6 +48,19 @@ public class SymbolTable {
         symbol.getNamespace(),
         ns -> new TreeMap<>()
     ).put(symbol.getName(), type);
+  }
+
+  /**
+   * Remove a symbol from SymbolTable.
+   */
+  public void remove(Symbol symbol) {
+    tableByNamespace.computeIfPresent(
+        symbol.getNamespace(),
+        (k, v) -> {
+          v.remove(symbol.getName());
+          return v;
+        }
+    );
   }
 
   /**
@@ -76,6 +90,21 @@ public class SymbolTable {
       return table.subMap(prefix.getName(), prefix.getName() + Character.MAX_VALUE);
     }
     return emptyMap();
+  }
+
+  /**
+   * Look up all top level symbols in the namespace.
+   * this function is mainly used by SELECT * use case to get the top level fields
+   * Todo. currently, the top level fields is the field which doesn't include "." in the name.
+   *
+   * @param namespace     a namespace
+   * @return              all symbols in the namespace map
+   */
+  public Map<String, ExprType> lookupAllFields(Namespace namespace) {
+    return tableByNamespace.getOrDefault(namespace, emptyNavigableMap())
+        .entrySet().stream()
+        .filter(entry -> !entry.getKey().contains("."))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   /**

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/ast/AbstractNodeVisitor.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/ast/AbstractNodeVisitor.java
@@ -17,6 +17,7 @@ package com.amazon.opendistroforelasticsearch.sql.ast;
 
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.AggregateFunction;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Alias;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.AllFields;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.And;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Argument;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.AttributeList;
@@ -181,6 +182,10 @@ public abstract class AbstractNodeVisitor<T, C> {
   }
 
   public T visitAlias(Alias node, C context) {
+    return visitChildren(node, context);
+  }
+
+  public T visitAllFields(AllFields node, C context) {
     return visitChildren(node, context);
   }
 }

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/ast/dsl/AstDSL.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/ast/dsl/AstDSL.java
@@ -17,6 +17,7 @@ package com.amazon.opendistroforelasticsearch.sql.ast.dsl;
 
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.AggregateFunction;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Alias;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.AllFields;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.And;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Argument;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Compare;

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/ast/expression/AllFields.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/ast/expression/AllFields.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.ast.expression;
+
+import com.amazon.opendistroforelasticsearch.sql.ast.AbstractNodeVisitor;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+/**
+ * Represent the All fields which is been used in SELECT *.
+ */
+@ToString
+@EqualsAndHashCode(callSuper = false)
+public class AllFields extends UnresolvedExpression {
+  public static final AllFields INSTANCE = new AllFields();
+
+  private AllFields() {
+  }
+
+  public static AllFields of() {
+    return INSTANCE;
+  }
+
+  @Override
+  public <R, C> R accept(AbstractNodeVisitor<R, C> nodeVisitor, C context) {
+    return nodeVisitor.visitAllFields(this, context);
+  }
+}

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/ast/tree/Project.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/ast/tree/Project.java
@@ -52,6 +52,17 @@ public class Project extends UnresolvedPlan {
     return !argExprList.isEmpty();
   }
 
+  /**
+   * The Project could been used to exclude fields from the source.
+   */
+  public boolean isExcluded() {
+    if (hasArgument()) {
+      Argument argument = argExprList.get(0);
+      return (Boolean) argument.getValue().getValue();
+    }
+    return false;
+  }
+
   @Override
   public Project attach(UnresolvedPlan child) {
     this.child = child;

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprMissingValue.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprMissingValue.java
@@ -35,7 +35,7 @@ public class ExprMissingValue extends AbstractExprValue {
 
   @Override
   public Object value() {
-    throw new ExpressionEvaluationException("invalid to call value operation on missing value");
+    return null;
   }
 
   @Override

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/ExecutionEngine.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/executor/ExecutionEngine.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.sql.executor;
 
 import com.amazon.opendistroforelasticsearch.sql.common.response.ResponseListener;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
+import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
 import com.amazon.opendistroforelasticsearch.sql.planner.physical.PhysicalPlan;
 import java.util.List;
 import lombok.Data;
@@ -40,7 +41,20 @@ public interface ExecutionEngine {
    */
   @Data
   class QueryResponse {
+    private final Schema schema;
     private final List<ExprValue> results;
+  }
+
+  @Data
+  class Schema {
+    private final List<Column> columns;
+
+    @Data
+    public static class Column {
+      private final String name;
+      private final String alias;
+      private final ExprType exprType;
+    }
   }
 
 }

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/NamedExpression.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/NamedExpression.java
@@ -22,6 +22,7 @@ import com.amazon.opendistroforelasticsearch.sql.expression.env.Environment;
 import com.google.common.base.Strings;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
@@ -49,6 +50,7 @@ public class NamedExpression implements Expression {
   /**
    * Optional alias.
    */
+  @Getter
   private String alias;
 
   @Override

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/PhysicalPlan.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/PhysicalPlan.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.sql.planner.physical;
 
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
+import com.amazon.opendistroforelasticsearch.sql.executor.ExecutionEngine;
 import com.amazon.opendistroforelasticsearch.sql.planner.PlanNode;
 import java.util.Iterator;
 
@@ -42,5 +43,10 @@ public abstract class PhysicalPlan implements PlanNode<PhysicalPlan>,
 
   public void close() {
     getChild().forEach(PhysicalPlan::close);
+  }
+
+  public ExecutionEngine.Schema schema() {
+    throw new IllegalStateException(String.format("[BUG] schema can been only applied to "
+        + "ProjectOperator, instead of %s", toString()));
   }
 }

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/ProjectOperator.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/ProjectOperator.java
@@ -17,11 +17,13 @@ package com.amazon.opendistroforelasticsearch.sql.planner.physical;
 
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprTupleValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
+import com.amazon.opendistroforelasticsearch.sql.executor.ExecutionEngine;
 import com.amazon.opendistroforelasticsearch.sql.expression.NamedExpression;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -60,11 +62,15 @@ public class ProjectOperator extends PhysicalPlan {
     ImmutableMap.Builder<String, ExprValue> mapBuilder = new Builder<>();
     for (NamedExpression expr : projectList) {
       ExprValue exprValue = expr.valueOf(inputValue.bindingTuples());
-      // missing value is ignored.
-      if (!exprValue.isMissing()) {
-        mapBuilder.put(expr.getName(), exprValue);
-      }
+      mapBuilder.put(expr.getName(), exprValue);
     }
     return ExprTupleValue.fromExprValueMap(mapBuilder.build());
+  }
+
+  @Override
+  public ExecutionEngine.Schema schema() {
+    return new ExecutionEngine.Schema(getProjectList().stream()
+        .map(expr -> new ExecutionEngine.Schema.Column(expr.getName(),
+            expr.getName(), expr.type())).collect(Collectors.toList()));
   }
 }

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/ProjectOperator.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/ProjectOperator.java
@@ -71,6 +71,6 @@ public class ProjectOperator extends PhysicalPlan {
   public ExecutionEngine.Schema schema() {
     return new ExecutionEngine.Schema(getProjectList().stream()
         .map(expr -> new ExecutionEngine.Schema.Column(expr.getName(),
-            expr.getName(), expr.type())).collect(Collectors.toList()));
+            expr.getAlias(), expr.type())).collect(Collectors.toList()));
   }
 }

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/AnalyzerTest.java
@@ -32,13 +32,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL;
 import com.amazon.opendistroforelasticsearch.sql.exception.SemanticCheckException;
 import com.amazon.opendistroforelasticsearch.sql.expression.DSL;
+import com.amazon.opendistroforelasticsearch.sql.expression.config.ExpressionConfig;
 import com.amazon.opendistroforelasticsearch.sql.planner.logical.LogicalPlanDSL;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@Configuration
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ExpressionConfig.class, AnalyzerTest.class})
 class AnalyzerTest extends AnalyzerTestBase {
   @Test
   public void filter_relation() {

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzerTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzerTest.java
@@ -29,9 +29,16 @@ import com.amazon.opendistroforelasticsearch.sql.common.antlr.SyntaxCheckExcepti
 import com.amazon.opendistroforelasticsearch.sql.exception.SemanticCheckException;
 import com.amazon.opendistroforelasticsearch.sql.expression.DSL;
 import com.amazon.opendistroforelasticsearch.sql.expression.Expression;
+import com.amazon.opendistroforelasticsearch.sql.expression.config.ExpressionConfig;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-
+@Configuration
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ExpressionConfig.class, AnalyzerTestBase.class})
 class ExpressionAnalyzerTest extends AnalyzerTestBase {
 
   @Test
@@ -79,22 +86,6 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
     assertAnalyzeEqual(
         DSL.ref("integer_value", INTEGER),
         AstDSL.qualifiedName("integer_value")
-    );
-  }
-
-  @Test
-  public void named_expression() {
-    assertAnalyzeEqual(
-        DSL.named("int", DSL.ref("integer_value", INTEGER)),
-        AstDSL.alias("int", AstDSL.qualifiedName("integer_value"))
-    );
-  }
-
-  @Test
-  public void named_expression_with_alias() {
-    assertAnalyzeEqual(
-        DSL.named("integer", DSL.ref("integer_value", INTEGER), "int"),
-        AstDSL.alias("integer", AstDSL.qualifiedName("integer_value"), "int")
     );
   }
 

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/SelectAnalyzeTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/SelectAnalyzeTest.java
@@ -1,0 +1,161 @@
+/*
+ *
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.analysis;
+
+import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.argument;
+import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.booleanLiteral;
+import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.field;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.DOUBLE;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRING;
+
+import com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.AllFields;
+import com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType;
+import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
+import com.amazon.opendistroforelasticsearch.sql.expression.DSL;
+import com.amazon.opendistroforelasticsearch.sql.expression.config.ExpressionConfig;
+import com.amazon.opendistroforelasticsearch.sql.planner.logical.LogicalPlanDSL;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Configuration
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ExpressionConfig.class, SelectAnalyzeTest.class})
+public class SelectAnalyzeTest extends AnalyzerTestBase {
+
+  @Override
+  protected Map<String, ExprType> typeMapping() {
+    return new ImmutableMap.Builder<String, ExprType>()
+        .put("integer_value", ExprCoreType.INTEGER)
+        .put("double_value", ExprCoreType.DOUBLE)
+        .put("string_value", ExprCoreType.STRING)
+        .build();
+  }
+
+  @Test
+  public void project_all_from_source() {
+    assertAnalyzeEqual(
+        LogicalPlanDSL.project(
+            LogicalPlanDSL.relation("schema"),
+            DSL.named("integer_value", DSL.ref("integer_value", INTEGER)),
+            DSL.named("double_value", DSL.ref("double_value", DOUBLE)),
+            DSL.named("string_value", DSL.ref("string_value", STRING)),
+            DSL.named("integer_value", DSL.ref("integer_value", INTEGER)),
+            DSL.named("double_value", DSL.ref("double_value", DOUBLE))
+        ),
+        AstDSL.projectWithArg(
+            AstDSL.relation("schema"),
+            AstDSL.defaultFieldsArgs(),
+            AstDSL.field("integer_value"), // Field not wrapped by Alias
+            AstDSL.alias("double_value", AstDSL.field("double_value")),
+            AllFields.of()));
+  }
+
+  @Test
+  public void select_and_project_all() {
+    assertAnalyzeEqual(
+        LogicalPlanDSL.project(
+            LogicalPlanDSL.project(
+                LogicalPlanDSL.relation("schema"),
+                DSL.named("integer_value", DSL.ref("integer_value", INTEGER)),
+                DSL.named("double_value", DSL.ref("double_value", DOUBLE))
+            ),
+            DSL.named("integer_value", DSL.ref("integer_value", INTEGER)),
+            DSL.named("double_value", DSL.ref("double_value", DOUBLE))
+        ),
+        AstDSL.projectWithArg(
+            AstDSL.projectWithArg(
+                AstDSL.relation("schema"),
+                AstDSL.defaultFieldsArgs(),
+                AstDSL.field("integer_value"),
+                AstDSL.field("double_value")),
+            AstDSL.defaultFieldsArgs(),
+            AllFields.of()
+        ));
+  }
+
+  @Test
+  public void remove_and_project_all() {
+    assertAnalyzeEqual(
+        LogicalPlanDSL.project(
+            LogicalPlanDSL.remove(
+                LogicalPlanDSL.relation("schema"),
+                DSL.ref("integer_value", INTEGER),
+                DSL.ref("double_value", DOUBLE)
+            ),
+            DSL.named("string_value", DSL.ref("string_value", STRING))
+        ),
+        AstDSL.projectWithArg(
+            AstDSL.projectWithArg(
+                AstDSL.relation("schema"),
+                AstDSL.exprList(argument("exclude", booleanLiteral(true))),
+                AstDSL.field("integer_value"),
+                AstDSL.field("double_value")),
+            AstDSL.defaultFieldsArgs(),
+            AllFields.of()
+        ));
+  }
+
+  @Test
+  public void stats_and_project_all() {
+    assertAnalyzeEqual(
+        LogicalPlanDSL.project(
+            LogicalPlanDSL.aggregation(
+                LogicalPlanDSL.relation("schema"),
+                ImmutableList.of(dsl.avg(DSL.ref("integer_value", INTEGER))),
+                ImmutableList.of(DSL.ref("string_value", STRING))),
+            DSL.named("string_value", DSL.ref("string_value", STRING)),
+            DSL.named("avg(integer_value)", DSL.ref("avg(integer_value)", DOUBLE))
+        ),
+        AstDSL.projectWithArg(
+            AstDSL.agg(
+                AstDSL.relation("schema"),
+                AstDSL.exprList(AstDSL.aggregate("avg", field("integer_value"))),
+                null,
+                ImmutableList.of(field("string_value")),
+                AstDSL.defaultStatsArgs()), AstDSL.defaultFieldsArgs(),
+            AllFields.of()));
+  }
+
+  @Test
+  public void rename_and_project_all() {
+    assertAnalyzeEqual(
+        LogicalPlanDSL.project(
+            LogicalPlanDSL.rename(
+                LogicalPlanDSL.relation("schema"),
+                ImmutableMap.of(DSL.ref("integer_value", INTEGER), DSL.ref("ivalue", INTEGER))),
+            DSL.named("ivalue", DSL.ref("ivalue", INTEGER)),
+            DSL.named("string_value", DSL.ref("string_value", STRING)),
+            DSL.named("double_value", DSL.ref("double_value", DOUBLE))
+        ),
+        AstDSL.projectWithArg(
+            AstDSL.rename(
+                AstDSL.relation("schema"),
+                AstDSL.map(AstDSL.field("integer_value"), AstDSL.field("ivalue"))),
+            AstDSL.defaultFieldsArgs(),
+            AllFields.of()
+        ));
+  }
+}

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/SelectExpressionAnalyzerTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/SelectExpressionAnalyzerTest.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.analysis;
+
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
+import com.amazon.opendistroforelasticsearch.sql.expression.DSL;
+import com.amazon.opendistroforelasticsearch.sql.expression.NamedExpression;
+import com.amazon.opendistroforelasticsearch.sql.expression.config.ExpressionConfig;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Configuration
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ExpressionConfig.class, SelectExpressionAnalyzerTest.class})
+public class SelectExpressionAnalyzerTest extends AnalyzerTestBase {
+
+
+  @Test
+  public void named_expression() {
+    assertAnalyzeEqual(
+        DSL.named("int", DSL.ref("integer_value", INTEGER)),
+        AstDSL.alias("int", AstDSL.qualifiedName("integer_value"))
+    );
+  }
+
+  @Test
+  public void named_expression_with_alias() {
+    assertAnalyzeEqual(
+        DSL.named("integer", DSL.ref("integer_value", INTEGER), "int"),
+        AstDSL.alias("integer", AstDSL.qualifiedName("integer_value"), "int")
+    );
+  }
+
+  protected List<NamedExpression> analyze(UnresolvedExpression unresolvedExpression) {
+
+    return new SelectExpressionAnalyzer(expressionAnalyzer)
+        .analyze(Arrays.asList(unresolvedExpression),
+            analysisContext);
+  }
+
+  protected void assertAnalyzeEqual(NamedExpression expected,
+                                    UnresolvedExpression unresolvedExpression) {
+    assertEquals(Arrays.asList(expected), analyze(unresolvedExpression));
+  }
+}

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/config/TestConfig.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/config/TestConfig.java
@@ -47,7 +47,7 @@ public class TestConfig {
   public static final String STRING_TYPE_NULL_VALUE_FILED = "string_null_value";
   public static final String STRING_TYPE_MISSING_VALUE_FILED = "string_missing_value";
 
-  private static Map<String, ExprType> typeMapping = new ImmutableMap.Builder<String, ExprType>()
+  public static Map<String, ExprType> typeMapping = new ImmutableMap.Builder<String, ExprType>()
       .put("integer_value", ExprCoreType.INTEGER)
       .put(INT_TYPE_NULL_VALUE_FIELD, ExprCoreType.INTEGER)
       .put(INT_TYPE_MISSING_VALUE_FIELD, ExprCoreType.INTEGER)

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprMissingValueTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprMissingValueTest.java
@@ -20,6 +20,7 @@ import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtil
 import static com.amazon.opendistroforelasticsearch.sql.utils.ComparisonUtil.compare;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,9 +38,7 @@ class ExprMissingValueTest {
 
   @Test
   public void getValue() {
-    ExpressionEvaluationException exception = assertThrows(ExpressionEvaluationException.class,
-        () -> LITERAL_MISSING.value());
-    assertEquals("invalid to call value operation on missing value", exception.getMessage());
+    assertNull(LITERAL_MISSING.value());
   }
 
   @Test

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprTupleValueTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprTupleValueTest.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.sql.data.model;
 import static com.amazon.opendistroforelasticsearch.sql.utils.ComparisonUtil.compare;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -37,6 +38,15 @@ class ExprTupleValueTest {
     ExprValue tupleValue = ExprValueUtils.tupleValue(ImmutableMap.of("integer_value", 2));
     ExprValue intValue = ExprValueUtils.integerValue(10);
     assertFalse(tupleValue.equals(intValue));
+  }
+
+  @Test
+  public void compare_tuple_with_different_key() {
+    ExprValue tupleValue1 = ExprValueUtils.tupleValue(ImmutableMap.of("value", 2));
+    ExprValue tupleValue2 =
+        ExprValueUtils.tupleValue(ImmutableMap.of("integer_value", 2, "float_value", 1f));
+    assertNotEquals(tupleValue1, tupleValue2);
+    assertNotEquals(tupleValue2, tupleValue1);
   }
 
   @Test

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/NamedExpressionTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/NamedExpressionTest.java
@@ -42,4 +42,13 @@ class NamedExpressionTest extends ExpressionTestBase {
     assertEquals("ten", namedExpression.getName());
   }
 
+  @Test
+  void name_an_named_expression() {
+    LiteralExpression delegated = DSL.literal(10);
+    Expression expression = DSL.named("10", delegated, "ten");
+
+    NamedExpression namedExpression = DSL.named(expression);
+    assertEquals("ten", namedExpression.getName());
+  }
+
 }

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/logical/LogicalDedupeTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/logical/LogicalDedupeTest.java
@@ -28,8 +28,16 @@ import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.I
 
 import com.amazon.opendistroforelasticsearch.sql.analysis.AnalyzerTestBase;
 import com.amazon.opendistroforelasticsearch.sql.expression.DSL;
+import com.amazon.opendistroforelasticsearch.sql.expression.config.ExpressionConfig;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@Configuration
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ExpressionConfig.class, AnalyzerTestBase.class})
 class LogicalDedupeTest extends AnalyzerTestBase {
   @Test
   public void analyze_dedup_with_two_field_with_default_option() {

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/logical/LogicalEvalTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/logical/LogicalEvalTest.java
@@ -21,11 +21,18 @@ import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.I
 import com.amazon.opendistroforelasticsearch.sql.analysis.AnalyzerTestBase;
 import com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL;
 import com.amazon.opendistroforelasticsearch.sql.expression.DSL;
+import com.amazon.opendistroforelasticsearch.sql.expression.config.ExpressionConfig;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@Configuration
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ExpressionConfig.class, AnalyzerTestBase.class})
 @ExtendWith(MockitoExtension.class)
 public class LogicalEvalTest extends AnalyzerTestBase {
 

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/logical/LogicalSortTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/logical/LogicalSortTest.java
@@ -31,9 +31,17 @@ import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.I
 import com.amazon.opendistroforelasticsearch.sql.analysis.AnalyzerTestBase;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.Sort.SortOption;
 import com.amazon.opendistroforelasticsearch.sql.expression.DSL;
+import com.amazon.opendistroforelasticsearch.sql.expression.config.ExpressionConfig;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@Configuration
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ExpressionConfig.class, AnalyzerTestBase.class})
 class LogicalSortTest extends AnalyzerTestBase {
   @Test
   public void analyze_sort_with_two_field_with_default_option() {

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/ProjectOperatorTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/ProjectOperatorTest.java
@@ -107,8 +107,8 @@ class ProjectOperatorTest extends PhysicalPlanTestBase {
         DSL.named("action", DSL.ref("action", STRING)));
 
     assertThat(project.schema().getColumns(), contains(
-        new ExecutionEngine.Schema.Column("response", "response", INTEGER),
-        new ExecutionEngine.Schema.Column("action", "action", STRING)
+        new ExecutionEngine.Schema.Column("response", null, INTEGER),
+        new ExecutionEngine.Schema.Column("action", null, STRING)
     ));
   }
 }

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/ProjectOperatorTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/ProjectOperatorTest.java
@@ -15,17 +15,22 @@
 
 package com.amazon.opendistroforelasticsearch.sql.planner.physical;
 
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.LITERAL_MISSING;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.stringValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRING;
 import static com.amazon.opendistroforelasticsearch.sql.planner.physical.PhysicalPlanDSL.project;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.mockito.Mockito.when;
 
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprTupleValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils;
+import com.amazon.opendistroforelasticsearch.sql.executor.ExecutionEngine;
 import com.amazon.opendistroforelasticsearch.sql.expression.DSL;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
@@ -74,7 +79,7 @@ class ProjectOperatorTest extends PhysicalPlanTestBase {
   }
 
   @Test
-  public void project_ignore_missing_value() {
+  public void project_keep_missing_value() {
     when(inputPlan.hasNext()).thenReturn(true, true, false);
     when(inputPlan.next())
         .thenReturn(ExprValueUtils.tupleValue(ImmutableMap.of("action", "GET", "response", 200)))
@@ -90,6 +95,20 @@ class ProjectOperatorTest extends PhysicalPlanTestBase {
             iterableWithSize(2),
             hasItems(
                 ExprValueUtils.tupleValue(ImmutableMap.of("response", 200, "action", "GET")),
-                ExprValueUtils.tupleValue(ImmutableMap.of("action", "POST")))));
+                ExprTupleValue.fromExprValueMap(ImmutableMap.of("response",
+                    LITERAL_MISSING,
+                    "action", stringValue("POST"))))));
+  }
+
+  @Test
+  public void project_schema() {
+    PhysicalPlan project = project(inputPlan,
+        DSL.named("response", DSL.ref("response", INTEGER)),
+        DSL.named("action", DSL.ref("action", STRING)));
+
+    assertThat(project.schema().getColumns(), contains(
+        new ExecutionEngine.Schema.Column("response", "response", INTEGER),
+        new ExecutionEngine.Schema.Column("action", "action", STRING)
+    ));
   }
 }

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/RemoveOperatorTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/planner/physical/RemoveOperatorTest.java
@@ -22,6 +22,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.iterableWithSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
@@ -116,5 +118,16 @@ class RemoveOperatorTest extends PhysicalPlanTestBase {
     List<ExprValue> result = execute(plan);
 
     assertThat(result, allOf(iterableWithSize(1), hasItems(ExprValueUtils.integerValue(1))));
+  }
+
+  @Test
+  public void invalid_to_retrieve_schema_from_remove() {
+    PhysicalPlan plan = remove(inputPlan, DSL.ref("response", STRING), DSL.ref("referer", STRING));
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> plan.schema());
+    assertEquals(
+        "[BUG] schema can been only applied to ProjectOperator, "
+            + "instead of RemoveOperator(input=inputPlan, removeList=[response, referer])",
+        exception.getMessage());
   }
 }

--- a/docs/category.json
+++ b/docs/category.json
@@ -17,6 +17,7 @@
   "sql_cli": [
     "user/dql/expressions.rst",
     "user/general/identifiers.rst",
+    "user/general/values.rst",
     "user/dql/functions.rst",
     "user/beyond/partiql.rst"
   ]

--- a/docs/experiment/ppl/cmd/search.rst
+++ b/docs/experiment/ppl/cmd/search.rst
@@ -32,14 +32,14 @@ PPL query::
 
     od> source=accounts;
     fetched rows / total rows = 4/4
-    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
-    | account_number   | balance   | firstname   | lastname   | age   | gender   | address              | employer   | email                 | city   | state   |
-    |------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------|
-    | 1                | 39225     | Amber       | Duke       | 32    | M        | 880 Holmes Lane      | Pyrami     | amberduke@pyrami.com  | Brogan | IL      |
-    | 6                | 5686      | Hattie      | Bond       | 36    | M        | 671 Bristol Street   | Netagy     | hattiebond@netagy.com | Dante  | TN      |
-    | 13               | 32838     | Nanette     | Bates      | 28    | F        | 789 Madison Street   | Quility    | null                  | Nogal  | VA      |
-    | 18               | 4180      | Dale        | Adams      | 33    | M        | 467 Hutchinson Court | null       | daleadams@boink.com   | Orick  | MD      |
-    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
+    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
+    | account_number   | firstname   | address              | balance   | gender   | city   | employer   | state   | age   | email                 | lastname   |
+    |------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------|
+    | 1                | Amber       | 880 Holmes Lane      | 39225     | M        | Brogan | Pyrami     | IL      | 32    | amberduke@pyrami.com  | Duke       |
+    | 6                | Hattie      | 671 Bristol Street   | 5686      | M        | Dante  | Netagy     | TN      | 36    | hattiebond@netagy.com | Bond       |
+    | 13               | Nanette     | 789 Madison Street   | 32838     | F        | Nogal  | Quility    | VA      | 28    | null                  | Bates      |
+    | 18               | Dale        | 467 Hutchinson Court | 4180      | M        | Orick  | null       | MD      | 33    | daleadams@boink.com   | Adams      |
+    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
 
 Example 2: Fetch data with condition
 ====================================
@@ -50,10 +50,10 @@ PPL query::
 
     od> source=accounts account_number=1 or gender="F";
     fetched rows / total rows = 2/2
-    +------------------+-----------+-------------+------------+-------+----------+--------------------+------------+----------------------+--------+---------+
-    | account_number   | balance   | firstname   | lastname   | age   | gender   | address            | employer   | email                | city   | state   |
-    |------------------+-----------+-------------+------------+-------+----------+--------------------+------------+----------------------+--------+---------|
-    | 1                | 39225     | Amber       | Duke       | 32    | M        | 880 Holmes Lane    | Pyrami     | amberduke@pyrami.com | Brogan | IL      |
-    | 13               | 32838     | Nanette     | Bates      | 28    | F        | 789 Madison Street | Quility    | null                 | Nogal  | VA      |
-    +------------------+-----------+-------------+------------+-------+----------+--------------------+------------+----------------------+--------+---------+
+    +------------------+-------------+--------------------+-----------+----------+--------+------------+---------+-------+----------------------+------------+
+    | account_number   | firstname   | address            | balance   | gender   | city   | employer   | state   | age   | email                | lastname   |
+    |------------------+-------------+--------------------+-----------+----------+--------+------------+---------+-------+----------------------+------------|
+    | 1                | Amber       | 880 Holmes Lane    | 39225     | M        | Brogan | Pyrami     | IL      | 32    | amberduke@pyrami.com | Duke       |
+    | 13               | Nanette     | 789 Madison Street | 32838     | F        | Nogal  | Quility    | VA      | 28    | null                 | Bates      |
+    +------------------+-------------+--------------------+-----------+----------+--------+------------+---------+-------+----------------------+------------+
 

--- a/docs/user/general/identifiers.rst
+++ b/docs/user/general/identifiers.rst
@@ -40,14 +40,14 @@ Here are examples for using index pattern directly without quotes::
 
     od> SELECT * FROM *cc*nt*;
     fetched rows / total rows = 4/4
-    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
-    | account_number   | balance   | firstname   | lastname   | age   | gender   | address              | employer   | email                 | city   | state   |
-    |------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------|
-    | 1                | 39225     | Amber       | Duke       | 32    | M        | 880 Holmes Lane      | Pyrami     | amberduke@pyrami.com  | Brogan | IL      |
-    | 6                | 5686      | Hattie      | Bond       | 36    | M        | 671 Bristol Street   | Netagy     | hattiebond@netagy.com | Dante  | TN      |
-    | 13               | 32838     | Nanette     | Bates      | 28    | F        | 789 Madison Street   | Quility    | null                  | Nogal  | VA      |
-    | 18               | 4180      | Dale        | Adams      | 33    | M        | 467 Hutchinson Court | null       | daleadams@boink.com   | Orick  | MD      |
-    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
+    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
+    | account_number   | firstname   | address              | balance   | gender   | city   | employer   | state   | age   | email                 | lastname   |
+    |------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------|
+    | 1                | Amber       | 880 Holmes Lane      | 39225     | M        | Brogan | Pyrami     | IL      | 32    | amberduke@pyrami.com  | Duke       |
+    | 6                | Hattie      | 671 Bristol Street   | 5686      | M        | Dante  | Netagy     | TN      | 36    | hattiebond@netagy.com | Bond       |
+    | 13               | Nanette     | 789 Madison Street   | 32838     | F        | Nogal  | Quility    | VA      | 28    | null                  | Bates      |
+    | 18               | Dale        | 467 Hutchinson Court | 4180      | M        | Orick  | null       | MD      | 33    | daleadams@boink.com   | Adams      |
+    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
 
 
 Delimited Identifiers
@@ -76,14 +76,14 @@ Here are examples for quoting an index name by back ticks::
 
     od> SELECT * FROM `accounts`;
     fetched rows / total rows = 4/4
-    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
-    | account_number   | balance   | firstname   | lastname   | age   | gender   | address              | employer   | email                 | city   | state   |
-    |------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------|
-    | 1                | 39225     | Amber       | Duke       | 32    | M        | 880 Holmes Lane      | Pyrami     | amberduke@pyrami.com  | Brogan | IL      |
-    | 6                | 5686      | Hattie      | Bond       | 36    | M        | 671 Bristol Street   | Netagy     | hattiebond@netagy.com | Dante  | TN      |
-    | 13               | 32838     | Nanette     | Bates      | 28    | F        | 789 Madison Street   | Quility    | null                  | Nogal  | VA      |
-    | 18               | 4180      | Dale        | Adams      | 33    | M        | 467 Hutchinson Court | null       | daleadams@boink.com   | Orick  | MD      |
-    +------------------+-----------+-------------+------------+-------+----------+----------------------+------------+-----------------------+--------+---------+
+    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
+    | account_number   | firstname   | address              | balance   | gender   | city   | employer   | state   | age   | email                 | lastname   |
+    |------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------|
+    | 1                | Amber       | 880 Holmes Lane      | 39225     | M        | Brogan | Pyrami     | IL      | 32    | amberduke@pyrami.com  | Duke       |
+    | 6                | Hattie      | 671 Bristol Street   | 5686      | M        | Dante  | Netagy     | TN      | 36    | hattiebond@netagy.com | Bond       |
+    | 13               | Nanette     | 789 Madison Street   | 32838     | F        | Nogal  | Quility    | VA      | 28    | null                  | Bates      |
+    | 18               | Dale        | 467 Hutchinson Court | 4180      | M        | Orick  | null       | MD      | 33    | daleadams@boink.com   | Adams      |
+    +------------------+-------------+----------------------+-----------+----------+--------+------------+---------+-------+-----------------------+------------+
 
 
 Case Sensitivity

--- a/docs/user/general/values.rst
+++ b/docs/user/general/values.rst
@@ -1,0 +1,91 @@
+==========
+Data Types
+==========
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+NULL and MISSING Values
+=======================
+ODFE SQL has two ways to represent missing information. (1) The presence of the field with a NULL for its value. and (2) the absence of the filed.
+
+Please note, when response is in table format, the MISSING value is translate to NULL value.
+
+Here is an example, Nanette doesn't have email field and Dail has employer filed with NULL value::
+
+    od> SELECT firstname, employer, email FROM accounts;
+    fetched rows / total rows = 4/4
+    +-------------+------------+-----------------------+
+    | firstname   | employer   | email                 |
+    |-------------+------------+-----------------------|
+    | Amber       | Pyrami     | amberduke@pyrami.com  |
+    | Hattie      | Netagy     | hattiebond@netagy.com |
+    | Nanette     | Quility    | null                  |
+    | Dale        | null       | daleadams@boink.com   |
+    +-------------+------------+-----------------------+
+
+
+General NULL and MISSING Values Handling
+----------------------------------------
+In general, if any operand evaluates to a MISSING value, the enclosing operator will return MISSING; if none of operands evaluates to a MISSING value but there is an operand evaluates to a NULL value, the enclosing operator will return NULL.
+
+Here is an example::
+
+    od> SELECT firstname, employer LIKE 'Quility', email LIKE '%com' FROM accounts;
+    fetched rows / total rows = 4/4
+    +-------------+---------------------------+---------------------+
+    | firstname   | employer LIKE 'Quility'   | email LIKE '%com'   |
+    |-------------+---------------------------+---------------------|
+    | Amber       | False                     | True                |
+    | Hattie      | False                     | True                |
+    | Nanette     | True                      | null                |
+    | Dale        | null                      | True                |
+    +-------------+---------------------------+---------------------+
+
+Special NULL and MISSING Values Handling
+----------------------------------------
+THe AND, OR and NOT have special logic to handling NULL and MISSING value.
+
+The following table is the truth table for AND and OR.
+
++---------+---------+---------+---------+
+| A       | B       | A AND B | A OR B  |
++---------+---------+---------+---------+
+| TRUE    | TRUE    | TRUE    | TRUE    |
++---------+---------+---------+---------+
+| TRUE    | FALSE   | FALSE   | TRUE    |
++---------+---------+---------+---------+
+| TRUE    | NULL    | NULL    | TRUE    |
++---------+---------+---------+---------+
+| TRUE    | MISSING | MISSING | TRUE    |
++---------+---------+---------+---------+
+| FALSE   | FALSE   | FALSE   | FALSE   |
++---------+---------+---------+---------+
+| FALSE   | NULL    | FALSE   | NULL    |
++---------+---------+---------+---------+
+| FALSE   | MISSING | FALSE   | MISSING |
++---------+---------+---------+---------+
+| NULL    | NULL    | NULL    | NULL    |
++---------+---------+---------+---------+
+| NULL    | MISSING | MISSING | NULL    |
++---------+---------+---------+---------+
+| MISSING | MISSING | MISSING | MISSING |
++---------+---------+---------+---------+
+
+The following table is the truth table for NOT.
+
++---------+---------+
+| A       | NOT A   |
++---------+---------+
+| TRUE    | FALSE   |
++---------+---------+
+| FALSE   | TRUE    |
++---------+---------+
+| NULL    | NULL    |
++---------+---------+
+| MISSING | MISSING |
++---------+---------+

--- a/doctest/test_data/accounts.json
+++ b/doctest/test_data/accounts.json
@@ -1,4 +1,4 @@
 {"account_number":1,"balance":39225,"firstname":"Amber","lastname":"Duke","age":32,"gender":"M","address":"880 Holmes Lane","employer":"Pyrami","email":"amberduke@pyrami.com","city":"Brogan","state":"IL"}
 {"account_number":6,"balance":5686,"firstname":"Hattie","lastname":"Bond","age":36,"gender":"M","address":"671 Bristol Street","employer":"Netagy","email":"hattiebond@netagy.com","city":"Dante","state":"TN"}
-{"account_number":13,"balance":32838,"firstname":"Nanette","lastname":"Bates","age":28,"gender":"F","address":"789 Madison Street","employer":"Quility","email":null,"city":"Nogal","state":"VA"}
+{"account_number":13,"balance":32838,"firstname":"Nanette","lastname":"Bates","age":28,"gender":"F","address":"789 Madison Street","employer":"Quility","city":"Nogal","state":"VA"}
 {"account_number":18,"balance":4180,"firstname":"Dale","lastname":"Adams","age":33,"gender":"M","address":"467 Hutchinson Court","employer":null,"email":"daleadams@boink.com","city":"Orick","state":"MD"}

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/executor/ElasticsearchExecutionEngine.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/executor/ElasticsearchExecutionEngine.java
@@ -47,7 +47,7 @@ public class ElasticsearchExecutionEngine implements ExecutionEngine {
               result.add(plan.next());
             }
 
-            QueryResponse response = new QueryResponse(result);
+            QueryResponse response = new QueryResponse(physicalPlan.schema(), result);
             listener.onResponse(response);
           } catch (Exception e) {
             listener.onFailure(e);

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/executor/ElasticsearchExecutionEngineTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/executor/ElasticsearchExecutionEngineTest.java
@@ -32,6 +32,7 @@ import com.amazon.opendistroforelasticsearch.sql.common.response.ResponseListene
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.executor.protector.ElasticsearchExecutionProtector;
+import com.amazon.opendistroforelasticsearch.sql.executor.ExecutionEngine;
 import com.amazon.opendistroforelasticsearch.sql.planner.physical.PhysicalPlan;
 import com.amazon.opendistroforelasticsearch.sql.storage.TableScanOperator;
 import java.util.ArrayList;
@@ -52,6 +53,8 @@ class ElasticsearchExecutionEngineTest {
   @Mock private ElasticsearchClient client;
 
   @Mock private ElasticsearchExecutionProtector protector;
+
+  @Mock private static ExecutionEngine.Schema schema;
 
   @BeforeEach
   void setUp() {
@@ -147,6 +150,11 @@ class ElasticsearchExecutionEngineTest {
     @Override
     public ExprValue next() {
       return it.next();
+    }
+
+    @Override
+    public ExecutionEngine.Schema schema() {
+      return schema;
     }
   }
 }

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -39,7 +39,10 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.6.2')
 
     // JDBC drivers for comparison test. Somehow Apache Derby throws security permission exception.
-    testCompile group: 'com.amazon.opendistroforelasticsearch.client', name: 'opendistro-sql-jdbc', version: '1.8.0.0'
+    testCompile fileTree('../sql-jdbc/build/libs') {
+        include '*.jar'
+        builtBy 'compileJdbc'
+    }
     testCompile group: 'com.h2database', name: 'h2', version: '1.4.200'
     testCompile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.28.0'
     //testCompile group: 'org.apache.derby', name: 'derby', version: '10.15.1.3'
@@ -183,3 +186,9 @@ testClusters.comparisonTest {
     plugin file(tasks.getByPath(':plugin:bundlePlugin').archiveFile)
 }
 
+task compileJdbc(type:Exec) {
+    workingDir '../sql-jdbc/'
+
+    commandLine './gradlew', 'build'
+    commandLine './gradlew', 'shadowJar'
+}

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/DedupCommandIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/DedupCommandIT.java
@@ -66,11 +66,11 @@ public class DedupCommandIT extends PPLIntegTestCase {
     verifyDataRows(
         result,
         rows("Amber JOHnny", 39225),
-        rows("Hattie"),
+        rows("Hattie", null),
         rows("Nanette", 32838),
         rows("Dale", 4180),
-        rows("Elinor"),
-        rows("Virginia"),
+        rows("Elinor", null),
+        rows("Virginia", null),
         rows("Dillard", 48086));
   }
 }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/OperatorIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/OperatorIT.java
@@ -22,7 +22,6 @@ import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.verify
 
 import java.io.IOException;
 import org.elasticsearch.client.ResponseException;
-import org.hamcrest.Matchers;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
@@ -118,7 +117,8 @@ public class OperatorIT extends PPLIntegTestCase {
             String.format(
                 "source=%s | eval f = balance * 1 | fields f", TEST_INDEX_BANK_WITH_NULL_VALUES));
     verifyDataRows(
-        result, rows(39225), rows(32838), rows(4180), rows(48086), rows(), rows(), rows());
+        result, rows(39225), rows(32838), rows(4180), rows(48086), rows(JSONObject.NULL),
+        rows(JSONObject.NULL), rows(JSONObject.NULL));
   }
 
   @Test

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
@@ -110,7 +110,7 @@ public class StandaloneIT extends PPLIntegTestCase {
 
           @Override
           public void onResponse(QueryResponse response) {
-            QueryResult result = new QueryResult(response.getResults());
+            QueryResult result = new QueryResult(response.getSchema(), response.getResults());
             String json = new SimpleJsonResponseFormatter(PRETTY).format(result);
             actual.set(json);
           }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/util/MatcherUtils.java
@@ -244,6 +244,8 @@ public class MatcherUtils {
             isEqual = ((JSONObject) expected).similar(array.get(i));
           } else if (expected instanceof JSONArray) {
             isEqual = ((JSONArray) expected).similar(array.get(i));
+          } else if (null == expected) {
+            isEqual = JSONObject.NULL == array.get(i);
           } else {
             isEqual = expected.equals(array.get(i));
           }

--- a/integ-test/src/test/resources/correctness/expressions/literals.txt
+++ b/integ-test/src/test/resources/correctness/expressions/literals.txt
@@ -2,3 +2,4 @@
 true
 -4.567
 -123,false
+'ODFE'

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -121,7 +121,8 @@ public class RestSQLQueryAction extends BaseRestHandler {
     return new ResponseListener<QueryResponse>() {
       @Override
       public void onResponse(QueryResponse response) {
-        sendResponse(OK, formatter.format(new QueryResult(response.getResults())));
+        sendResponse(OK, formatter.format(new QueryResult(response.getSchema(),
+            response.getResults())));
       }
 
       @Override

--- a/plugin/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/rest/RestPPLQueryAction.java
+++ b/plugin/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/rest/RestPPLQueryAction.java
@@ -119,7 +119,8 @@ public class RestPPLQueryAction extends BaseRestHandler {
     return new ResponseListener<QueryResponse>() {
       @Override
       public void onResponse(QueryResponse response) {
-        sendResponse(OK, formatter.format(new QueryResult(response.getResults())));
+        sendResponse(OK, formatter.format(new QueryResult(response.getSchema(),
+            response.getResults())));
       }
 
       @Override

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     compile project(':protocol')
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
 
 }

--- a/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLService.java
+++ b/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLService.java
@@ -29,6 +29,7 @@ import com.amazon.opendistroforelasticsearch.sql.ppl.antlr.PPLSyntaxParser;
 import com.amazon.opendistroforelasticsearch.sql.ppl.domain.PPLQueryRequest;
 import com.amazon.opendistroforelasticsearch.sql.ppl.parser.AstBuilder;
 import com.amazon.opendistroforelasticsearch.sql.ppl.parser.AstExpressionBuilder;
+import com.amazon.opendistroforelasticsearch.sql.ppl.utils.UnresolvedPlanHelper;
 import com.amazon.opendistroforelasticsearch.sql.storage.StorageEngine;
 import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -55,7 +56,8 @@ public class PPLService {
       UnresolvedPlan ast = cst.accept(new AstBuilder(new AstExpressionBuilder()));
 
       // 2.Analyze abstract syntax to generate logical plan
-      LogicalPlan logicalPlan = analyzer.analyze(ast, new AnalysisContext());
+      LogicalPlan logicalPlan = analyzer.analyze(UnresolvedPlanHelper.addSelectAll(ast),
+          new AnalysisContext());
 
       // 3.Generate optimal physical plan from logical plan
       PhysicalPlan physicalPlan = new Planner(storageEngine).plan(logicalPlan);

--- a/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/utils/UnresolvedPlanHelper.java
+++ b/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/utils/UnresolvedPlanHelper.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.ppl.utils;
+
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.AllFields;
+import com.amazon.opendistroforelasticsearch.sql.ast.tree.Project;
+import com.amazon.opendistroforelasticsearch.sql.ast.tree.UnresolvedPlan;
+import com.google.common.collect.ImmutableList;
+import lombok.experimental.UtilityClass;
+
+/**
+ * The helper to add select to {@link UnresolvedPlan} if needed.
+ */
+@UtilityClass
+public class UnresolvedPlanHelper {
+
+  /**
+   * Attach Select All to PPL commands if required.
+   */
+  public UnresolvedPlan addSelectAll(UnresolvedPlan plan) {
+    if ((plan instanceof Project) && !((Project) plan).isExcluded()) {
+      return plan;
+    } else {
+      return new Project(ImmutableList.of(AllFields.of())).attach(plan);
+    }
+  }
+}

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLServiceTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLServiceTest.java
@@ -56,6 +56,9 @@ public class PPLServiceTest {
   @Mock
   private PhysicalPlan plan;
 
+  @Mock
+  private ExecutionEngine.Schema schema;
+
   /**
    * Setup the test context.
    */
@@ -76,7 +79,7 @@ public class PPLServiceTest {
   public void testExecuteShouldPass() {
     doAnswer(invocation -> {
       ResponseListener<QueryResponse> listener = invocation.getArgument(1);
-      listener.onResponse(new QueryResponse(Collections.emptyList()));
+      listener.onResponse(new QueryResponse(schema, Collections.emptyList()));
       return null;
     }).when(executionEngine).execute(any(), any());
 
@@ -96,6 +99,21 @@ public class PPLServiceTest {
 
   @Test
   public void testExecuteWithIllegalQueryShouldBeCaughtByHandler() {
+    pplService.execute(new PPLQueryRequest("search", null), new ResponseListener<QueryResponse>() {
+      @Override
+      public void onResponse(QueryResponse pplQueryResponse) {
+        Assert.fail();
+      }
+
+      @Override
+      public void onFailure(Exception e) {
+
+      }
+    });
+  }
+
+  @Test
+  public void test() {
     pplService.execute(new PPLQueryRequest("search", null), new ResponseListener<QueryResponse>() {
       @Override
       public void onResponse(QueryResponse pplQueryResponse) {

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/utils/UnresolvedPlanHelperTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/utils/UnresolvedPlanHelperTest.java
@@ -1,0 +1,68 @@
+/*
+ *
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.ppl.utils;
+
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.AllFields;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
+import com.amazon.opendistroforelasticsearch.sql.ast.tree.Project;
+import com.amazon.opendistroforelasticsearch.sql.ast.tree.Rename;
+import com.amazon.opendistroforelasticsearch.sql.ast.tree.UnresolvedPlan;
+import java.util.Arrays;
+import junit.framework.TestCase;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnresolvedPlanHelperTest extends TestCase {
+
+  @Test
+  public void addProjectForRenameOperator() {
+    Rename rename = Mockito.mock(Rename.class);
+
+    UnresolvedPlan plan = UnresolvedPlanHelper.addSelectAll(rename);
+    assertTrue(plan instanceof Project);
+  }
+
+  @Test
+  public void addProjectForProjectExcludeOperator() {
+    Project project = Mockito.mock(Project.class);
+    when(project.isExcluded()).thenReturn(true);
+
+    UnresolvedPlan plan = UnresolvedPlanHelper.addSelectAll(project);
+    assertTrue(plan instanceof Project);
+    assertThat(((Project) plan).getProjectList(), Matchers.contains(AllFields.of()));
+  }
+
+  @Test
+  public void dontAddProjectForProjectOperator() {
+    Project project = Mockito.mock(Project.class);
+    UnresolvedExpression expression = Mockito.mock(UnresolvedExpression.class);
+    when(project.isExcluded()).thenReturn(false);
+    when(project.getProjectList()).thenReturn(Arrays.asList(expression));
+
+    UnresolvedPlan plan = UnresolvedPlanHelper.addSelectAll(project);
+    assertTrue(plan instanceof Project);
+    assertThat(((Project) plan).getProjectList(), Matchers.contains(expression));
+  }
+}

--- a/protocol/src/test/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/QueryResultTest.java
+++ b/protocol/src/test/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/QueryResultTest.java
@@ -17,34 +17,45 @@
 package com.amazon.opendistroforelasticsearch.sql.protocol.response;
 
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.tupleValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRING;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.amazon.opendistroforelasticsearch.sql.executor.ExecutionEngine;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Collections;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class QueryResultTest {
 
+  private ExecutionEngine.Schema schema = new ExecutionEngine.Schema(ImmutableList.of(
+      new ExecutionEngine.Schema.Column("name", "name", STRING),
+      new ExecutionEngine.Schema.Column("age", "age", INTEGER)));
+
+
   @Test
   void size() {
-    QueryResult response = new QueryResult(Arrays.asList(
-        tupleValue(ImmutableMap.of("name", "John", "age", 20)),
-        tupleValue(ImmutableMap.of("name", "Allen", "age", 30)),
-        tupleValue(ImmutableMap.of("name", "Smith", "age", 40))
-    ));
+    QueryResult response = new QueryResult(
+        schema,
+        Arrays.asList(
+            tupleValue(ImmutableMap.of("name", "John", "age", 20)),
+            tupleValue(ImmutableMap.of("name", "Allen", "age", 30)),
+            tupleValue(ImmutableMap.of("name", "Smith", "age", 40))
+        ));
     assertEquals(3, response.size());
   }
 
   @Test
   void columnNameTypes() {
-    QueryResult response = new QueryResult(Collections.singletonList(
-        tupleValue(ImmutableMap.of("name", "John", "age", 20))
-    ));
+    QueryResult response = new QueryResult(
+        schema,
+        Collections.singletonList(
+            tupleValue(ImmutableMap.of("name", "John", "age", 20))
+        ));
 
     assertEquals(
         ImmutableMap.of("name", "string", "age", "integer"),
@@ -54,17 +65,23 @@ class QueryResultTest {
 
   @Test
   void columnNameTypesFromEmptyExprValues() {
-    QueryResult response = new QueryResult(Collections.emptyList());
-    assertTrue(response.columnNameTypes().isEmpty());
+    QueryResult response = new QueryResult(
+        schema,
+        Collections.emptyList());
+    assertEquals(
+        ImmutableMap.of("name", "string", "age", "integer"),
+        response.columnNameTypes()
+    );
   }
 
-  @Disabled("Need to figure out column headers in other way than inferring from data implicitly")
   @Test
   void columnNameTypesFromExprValuesWithMissing() {
-    QueryResult response = new QueryResult(Arrays.asList(
-        tupleValue(ImmutableMap.of("name", "John")),
-        tupleValue(ImmutableMap.of("name", "John", "age", 20))
-    ));
+    QueryResult response = new QueryResult(
+        schema,
+        Arrays.asList(
+            tupleValue(ImmutableMap.of("name", "John")),
+            tupleValue(ImmutableMap.of("name", "John", "age", 20))
+        ));
 
     assertEquals(
         ImmutableMap.of("name", "string", "age", "integer"),
@@ -74,10 +91,12 @@ class QueryResultTest {
 
   @Test
   void iterate() {
-    QueryResult response = new QueryResult(Arrays.asList(
-        tupleValue(ImmutableMap.of("name", "John", "age", 20)),
-        tupleValue(ImmutableMap.of("name", "Allen", "age", 30))
-    ));
+    QueryResult response = new QueryResult(
+        schema,
+        Arrays.asList(
+            tupleValue(ImmutableMap.of("name", "John", "age", 20)),
+            tupleValue(ImmutableMap.of("name", "Allen", "age", 30))
+        ));
 
     int i = 0;
     for (Object[] objects : response) {

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
@@ -66,6 +66,7 @@ public enum ElasticsearchType {
     SCALED_FLOAT(JDBCType.DOUBLE, Double.class, 15, 25, true),
     KEYWORD(JDBCType.VARCHAR, String.class, 256, 0, false),
     TEXT(JDBCType.VARCHAR, String.class, Integer.MAX_VALUE, 0, false),
+    STRING(JDBCType.VARCHAR, String.class, Integer.MAX_VALUE, 0, false),
     IP(JDBCType.VARCHAR, String.class, 15, 0, false),
     NESTED(JDBCType.STRUCT, null, 0, 0, false),
     OBJECT(JDBCType.STRUCT, null, 0, 0, false),

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilder.java
@@ -22,6 +22,7 @@ import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDis
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.SimpleSelectContext;
 
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Alias;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.AllFields;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.Project;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.Relation;
@@ -33,8 +34,7 @@ import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLP
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParserBaseVisitor;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
@@ -45,8 +45,6 @@ import org.antlr.v4.runtime.tree.ParseTree;
  */
 @RequiredArgsConstructor
 public class AstBuilder extends OpenDistroSQLParserBaseVisitor<UnresolvedPlan> {
-
-  private static final Project SELECT_ALL = null;
 
   private final AstExpressionBuilder expressionBuilder = new AstExpressionBuilder();
 
@@ -62,10 +60,12 @@ public class AstBuilder extends OpenDistroSQLParserBaseVisitor<UnresolvedPlan> {
     UnresolvedPlan project = visit(query.selectClause());
 
     if (query.fromClause() == null) {
-      if (project == SELECT_ALL) {
+      Optional<UnresolvedExpression> allFields =
+          ((Project) project).getProjectList().stream().filter(node -> node instanceof AllFields)
+              .findFirst();
+      if (allFields.isPresent()) {
         throw new SyntaxCheckException("No FROM clause found for select all");
       }
-
       // Attach an Values operator with only a empty row inside so that
       // Project operator can have a chance to evaluate its expression
       // though the evaluation doesn't have any dependency on what's in Values.
@@ -74,19 +74,18 @@ public class AstBuilder extends OpenDistroSQLParserBaseVisitor<UnresolvedPlan> {
     }
 
     UnresolvedPlan relation = visit(query.fromClause());
-    return (project == SELECT_ALL) ? relation : project.attach(relation);
+    return project.attach(relation);
   }
 
   @Override
   public UnresolvedPlan visitSelectClause(SelectClauseContext ctx) {
+    ImmutableList.Builder<UnresolvedExpression> builder =
+        new ImmutableList.Builder<>();
     if (ctx.selectElements().star != null) { //TODO: project operator should be required?
-      return SELECT_ALL;
+      builder.add(AllFields.of());
     }
-
-    List<SelectElementContext> selectElements = ctx.selectElements().selectElement();
-    return new Project(selectElements.stream()
-                                     .map(this::visitSelectItem)
-                                     .collect(Collectors.toList()));
+    ctx.selectElements().selectElement().forEach(field -> builder.add(visitSelectItem(field)));
+    return new Project(builder.build());
   }
 
   @Override

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLServiceTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLServiceTest.java
@@ -52,6 +52,9 @@ class SQLServiceTest {
   @Mock
   private ExecutionEngine executionEngine;
 
+  @Mock
+  private ExecutionEngine.Schema schema;
+
   @BeforeEach
   public void setUp() {
     context.registerBean(StorageEngine.class, () -> storageEngine);
@@ -65,7 +68,7 @@ class SQLServiceTest {
   public void canExecuteSqlQuery() {
     doAnswer(invocation -> {
       ResponseListener<QueryResponse> listener = invocation.getArgument(1);
-      listener.onResponse(new QueryResponse(Collections.emptyList()));
+      listener.onResponse(new QueryResponse(schema, Collections.emptyList()));
       return null;
     }).when(executionEngine).execute(any(), any());
 
@@ -88,7 +91,7 @@ class SQLServiceTest {
   public void canExecuteFromPhysicalPlan() {
     doAnswer(invocation -> {
       ResponseListener<QueryResponse> listener = invocation.getArgument(1);
-      listener.onResponse(new QueryResponse(Collections.emptyList()));
+      listener.onResponse(new QueryResponse(schema, Collections.emptyList()));
       return null;
     }).when(executionEngine).execute(any(), any());
 

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
@@ -30,6 +30,7 @@ import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.AllFields;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.UnresolvedPlan;
 import com.amazon.opendistroforelasticsearch.sql.common.antlr.SyntaxCheckException;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.SQLSyntaxParser;
@@ -75,11 +76,27 @@ class AstBuilderTest {
   @Test
   public void can_build_select_all_from_index() {
     assertEquals(
-        relation("test"),
+        project(
+            relation("test"),
+            AllFields.of()
+        ),
         buildAST("SELECT * FROM test")
     );
 
     assertThrows(SyntaxCheckException.class, () -> buildAST("SELECT *"));
+  }
+
+  @Test
+  public void can_build_select_all_and_fields_from_index() {
+    assertEquals(
+        project(
+            relation("test"),
+            AllFields.of(),
+            alias("age", qualifiedName("age")),
+            alias("age", qualifiedName("age"), "a")
+        ),
+        buildAST("SELECT *, age, age as a FROM test")
+    );
   }
 
   @Test


### PR DESCRIPTION
## Description of changes
1. Auto add FIELDS * for PPL command.
2. In Analyzer, expend SELECT * to SELECT all fields.
3. Extract type info from QueryPlan and add to QueryResponse.
4. Support NULL and MISSING value in response. https://github.com/penghuo/sql/blob/pr-select-all/docs/user/general/values.rst

-------------------------------------------------------------------------------------

## Problem Statements

### Background

Before explain the current issue, firstly, let’s setup the context.

#### Sample Data

Let’s explain the problem with an example,  the bank index which has 2 fields.

```
    "mappings" : {
      "properties" : {
        "account_number" : {
          "type" : "long"
        },
        "age" : {
          "type" : "integer"
        }
      }
    }
```

Then we add some data to the index.

```
POST bank/_doc/1
{"account_number":1,"age":31}

// age is null
POST bank/_doc/2
{"account_number":2,"age":null}

// age is missing
POST bank/_doc/3
{"account_number":3}
```

#### JDBC and JSON data format

Then, we define the response data format for query “`SELECT account_number FROM bank`” as follows.

* JDBC Format. There there mandatory fields, “field name”, “field type” and “data”. e.g.

```
{
  "schema": [{
    "name": "account_number",
    "type": "long"
  }],
  "total": 3,
  "datarows": [
    [1],
    [2],
    [3]
  ],
  "size": 3
}
```

* JSON Format, comparing with JDBC format, it doesn’t have schema field

```
{
  "datarows": [
    {"account_number": 1},
    {"account_number": 2},
    {"account_number": 3}
  ]
}
```

### Issue 1. Represent NULL and MISSING in Response

With these sample data and response data format in mind, let go through more query and examine their results.
Considering the query:** SELECT age, account_number FROM bank. **
The JDBC format doesn’t have MISSING value. If the field exist in the schema but missed in the document, it should considered as NULL value.
The JSON format could represent the MISSING value properly.

```
* JDBC Format
{
  "schema": [
    {
      "name": "age",
      "type": "integer"
    },
    {
      "name": "account_number",
      "type": "long"
    }
  ],
  "total": 3,
  "datarows": [
    [
      31,
      1
    ],
    [
      null,
      2
    ],
    [
      null,
      3
    ],
  ],
  "size": 3
}

* JSON Format
{
  "datarows": [
    {"age": 1, "account_number": 1},
    {"age": null, "account_number": 2},
    {"account_number": 3}
  ]
}
```

### Issue 2. ExprValue to JDBC format

Based on our current impementation, all the SQL operator is translated to chain of PhysicalOpeartor. Each PhysicalOpeartor provide the ExprValue as the return value. The protocol pull the result from PhysicalOperator and transalte to the expected format. e.g. Taking the above query as example, the result of the PhysicalOpeartor is a list of ExprValues.

```
[
    {"age": ExprIntegerValue(1), "account_number": ExprIntegerValue(1)},
    {"age": ExprNullValue(), "account_number": ExprIntegerValue(2)},
    {"account_number": ExprIntegerValue(3)}
]
```

The current solution is extract field name and field type from the data itself. This solution has two problems

1. It is impossible to derive the type from NULL value.
2. If the field is missing in the ExprValue, there is no way to derive it.

## Issue 3. The Type info is missing

In current design, the Protocol is a seperate module which work independently with QueryEngine. The Protocol module receive the list of ExprTupleValue from QueryEngine, then the Protocol module format the result based on the type of ExprValue. the problem is ExprNullValue and ExprMissingValue doesn’t have type assosicate with it. thus the Protocol module can’t derive the type info from input ExprTupleValue directly. 

## Issue 4. What is *(all field) means in SELECT

In current design, the SELECT * clause ingored in the AST builder logic, because it means select all the data from input operator. The issue is similar as Issue 3 that if the input operator produce NULL or MISSING value, then the Protocol have no idea to derive type info from it.

## Requirements

* The JDBC format should been supported. The MISSING and NULL value should been representd as NULL.
* The JSON format should been supported.
* The Protocol module should receive the QueryResponse which include schema and data.

## Solution

### Includ NULL and MISSING value in the QueryResult (Issue 1, 2)

The SELECT operator will be translated to PhysicalOpeartor with a list of expression to resolve ExprValue from input data. With the above example, when handling NULL and MISSING value, the expected output data should be as follows.

```
[
    {"age": ExprIntegerValue(1), "account_number": ExprIntegerValue(1)},
    {"age": ExprNullValue(), "account_number": ExprIntegerValue(2)},
    {"age": ExprMissingValue(), "account_number": ExprIntegerValue(3)}
]
```

An aditionial list of Schema is also required to when protocol is JDBC.

```
{
  "schema": [
    {
      "name": "age",
      "type": "integer"
    },
    {
      "name": "account_number",
      "type": "long"
    }
  ]    
}
```

Then the protocol module could easily translate the JDBC format or JSON format.

### Expend SELECT * to SELECT ...fields (Issue 4)

In our current implementation, in SQL, the SELECT * is ignored and in PPL there even no fields * command. This solution works fine for JSON format which doesn’t require schema, but it doens’s works for JDBC format.
The proposal in here is 

1. Automatically add the fields command to PPL query 
2. Expand SELECT * to SELECT ...fields.

#### Automatically add fields * to PPL query

Comparing with SQL, the PPL grammer doesn’t require the Fields command is the last command. Thus, the fields * command should been automatically added.
The automatically added logic is if the last operator is not Fields command, the Fields * command will been added. 

#### Expand SELECT * to SELECT ...fields

In Analyzer, we should expend the * to all fields in the current scope. There are two issues we need to address, 

1. No all the fields in the current scope should been used to expand *. The original scope is from Elasticsearch mapping which include nested mapping. In current design, only the top fields will be retrived from the current scope, all the nested fields will been ignored.
2. The scope should been dynamtic maintain in the Analyzer. For example, the stats command will define the new scope. 

### Retrive Type Info from ProjectOperator and Expose to Protocol (Issue 3)

After expending the * and automatically add fields, the type info could been retrived from ProjectOperator. Then the Protocol could get schema and data from QueryEngine.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
