### PR TITLE
Add query size limit

### DIFF
--- a/common/src/main/java/com/amazon/opendistroforelasticsearch/sql/common/setting/Settings.java
+++ b/common/src/main/java/com/amazon/opendistroforelasticsearch/sql/common/setting/Settings.java
@@ -26,7 +26,15 @@ import lombok.RequiredArgsConstructor;
 public abstract class Settings {
   @RequiredArgsConstructor
   public enum Key {
-    PPL_QUERY_MEMORY_LIMIT("opendistro.ppl.query.memory_limit");
+    /**
+     * PPL Setting.
+     */
+    PPL_QUERY_MEMORY_LIMIT("opendistro.ppl.query.memory_limit"),
+
+    /**
+     * Common Setting for SQL and PPL.
+     */
+    QUERY_SIZE_LIMIT("opendistro.query.size_limit");
 
     @Getter
     private final String keyValue;

--- a/docs/experiment/ppl/admin/settings.rst
+++ b/docs/experiment/ppl/admin/settings.rst
@@ -46,3 +46,33 @@ PPL query::
       "transient": {}
     }
 
+opendistro.query.size_limit
+=================================
+
+Description
+-----------
+
+The size configure the maximum amount of documents to be pull from Elasticsearch. The default value is: 200
+
+Notes: This setting will impact the correctness of the aggregation operation, for example, there are 1000 docs in the index, by default, only 200 docs will be extract from index and do aggregation.
+
+Example
+-------
+
+PPL query::
+
+    sh$ curl -sS -H 'Content-Type: application/json' \
+    ... -X PUT localhost:9200/_cluster/settings \
+    ... -d '{"persistent" : {"opendistro.query.size_limit" : "1000"}}'
+    {
+      "acknowledged": true,
+      "persistent": {
+        "opendistro": {
+          "query": {
+            "size_limit": "1000"
+          }
+        }
+      },
+      "transient": {}
+    }
+

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchQueryRequest.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchQueryRequest.java
@@ -1,0 +1,104 @@
+/*
+ *
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.elasticsearch.request;
+
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.ElasticsearchResponse;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+/**
+ * Elasticsearch search request. This has to be stateful because it needs to:
+ *
+ * <p>1) Accumulate search source builder when visiting logical plan to push down operation. 2)
+ * Indicate the search already done.
+ */
+@EqualsAndHashCode
+@Getter
+@ToString
+public class ElasticsearchQueryRequest implements ElasticsearchRequest {
+
+  /**
+   * Default query timeout in minutes.
+   */
+  public static final TimeValue DEFAULT_QUERY_TIMEOUT = TimeValue.timeValueMinutes(1L);
+
+  /**
+   * Index name.
+   */
+  private final String indexName;
+
+  /**
+   * Search request source builder.
+   */
+  private final SearchSourceBuilder sourceBuilder;
+
+  /**
+   * Indicate the search already done.
+   */
+  private boolean searchDone = false;
+
+  /**
+   * Constructor of ElasticsearchQueryRequest.
+   */
+  public ElasticsearchQueryRequest(String indexName, int size) {
+    this.indexName = indexName;
+    this.sourceBuilder = new SearchSourceBuilder();
+    sourceBuilder.from(0);
+    sourceBuilder.size(size);
+    sourceBuilder.timeout(DEFAULT_QUERY_TIMEOUT);
+
+  }
+
+  @Override
+  public ElasticsearchResponse search(Function<SearchRequest, SearchResponse> searchAction,
+                                      Function<SearchScrollRequest, SearchResponse> scrollAction) {
+    if (searchDone) {
+      return new ElasticsearchResponse(SearchHits.empty());
+    } else {
+      searchDone = true;
+      return new ElasticsearchResponse(searchAction.apply(searchRequest()));
+    }
+  }
+
+  @Override
+  public void clean(Consumer<String> cleanAction) {
+    //do nothing.
+  }
+
+  /**
+   * Generate Elasticsearch search request.
+   *
+   * @return search request
+   */
+  @VisibleForTesting
+  protected SearchRequest searchRequest() {
+    return new SearchRequest()
+        .indices(indexName)
+        .source(sourceBuilder);
+  }
+}

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchScrollRequest.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchScrollRequest.java
@@ -1,0 +1,125 @@
+/*
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.elasticsearch.request;
+
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.ElasticsearchResponse;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+/**
+ * Elasticsearch scroll search request. This has to be stateful because it needs to:
+ *
+ * <p>1) Accumulate search source builder when visiting logical plan to push down operation 2)
+ * Maintain scroll ID between calls to client search method
+ */
+@EqualsAndHashCode
+@RequiredArgsConstructor
+@Getter
+@ToString
+public class ElasticsearchScrollRequest implements ElasticsearchRequest {
+
+  /** Default scroll context timeout in minutes. */
+  public static final TimeValue DEFAULT_SCROLL_TIMEOUT = TimeValue.timeValueMinutes(1L);
+
+  /** Index name. */
+  private final String indexName;
+
+  /**
+   * Scroll id which is set after first request issued. Because ElasticsearchClient is shared by
+   * multi-thread so this state has to be maintained here.
+   */
+  @Setter private String scrollId;
+
+  /** Search request source builder. */
+  private final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+
+
+  @Override
+  public ElasticsearchResponse search(Function<SearchRequest, SearchResponse> searchAction,
+                                      Function<SearchScrollRequest, SearchResponse> scrollAction) {
+    SearchResponse esResponse;
+    if (isScrollStarted()) {
+      esResponse = scrollAction.apply(scrollRequest());
+    } else {
+      esResponse = searchAction.apply(searchRequest());
+    }
+    setScrollId(esResponse.getScrollId());
+
+    return new ElasticsearchResponse(esResponse);
+  }
+
+  @Override
+  public void clean(Consumer<String> cleanAction) {
+    try {
+      if (isScrollStarted()) {
+        cleanAction.accept(getScrollId());
+      }
+    } finally {
+      reset();
+    }
+  }
+
+  /**
+   * Generate Elasticsearch search request.
+   *
+   * @return search request
+   */
+  public SearchRequest searchRequest() {
+    return new SearchRequest()
+        .indices(indexName)
+        .scroll(DEFAULT_SCROLL_TIMEOUT)
+        .source(sourceBuilder);
+  }
+
+  /**
+   * Is scroll started which means pages after first is being requested.
+   *
+   * @return true if scroll started
+   */
+  public boolean isScrollStarted() {
+    return (scrollId != null);
+  }
+
+  /**
+   * Generate Elasticsearch scroll request by scroll id maintained.
+   *
+   * @return scroll request
+   */
+  public SearchScrollRequest scrollRequest() {
+    Objects.requireNonNull(scrollId, "Scroll id cannot be null");
+    return new SearchScrollRequest().scroll(DEFAULT_SCROLL_TIMEOUT).scrollId(scrollId);
+  }
+
+  /**
+   * Reset internal state in case any stale data. However, ideally the same instance is not supposed
+   * to be reused across different physical plan.
+   */
+  public void reset() {
+    scrollId = null;
+  }
+}

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/ElasticsearchResponse.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/ElasticsearchResponse.java
@@ -35,6 +35,10 @@ public class ElasticsearchResponse implements Iterable<SearchHit> {
     this.hits = esResponse.getHits(); // TODO: aggregation result is separate and not in SearchHit[]
   }
 
+  public ElasticsearchResponse(SearchHits hits) {
+    this.hits = hits;
+  }
+
   /**
    * Is response empty. As ES doc says, "Each call to the scroll API returns the next batch of
    * results until there are no more results left to return, ie the hits array is empty."

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/setting/ElasticsearchSettings.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/setting/ElasticsearchSettings.java
@@ -53,6 +53,12 @@ public class ElasticsearchSettings extends Settings {
       Setting.Property.NodeScope,
       Setting.Property.Dynamic);
 
+  private static final Setting<?> QUERY_SIZE_LIMIT_SETTINGS = Setting.intSetting(
+      Key.QUERY_SIZE_LIMIT.getKeyValue(),
+      200,
+      Setting.Property.NodeScope,
+      Setting.Property.Dynamic);
+
   /**
    * Construct ElasticsearchSetting.
    * The ElasticsearchSetting must be singleton.
@@ -61,6 +67,8 @@ public class ElasticsearchSettings extends Settings {
     ImmutableMap.Builder<Key, Setting<?>> settingBuilder = new ImmutableMap.Builder<>();
     register(settingBuilder, clusterSettings, Key.PPL_QUERY_MEMORY_LIMIT,
         PPL_QUERY_MEMORY_LIMIT_SETTINGS, new Updater(Key.PPL_QUERY_MEMORY_LIMIT));
+    register(settingBuilder, clusterSettings, Key.QUERY_SIZE_LIMIT,
+        QUERY_SIZE_LIMIT_SETTINGS, new Updater(Key.QUERY_SIZE_LIMIT));
     defaultSettings = settingBuilder.build();
   }
 
@@ -102,6 +110,9 @@ public class ElasticsearchSettings extends Settings {
    * Used by Plugin to init Setting.
    */
   public static List<Setting<?>> pluginSettings() {
-    return new ImmutableList.Builder<Setting<?>>().add(PPL_QUERY_MEMORY_LIMIT_SETTINGS).build();
+    return new ImmutableList.Builder<Setting<?>>()
+        .add(PPL_QUERY_MEMORY_LIMIT_SETTINGS)
+        .add(QUERY_SIZE_LIMIT_SETTINGS)
+        .build();
   }
 }

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndex.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndex.java
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage;
 
+import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType;
 import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
@@ -62,6 +63,8 @@ public class ElasticsearchIndex implements Table {
   /** Elasticsearch client connection. */
   private final ElasticsearchClient client;
 
+  private final Settings settings;
+
   /** Current Elasticsearch index name. */
   private final String indexName;
 
@@ -83,7 +86,7 @@ public class ElasticsearchIndex implements Table {
   /** TODO: Push down operations to index scan operator as much as possible in future. */
   @Override
   public PhysicalPlan implement(LogicalPlan plan) {
-    ElasticsearchIndexScan indexScan = new ElasticsearchIndexScan(client, indexName,
+    ElasticsearchIndexScan indexScan = new ElasticsearchIndexScan(client, settings, indexName,
         new ElasticsearchExprValueFactory(getFieldTypes()));
 
     /*

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScan.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScan.java
@@ -16,9 +16,11 @@
 
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage;
 
+import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value.ElasticsearchExprValueFactory;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.request.ElasticsearchQueryRequest;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.request.ElasticsearchRequest;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.ElasticsearchResponse;
 import com.amazon.opendistroforelasticsearch.sql.storage.TableScanOperator;
@@ -34,7 +36,9 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
-/** Elasticsearch index scan operator. */
+/**
+ * Elasticsearch index scan operator.
+ */
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 @ToString(onlyExplicitlyIncluded = true)
 public class ElasticsearchIndexScan extends TableScanOperator {
@@ -55,10 +59,12 @@ public class ElasticsearchIndexScan extends TableScanOperator {
   /**
    * Todo.
    */
-  public ElasticsearchIndexScan(ElasticsearchClient client, String indexName,
+  public ElasticsearchIndexScan(ElasticsearchClient client,
+                                Settings settings, String indexName,
                                 ElasticsearchExprValueFactory exprValueFactory) {
     this.client = client;
-    this.request = new ElasticsearchRequest(indexName);
+    this.request = new ElasticsearchQueryRequest(indexName,
+        settings.getSettingValue(Settings.Key.QUERY_SIZE_LIMIT));
     this.exprValueFactory = exprValueFactory;
   }
 

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchStorageEngine.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchStorageEngine.java
@@ -16,7 +16,9 @@
 
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage;
 
+import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.setting.ElasticsearchSettings;
 import com.amazon.opendistroforelasticsearch.sql.storage.StorageEngine;
 import com.amazon.opendistroforelasticsearch.sql.storage.Table;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +30,10 @@ public class ElasticsearchStorageEngine implements StorageEngine {
   /** Elasticsearch client connection. */
   private final ElasticsearchClient client;
 
+  private final Settings settings;
+
   @Override
   public Table getTable(String name) {
-    return new ElasticsearchIndex(client, name);
+    return new ElasticsearchIndex(client, settings, name);
   }
 }

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.mapping.IndexMapping;
-import com.amazon.opendistroforelasticsearch.sql.elasticsearch.request.ElasticsearchRequest;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.request.ElasticsearchScrollRequest;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.ElasticsearchResponse;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSortedMap;
@@ -164,7 +164,7 @@ class ElasticsearchNodeClientTest {
     when(scrollResponse.getHits()).thenReturn(SearchHits.empty());
 
     // Verify response for first scroll request
-    ElasticsearchRequest request = new ElasticsearchRequest("test");
+    ElasticsearchScrollRequest request = new ElasticsearchScrollRequest("test");
     ElasticsearchResponse response1 = client.search(request);
     assertFalse(response1.isEmpty());
 
@@ -208,7 +208,7 @@ class ElasticsearchNodeClientTest {
 
     ElasticsearchNodeClient client =
         new ElasticsearchNodeClient(mock(ClusterService.class), nodeClient);
-    ElasticsearchRequest request = new ElasticsearchRequest("test");
+    ElasticsearchScrollRequest request = new ElasticsearchScrollRequest("test");
     request.setScrollId("scroll123");
     client.cleanup(request);
     assertFalse(request.isScrollStarted());
@@ -224,7 +224,7 @@ class ElasticsearchNodeClientTest {
     ElasticsearchNodeClient client =
         new ElasticsearchNodeClient(mock(ClusterService.class), nodeClient);
 
-    ElasticsearchRequest request = new ElasticsearchRequest("test");
+    ElasticsearchScrollRequest request = new ElasticsearchScrollRequest("test");
     client.cleanup(request);
     verify(nodeClient, never()).prepareClearScroll();
   }

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchRestClientTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.mapping.IndexMapping;
-import com.amazon.opendistroforelasticsearch.sql.elasticsearch.request.ElasticsearchRequest;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.request.ElasticsearchScrollRequest;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.ElasticsearchResponse;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
@@ -137,7 +137,7 @@ class ElasticsearchRestClientTest {
     when(scrollResponse.getHits()).thenReturn(SearchHits.empty());
 
     // Verify response for first scroll request
-    ElasticsearchRequest request = new ElasticsearchRequest("test");
+    ElasticsearchScrollRequest request = new ElasticsearchScrollRequest("test");
     ElasticsearchResponse response1 = client.search(request);
     assertFalse(response1.isEmpty());
 
@@ -155,7 +155,30 @@ class ElasticsearchRestClientTest {
   void searchWithIOException() throws IOException {
     when(restClient.search(any(), any())).thenThrow(new IOException());
     assertThrows(
-        IllegalStateException.class, () -> client.search(new ElasticsearchRequest("test")));
+        IllegalStateException.class, () -> client.search(new ElasticsearchScrollRequest("test")));
+  }
+
+  @Test
+  void scrollWithIOException() throws IOException {
+    // Mock first scroll request
+    SearchResponse searchResponse = mock(SearchResponse.class);
+    when(restClient.search(any(), any())).thenReturn(searchResponse);
+    when(searchResponse.getScrollId()).thenReturn("scroll123");
+    when(searchResponse.getHits())
+        .thenReturn(
+            new SearchHits(
+                new SearchHit[] {new SearchHit(1)},
+                new TotalHits(1L, TotalHits.Relation.EQUAL_TO),
+                1.0F));
+
+    // Mock second scroll request followed
+    when(restClient.scroll(any(), any())).thenThrow(new IOException());
+
+    // First request run successfully
+    ElasticsearchScrollRequest scrollRequest = new ElasticsearchScrollRequest("test");
+    client.search(scrollRequest);
+    assertThrows(
+        IllegalStateException.class, () -> client.search(scrollRequest));
   }
 
   @Test
@@ -170,7 +193,7 @@ class ElasticsearchRestClientTest {
 
   @Test
   void cleanup() throws IOException {
-    ElasticsearchRequest request = new ElasticsearchRequest("test");
+    ElasticsearchScrollRequest request = new ElasticsearchScrollRequest("test");
     request.setScrollId("scroll123");
     client.cleanup(request);
     verify(restClient).clearScroll(any(), any());
@@ -179,7 +202,7 @@ class ElasticsearchRestClientTest {
 
   @Test
   void cleanupWithoutScrollId() throws IOException {
-    ElasticsearchRequest request = new ElasticsearchRequest("test");
+    ElasticsearchScrollRequest request = new ElasticsearchScrollRequest("test");
     client.cleanup(request);
     verify(restClient, never()).clearScroll(any(), any());
   }
@@ -188,7 +211,7 @@ class ElasticsearchRestClientTest {
   void cleanupWithIOException() throws IOException {
     when(restClient.clearScroll(any(), any())).thenThrow(new IOException());
 
-    ElasticsearchRequest request = new ElasticsearchRequest("test");
+    ElasticsearchScrollRequest request = new ElasticsearchScrollRequest("test");
     request.setScrollId("scroll123");
     assertThrows(IllegalStateException.class, () -> client.cleanup(request));
   }

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/executor/ElasticsearchExecutionProtectorTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/executor/ElasticsearchExecutionProtectorTest.java
@@ -25,13 +25,16 @@ import static com.amazon.opendistroforelasticsearch.sql.expression.DSL.named;
 import static com.amazon.opendistroforelasticsearch.sql.expression.DSL.ref;
 import static com.amazon.opendistroforelasticsearch.sql.planner.physical.PhysicalPlanDSL.filter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.Sort;
+import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprBooleanValue;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value.ElasticsearchExprValueFactory;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.executor.protector.ElasticsearchExecutionProtector;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.executor.protector.ResourceMonitorPlan;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.setting.ElasticsearchSettings;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage.ElasticsearchIndexScan;
 import com.amazon.opendistroforelasticsearch.sql.expression.Expression;
 import com.amazon.opendistroforelasticsearch.sql.expression.NamedExpression;
@@ -64,6 +67,9 @@ class ElasticsearchExecutionProtectorTest {
   @Mock
   private ElasticsearchExprValueFactory exprValueFactory;
 
+  @Mock
+  private ElasticsearchSettings settings;
+
   private ElasticsearchExecutionProtector executionProtector;
 
   @BeforeEach
@@ -73,6 +79,8 @@ class ElasticsearchExecutionProtectorTest {
 
   @Test
   public void testProtectIndexScan() {
+    when(settings.getSettingValue(Settings.Key.QUERY_SIZE_LIMIT)).thenReturn(200);
+
     String indexName = "test";
     NamedExpression include = named("age", ref("age", INTEGER));
     ReferenceExpression exclude = ref("name", STRING);
@@ -99,7 +107,7 @@ class ElasticsearchExecutionProtectorTest {
                                     filter(
                                         resourceMonitor(
                                             new ElasticsearchIndexScan(
-                                                client, indexName, exprValueFactory)),
+                                                client, settings, indexName, exprValueFactory)),
                                         filterExpr),
                                     aggregators,
                                     groupByExprs),
@@ -120,7 +128,7 @@ class ElasticsearchExecutionProtectorTest {
                                     PhysicalPlanDSL.agg(
                                         filter(
                                             new ElasticsearchIndexScan(
-                                                client, indexName, exprValueFactory),
+                                                client, settings, indexName, exprValueFactory),
                                             filterExpr),
                                         aggregators,
                                         groupByExprs),

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchQueryRequestTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchQueryRequestTest.java
@@ -1,0 +1,102 @@
+/*
+ *
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.elasticsearch.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.ElasticsearchResponse;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ElasticsearchQueryRequestTest {
+
+  @Mock
+  private Function<SearchRequest, SearchResponse> searchAction;
+
+  @Mock
+  private Function<SearchScrollRequest, SearchResponse> scrollAction;
+
+  @Mock
+  private Consumer<String> cleanAction;
+
+  @Mock
+  private SearchResponse searchResponse;
+
+  @Mock
+  private SearchHits searchHits;
+
+  @Mock
+  private SearchHit searchHit;
+
+  private final ElasticsearchQueryRequest request = new ElasticsearchQueryRequest("test", 200);
+
+  @Test
+  void search() {
+    when(searchAction.apply(any())).thenReturn(searchResponse);
+    when(searchResponse.getHits()).thenReturn(searchHits);
+    when(searchHits.getHits()).thenReturn(new SearchHit[]{searchHit});
+
+    ElasticsearchResponse searchResponse = request.search(searchAction, scrollAction);
+    assertFalse(searchResponse.isEmpty());
+    searchResponse = request.search(searchAction, scrollAction);
+    assertTrue(searchResponse.isEmpty());
+    verify(searchAction, times(1)).apply(any());
+  }
+
+  @Test
+  void clean() {
+    request.clean(cleanAction);
+    verify(cleanAction, never()).accept(any());
+  }
+
+  @Test
+  void searchRequest() {
+    request.getSourceBuilder().query(QueryBuilders.termQuery("name", "John"));
+
+    assertEquals(
+        new SearchRequest()
+            .indices("test")
+            .source(new SearchSourceBuilder()
+                .timeout(ElasticsearchQueryRequest.DEFAULT_QUERY_TIMEOUT)
+                .from(0)
+                .size(200)
+                .query(QueryBuilders.termQuery("name", "John"))),
+        request.searchRequest());
+  }
+}

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchScrollRequestTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/ElasticsearchScrollRequestTest.java
@@ -26,9 +26,9 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.junit.jupiter.api.Test;
 
-class ElasticsearchRequestTest {
+class ElasticsearchScrollRequestTest {
 
-  private final ElasticsearchRequest request = new ElasticsearchRequest("test");
+  private final ElasticsearchScrollRequest request = new ElasticsearchScrollRequest("test");
 
   @Test
   void searchRequest() {
@@ -37,7 +37,7 @@ class ElasticsearchRequestTest {
     assertEquals(
         new SearchRequest()
             .indices("test")
-            .scroll(ElasticsearchRequest.DEFAULT_SCROLL_TIMEOUT)
+            .scroll(ElasticsearchScrollRequest.DEFAULT_SCROLL_TIMEOUT)
             .source(new SearchSourceBuilder().query(QueryBuilders.termQuery("name", "John"))),
         request.searchRequest());
   }
@@ -55,7 +55,7 @@ class ElasticsearchRequestTest {
     request.setScrollId("scroll123");
     assertEquals(
         new SearchScrollRequest()
-            .scroll(ElasticsearchRequest.DEFAULT_SCROLL_TIMEOUT)
+            .scroll(ElasticsearchScrollRequest.DEFAULT_SCROLL_TIMEOUT)
             .scrollId("scroll123"),
         request.scrollRequest());
   }

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScanTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScanTest.java
@@ -26,10 +26,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value.ElasticsearchExprValueFactory;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.request.ElasticsearchQueryRequest;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.request.ElasticsearchRequest;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.ElasticsearchResponse;
 import com.google.common.collect.ImmutableMap;
@@ -38,6 +40,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -51,14 +54,22 @@ class ElasticsearchIndexScanTest {
   @Mock
   private ElasticsearchClient client;
 
+  @Mock
+  private Settings settings;
+
   private ElasticsearchExprValueFactory exprValueFactory = new ElasticsearchExprValueFactory(
-          ImmutableMap.of("name", STRING, "department", STRING));
+      ImmutableMap.of("name", STRING, "department", STRING));
+
+  @BeforeEach
+  void setup() {
+    when(settings.getSettingValue(Settings.Key.QUERY_SIZE_LIMIT)).thenReturn(200);
+  }
 
   @Test
   void queryEmptyResult() {
     mockResponse();
     try (ElasticsearchIndexScan indexScan =
-             new ElasticsearchIndexScan(client, "test", exprValueFactory)) {
+             new ElasticsearchIndexScan(client, settings, "test", exprValueFactory)) {
       indexScan.open();
       assertFalse(indexScan.hasNext());
     }
@@ -72,7 +83,7 @@ class ElasticsearchIndexScanTest {
         new SearchHit[]{employee(3, "Allen", "IT")});
 
     try (ElasticsearchIndexScan indexScan =
-             new ElasticsearchIndexScan(client, "employees", exprValueFactory)) {
+             new ElasticsearchIndexScan(client, settings, "employees", exprValueFactory)) {
       indexScan.open();
 
       assertTrue(indexScan.hasNext());
@@ -108,7 +119,7 @@ class ElasticsearchIndexScanTest {
   }
 
   private PushDownAssertion assertThat() {
-    return new PushDownAssertion(client, exprValueFactory);
+    return new PushDownAssertion(client, exprValueFactory, settings);
   }
 
   private static class PushDownAssertion {
@@ -117,9 +128,10 @@ class ElasticsearchIndexScanTest {
     private final ElasticsearchResponse response;
 
     public PushDownAssertion(ElasticsearchClient client,
-                             ElasticsearchExprValueFactory valueFactory) {
+                             ElasticsearchExprValueFactory valueFactory,
+                             Settings settings) {
       this.client = client;
-      this.indexScan = new ElasticsearchIndexScan(client, "test", valueFactory);
+      this.indexScan = new ElasticsearchIndexScan(client, settings, "test", valueFactory);
       this.response = mock(ElasticsearchResponse.class);
       when(response.isEmpty()).thenReturn(true);
     }
@@ -130,7 +142,7 @@ class ElasticsearchIndexScanTest {
     }
 
     PushDownAssertion shouldQuery(QueryBuilder expected) {
-      ElasticsearchRequest request = new ElasticsearchRequest("test");
+      ElasticsearchRequest request = new ElasticsearchQueryRequest("test", 200);
       request.getSourceBuilder().query(expected);
       when(client.search(request)).thenReturn(response);
       indexScan.open();

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchStorageEngineTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchStorageEngineTest.java
@@ -18,7 +18,9 @@ package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.setting.ElasticsearchSettings;
 import com.amazon.opendistroforelasticsearch.sql.storage.Table;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,9 +32,11 @@ class ElasticsearchStorageEngineTest {
 
   @Mock private ElasticsearchClient client;
 
+  @Mock private Settings settings;
+
   @Test
   public void getTable() {
-    ElasticsearchStorageEngine engine = new ElasticsearchStorageEngine(client);
+    ElasticsearchStorageEngine engine = new ElasticsearchStorageEngine(client, settings);
     Table table = engine.getTable("test");
     assertNotNull(table);
   }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLIntegTestCase.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/PPLIntegTestCase.java
@@ -15,7 +15,12 @@
 
 package com.amazon.opendistroforelasticsearch.sql.ppl;
 
+import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getResponseBody;
+import static com.amazon.opendistroforelasticsearch.sql.plugin.rest.RestPPLQueryAction.QUERY_API_ENDPOINT;
+
 import com.amazon.opendistroforelasticsearch.sql.legacy.SQLIntegTestCase;
+import java.io.IOException;
+import java.util.Locale;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -23,14 +28,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 
-import java.io.IOException;
-import java.util.Locale;
-
-import static com.amazon.opendistroforelasticsearch.sql.plugin.rest.RestPPLQueryAction.QUERY_API_ENDPOINT;
-import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getResponseBody;
-
 /**
- * ES Rest integration test base for PPL testing
+ * ES Rest integration test base for PPL testing.
  */
 public abstract class PPLIntegTestCase extends SQLIntegTestCase {
 
@@ -52,6 +51,42 @@ public abstract class PPLIntegTestCase extends SQLIntegTestCase {
     restOptionsBuilder.addHeader("Content-Type", "application/json");
     request.setOptions(restOptionsBuilder);
     return request;
+  }
+
+  protected static JSONObject updateClusterSettings(ClusterSetting setting) throws IOException {
+    Request request = new Request("PUT", "/_cluster/settings");
+    String persistentSetting = String.format(Locale.ROOT,
+        "{\"%s\": {\"%s\": %s}}", setting.type, setting.name, setting.value);
+    request.setJsonEntity(persistentSetting);
+    RequestOptions.Builder restOptionsBuilder = RequestOptions.DEFAULT.toBuilder();
+    restOptionsBuilder.addHeader("Content-Type", "application/json");
+    request.setOptions(restOptionsBuilder);
+    return new JSONObject(executeRequest(request));
+  }
+
+  protected static class ClusterSetting {
+    private final String type;
+    private final String name;
+    private final String value;
+
+    public ClusterSetting(String type, String name, String value) {
+      this.type = type;
+      this.name = name;
+      this.value = (value == null) ? "null" : ("\"" + value + "\"");
+    }
+
+    SQLIntegTestCase.ClusterSetting nullify() {
+      return new SQLIntegTestCase.ClusterSetting(type, name, null);
+    }
+
+    @Override
+    public String toString() {
+      return "ClusterSetting{"
+          + "type='" + type + '\''
+          + ", path='" + name + '\''
+          + ", value='" + value + '\''
+          + '}';
+    }
   }
 
   private JSONObject jsonify(String text) {

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StandaloneIT.java
@@ -19,6 +19,7 @@ package com.amazon.opendistroforelasticsearch.sql.ppl;
 import static com.amazon.opendistroforelasticsearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
 
 import com.amazon.opendistroforelasticsearch.sql.common.response.ResponseListener;
+import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchRestClient;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.executor.ElasticsearchExecutionEngine;
@@ -32,7 +33,9 @@ import com.amazon.opendistroforelasticsearch.sql.ppl.domain.PPLQueryRequest;
 import com.amazon.opendistroforelasticsearch.sql.protocol.response.QueryResult;
 import com.amazon.opendistroforelasticsearch.sql.protocol.response.format.SimpleJsonResponseFormatter;
 import com.amazon.opendistroforelasticsearch.sql.storage.StorageEngine;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.Request;
@@ -61,7 +64,7 @@ public class StandaloneIT extends PPLIntegTestCase {
     ElasticsearchClient client = new ElasticsearchRestClient(restClient);
     AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
     context.registerBean(StorageEngine.class,
-        () -> new ElasticsearchStorageEngine(client));
+        () -> new ElasticsearchStorageEngine(client, defaultSettings()));
     context.registerBean(ExecutionEngine.class, () -> new ElasticsearchExecutionEngine(client,
         new ElasticsearchExecutionProtector(new AlwaysHealthyMonitor())));
     context.register(PPLServiceConfig.class);
@@ -121,5 +124,18 @@ public class StandaloneIT extends PPLIntegTestCase {
           }
         });
     return actual.get();
+  }
+
+  private Settings defaultSettings() {
+    return new Settings() {
+      private final Map<Key, Integer> defaultSettings = new ImmutableMap.Builder<Key, Integer>()
+          .put(Key.QUERY_SIZE_LIMIT, 200)
+          .build();
+
+      @Override
+      public <T> T getSettingValue(Key key) {
+        return (T) defaultSettings.get(key);
+      }
+    };
   }
 }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StatsCommandIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StatsCommandIT.java
@@ -17,6 +17,7 @@ package com.amazon.opendistroforelasticsearch.sql.ppl;
 
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_ACCOUNT;
 
+import com.amazon.opendistroforelasticsearch.sql.legacy.SQLIntegTestCase;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +26,7 @@ public class StatsCommandIT extends PPLIntegTestCase {
   @Override
   public void init() throws IOException {
     loadIndex(Index.ACCOUNT);
+    setQuerySizeLimit();
   }
 
   @Test
@@ -97,5 +99,11 @@ public class StatsCommandIT extends PPLIntegTestCase {
             + "  \"size\": 1\n"
             + "}\n",
         result);
+  }
+
+  private void setQuerySizeLimit() throws IOException {
+    updateClusterSettings(
+        new SQLIntegTestCase.ClusterSetting("persistent", "opendistro.query.size_limit",
+            "2000"));
   }
 }

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/ElasticsearchSQLPluginConfig.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/ElasticsearchSQLPluginConfig.java
@@ -17,6 +17,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.legacy.plugin;
 
+import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchClient;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchNodeClient;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.executor.ElasticsearchExecutionEngine;
@@ -40,6 +41,9 @@ public class ElasticsearchSQLPluginConfig {
   @Autowired
   private NodeClient nodeClient;
 
+  @Autowired
+  private Settings settings;
+
   @Bean
   public ElasticsearchClient client() {
     return new ElasticsearchNodeClient(clusterService, nodeClient);
@@ -47,7 +51,7 @@ public class ElasticsearchSQLPluginConfig {
 
   @Bean
   public StorageEngine storageEngine() {
-    return new ElasticsearchStorageEngine(client());
+    return new ElasticsearchStorageEngine(client(), settings);
   }
 
   @Bean

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -23,6 +23,7 @@ import static org.elasticsearch.rest.RestStatus.OK;
 
 import com.amazon.opendistroforelasticsearch.sql.common.antlr.SyntaxCheckException;
 import com.amazon.opendistroforelasticsearch.sql.common.response.ResponseListener;
+import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.security.SecurityAccess;
 import com.amazon.opendistroforelasticsearch.sql.planner.logical.LogicalPlan;
 import com.amazon.opendistroforelasticsearch.sql.planner.physical.PhysicalPlan;
@@ -58,9 +59,15 @@ public class RestSQLQueryAction extends BaseRestHandler {
 
   private final ClusterService clusterService;
 
-  public RestSQLQueryAction(ClusterService clusterService) {
+  /**
+   * Settings required by been initialization.
+   */
+  private final Settings pluginSettings;
+
+  public RestSQLQueryAction(ClusterService clusterService, Settings pluginSettings) {
     super();
     this.clusterService = clusterService;
+    this.pluginSettings = pluginSettings;
   }
 
   @Override
@@ -108,6 +115,7 @@ public class RestSQLQueryAction extends BaseRestHandler {
       AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
       context.registerBean(ClusterService.class, () -> clusterService);
       context.registerBean(NodeClient.class, () -> client);
+      context.registerBean(Settings.class, () -> pluginSettings);
       context.register(ElasticsearchSQLPluginConfig.class);
       context.register(SQLServiceConfig.class);
       context.refresh();

--- a/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryActionTest.java
+++ b/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryActionTest.java
@@ -22,6 +22,7 @@ import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlAct
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
+import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.sql.domain.SQLQueryRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -40,6 +41,9 @@ public class RestSQLQueryActionTest {
   @Mock
   private NodeClient nodeClient;
 
+  @Mock
+  private Settings settings;
+
   @Test
   public void handleQueryThatCanSupport() {
     SQLQueryRequest request = new SQLQueryRequest(
@@ -48,7 +52,7 @@ public class RestSQLQueryActionTest {
         QUERY_API_ENDPOINT,
         "");
 
-    RestSQLQueryAction queryAction = new RestSQLQueryAction(clusterService);
+    RestSQLQueryAction queryAction = new RestSQLQueryAction(clusterService, settings);
     assertNotSame(NOT_SUPPORTED_YET, queryAction.prepareRequest(request, nodeClient));
   }
 
@@ -60,7 +64,7 @@ public class RestSQLQueryActionTest {
         EXPLAIN_API_ENDPOINT,
         "");
 
-    RestSQLQueryAction queryAction = new RestSQLQueryAction(clusterService);
+    RestSQLQueryAction queryAction = new RestSQLQueryAction(clusterService, settings);
     assertSame(NOT_SUPPORTED_YET, queryAction.prepareRequest(request, nodeClient));
   }
 
@@ -72,7 +76,7 @@ public class RestSQLQueryActionTest {
         QUERY_API_ENDPOINT,
         "");
 
-    RestSQLQueryAction queryAction = new RestSQLQueryAction(clusterService);
+    RestSQLQueryAction queryAction = new RestSQLQueryAction(clusterService, settings);
     assertSame(NOT_SUPPORTED_YET, queryAction.prepareRequest(request, nodeClient));
   }
 

--- a/plugin/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/SQLPlugin.java
+++ b/plugin/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/SQLPlugin.java
@@ -98,7 +98,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin {
 
     return Arrays.asList(
         new RestPPLQueryAction(restController, clusterService, pluginSettings),
-        new RestSqlAction(settings, clusterService),
+        new RestSqlAction(settings, clusterService, pluginSettings),
         new RestSqlStatsAction(settings, restController),
         new RestSqlSettingsAction(settings, restController)
     );

--- a/plugin/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/rest/ElasticsearchPluginConfig.java
+++ b/plugin/src/main/java/com/amazon/opendistroforelasticsearch/sql/plugin/rest/ElasticsearchPluginConfig.java
@@ -57,7 +57,7 @@ public class ElasticsearchPluginConfig {
 
   @Bean
   public StorageEngine storageEngine() {
-    return new ElasticsearchStorageEngine(client());
+    return new ElasticsearchStorageEngine(client(), settings);
   }
 
   @Bean


### PR DESCRIPTION
## Problem statements
In new SQL/PPL engine, the IndexScanOperator pull all the data from data source by using scroll operator. Depend on the amount of documents in the index, the scoll operation could trigger the OOM and have negative impact on the system availabilty. Instead of return all the documents, we should have a mechanism to limit the query result.

## Description of changes
* Change the IndexScanOperator only return limited documents.
* The limitation could be configured throught setting dynamatically.
* The default limitation value is 200.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
