### PR TITLE
Parse backtick strings (``) as identifiers instead of string literals

### DIFF
--- a/legacy/src/main/antlr/OpenDistroSqlLexer.g4
+++ b/legacy/src/main/antlr/OpenDistroSqlLexer.g4
@@ -290,7 +290,7 @@ COLON_SYMB:                         ':';
 // Literal Primitives
 
 START_NATIONAL_STRING_LITERAL:      'N' SQUOTA_STRING;
-STRING_LITERAL:                     DQUOTA_STRING | SQUOTA_STRING | BQUOTA_STRING;
+STRING_LITERAL:                     SQUOTA_STRING;
 DECIMAL_LITERAL:                    DEC_DIGIT+;
 HEXADECIMAL_LITERAL:                'X' '\'' (HEX_DIGIT HEX_DIGIT)+ '\''
                                     | '0X' HEX_DIGIT+;
@@ -317,6 +317,8 @@ DOT_ID:                             '.' ID_LITERAL;
 ID:                                 ID_LITERAL;
 // DOUBLE_QUOTE_ID:                 '"' ~'"'+ '"';
 REVERSE_QUOTE_ID:                   '`' ~'`'+ '`';
+DOUBLE_QUOTE_ID:                    DQUOTA_STRING;
+BACKTICK_QUOTE_ID:                  BQUOTA_STRING;
 STRING_USER_NAME:                   (
                                         SQUOTA_STRING | DQUOTA_STRING
                                         | BQUOTA_STRING | ID_LITERAL

--- a/legacy/src/main/antlr/OpenDistroSqlParser.g4
+++ b/legacy/src/main/antlr/OpenDistroSqlParser.g4
@@ -231,7 +231,8 @@ uid
 simpleId
     : ID
     | DOT_ID  // note: the current scope by adding DOT_ID to simpleId is large, move DOT_ID upwards tablename if needed
-    | STRING_LITERAL
+    | DOUBLE_QUOTE_ID
+    | BACKTICK_QUOTE_ID
     | keywordsCanBeId
     | functionNameBase
     ;

--- a/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/antlr/semantic/SemanticAnalyzerIdentifierTest.java
+++ b/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/antlr/semantic/SemanticAnalyzerIdentifierTest.java
@@ -172,4 +172,9 @@ public class SemanticAnalyzerIdentifierTest extends SemanticAnalyzerTestBase {
         validate("SELECT s.`age` FROM semantics AS s");
         validate("SELECT `s`.`age` FROM semantics AS `s`");
     }
+
+    @Test
+    public void queryWithBackticksQuotedFieldNameInFunctionShouldPass() {
+        validate("SELECT SUM(`age`) FROM semantics");
+    }
 }


### PR DESCRIPTION
*Issue #, if available:* #634 

*Description of changes:*
- parse backticked strings as identifiers, instead of string literals

Thanks @dai-chen for the fix suggestions! (https://github.com/opendistro-for-elasticsearch/sql/issues/634#issuecomment-666719987)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
