### PR TITLE
Support WHERE clause in new SQL parser

### DIFF
--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/lucene/LuceneQuery.java
@@ -16,6 +16,8 @@
 
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage.script.filter.lucene;
 
+import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType.ES_TEXT_KEYWORD;
+
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
 import com.amazon.opendistroforelasticsearch.sql.expression.FunctionExpression;
@@ -67,6 +69,13 @@ public abstract class LuceneQuery {
   protected QueryBuilder doBuild(String fieldName, ExprType fieldType, ExprValue literal) {
     throw new UnsupportedOperationException(
         "Subclass doesn't implement this and build method either");
+  }
+
+  protected String convertTextToKeyword(String fieldName, ExprType fieldType) {
+    if (fieldType == ES_TEXT_KEYWORD) { // Assume inner field name is always "keyword"
+      return fieldName + ".keyword";
+    }
+    return fieldName;
   }
 
 }

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/lucene/LuceneQuery.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/lucene/LuceneQuery.java
@@ -62,8 +62,8 @@ public abstract class LuceneQuery {
    * from reference and literal in function arguments.
    *
    * @param fieldName   field name
-   * @param fieldType        expr fieldType
-   * @param literal       expr literal
+   * @param fieldType   field type
+   * @param literal     field value literal
    * @return            query
    */
   protected QueryBuilder doBuild(String fieldName, ExprType fieldType, ExprValue literal) {
@@ -71,8 +71,16 @@ public abstract class LuceneQuery {
         "Subclass doesn't implement this and build method either");
   }
 
+  /**
+   * Convert multi-field text field name to its inner keyword field. The limitation and assumption
+   * is that the keyword field name is always "keyword" which is true by default.
+   *
+   * @param fieldName   field name
+   * @param fieldType   field type
+   * @return            keyword field name for multi-field, otherwise original field name returned
+   */
   protected String convertTextToKeyword(String fieldName, ExprType fieldType) {
-    if (fieldType == ES_TEXT_KEYWORD) { // Assume inner field name is always "keyword"
+    if (fieldType == ES_TEXT_KEYWORD) {
       return fieldName + ".keyword";
     }
     return fieldName;

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/lucene/TermQuery.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/lucene/TermQuery.java
@@ -16,8 +16,6 @@
 
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage.script.filter.lucene;
 
-import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType.ES_TEXT_KEYWORD;
-
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -30,9 +28,7 @@ public class TermQuery extends LuceneQuery {
 
   @Override
   protected QueryBuilder doBuild(String fieldName, ExprType fieldType, ExprValue literal) {
-    if (fieldType == ES_TEXT_KEYWORD) { // Assume inner field name is always "keyword"
-      fieldName += ".keyword";
-    }
+    fieldName = convertTextToKeyword(fieldName, fieldType);
     return QueryBuilders.termQuery(fieldName, literal.value());
   }
 

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/lucene/WildcardQuery.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/lucene/WildcardQuery.java
@@ -28,6 +28,7 @@ public class WildcardQuery extends LuceneQuery {
 
   @Override
   protected QueryBuilder doBuild(String fieldName, ExprType fieldType, ExprValue literal) {
+    fieldName = convertTextToKeyword(fieldName, fieldType);
     String matchText = convertSqlWildcardToLucene(literal.stringValue());
     return QueryBuilders.wildcardQuery(fieldName, matchText);
   }

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/FilterQueryBuilderTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/FilterQueryBuilderTest.java
@@ -171,7 +171,7 @@ class FilterQueryBuilderTest {
   @Test
   void should_build_bool_query_for_and_or_expression() {
     String[] names = { "filter", "should" };
-    FunctionExpression expr1 = dsl.equal(ref("name", ES_TEXT_KEYWORD), literal("John"));
+    FunctionExpression expr1 = dsl.equal(ref("name", STRING), literal("John"));
     FunctionExpression expr2 = dsl.equal(ref("age", INTEGER), literal(30));
     Expression[] exprs = {
         dsl.and(expr1, expr2),
@@ -185,7 +185,7 @@ class FilterQueryBuilderTest {
               + "    \"" + names[i] + "\" : [\n"
               + "      {\n"
               + "        \"term\" : {\n"
-              + "          \"name.keyword\" : {\n"
+              + "          \"name\" : {\n"
               + "            \"value\" : \"John\",\n"
               + "            \"boost\" : 1.0\n"
               + "          }\n"
@@ -231,6 +231,38 @@ class FilterQueryBuilderTest {
             dsl.not(
                 dsl.equal(
                     ref("age", INTEGER), literal(30)))));
+  }
+
+  @Test
+  void should_use_keyword_for_multi_field_in_equality_expression() {
+    assertEquals(
+        "{\n"
+            + "  \"term\" : {\n"
+            + "    \"name.keyword\" : {\n"
+            + "      \"value\" : \"John\",\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(
+            dsl.equal(
+                ref("name", ES_TEXT_KEYWORD), literal("John"))));
+  }
+
+  @Test
+  void should_use_keyword_for_multi_field_in_like_expression() {
+    assertEquals(
+        "{\n"
+            + "  \"wildcard\" : {\n"
+            + "    \"name.keyword\" : {\n"
+            + "      \"wildcard\" : \"John*\",\n"
+            + "      \"boost\" : 1.0\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(
+            dsl.like(
+                ref("name", ES_TEXT_KEYWORD), literal("John%"))));
   }
 
   private String buildQuery(Expression expr) {

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -114,6 +114,9 @@ task integTestWithNewEngine(type: RestIntegTestTask) {
 
         exclude 'com/amazon/opendistroforelasticsearch/sql/doctest/**/*IT.class'
         exclude 'com/amazon/opendistroforelasticsearch/sql/correctness/**'
+
+        // Skip old semantic analyzer IT
+        exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/QueryAnalysisIT.class'
     }
 }
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -115,7 +115,7 @@ task integTestWithNewEngine(type: RestIntegTestTask) {
         exclude 'com/amazon/opendistroforelasticsearch/sql/doctest/**/*IT.class'
         exclude 'com/amazon/opendistroforelasticsearch/sql/correctness/**'
 
-        // Skip old semantic analyzer IT
+        // Skip old semantic analyzer IT because analyzer in new engine has different behavior
         exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/QueryAnalysisIT.class'
     }
 }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLCorrectnessIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLCorrectnessIT.java
@@ -71,6 +71,4 @@ public class SQLCorrectnessIT extends CorrectnessTestBase {
     }
   }
 
-
-
 }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLCorrectnessIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLCorrectnessIT.java
@@ -32,7 +32,7 @@ public class SQLCorrectnessIT extends CorrectnessTestBase {
 
   private static final String ROOT_DIR = "correctness/";
   private static final String[] EXPR_TEST_DIR = { "expressions" };
-  private static final String[] QUERY_TEST_DIR = { "queries"/*, "bugfixes"*/ }; //TODO: skip bugfixes folder for now since it fails
+  private static final String[] QUERY_TEST_DIR = { "queries", "bugfixes" };
 
   @Override
   protected void init() throws Exception {

--- a/integ-test/src/test/resources/correctness/bugfixes/234.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/234.txt
@@ -1,1 +1,2 @@
 SELECT FlightNum FROM kibana_sample_data_flights where (AvgTicketPrice + 100) <= 1000
+SELECT FlightNum FROM kibana_sample_data_flights where ROUND(FlightTimeMin) > ABS(FlightDelayMin)

--- a/integ-test/src/test/resources/correctness/bugfixes/234.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/234.txt
@@ -1,0 +1,1 @@
+SELECT FlightNum FROM kibana_sample_data_flights where (AvgTicketPrice + 100) <= 1000

--- a/integ-test/src/test/resources/correctness/bugfixes/237.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/237.txt
@@ -1,2 +1,3 @@
-SELECT ((Origin = 'Munich Airport') and (Dest = 'Venice Marco Polo Airport')) AS Calculation_462181953506873347 FROM kibana_sample_data_flights
-SELECT ((Origin = 'Munich Airport') or (Dest = 'Venice Marco Polo Airport')) AS Calculation_462181953506873347 FROM kibana_sample_data_flights
+SELECT ((Origin = 'Munich Airport') AND (Dest = 'Venice Marco Polo Airport')) AS Calculation_462181953506873347 FROM kibana_sample_data_flights
+SELECT ((Origin = 'Munich Airport') OR (Origin = 'Itami Airport')) AS Calculation_462181953506873347 FROM kibana_sample_data_flights
+SELECT NOT (Origin = 'Munich Airport') AS Calculation_462181953506873347 FROM kibana_sample_data_flights

--- a/integ-test/src/test/resources/correctness/bugfixes/237.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/237.txt
@@ -1,0 +1,2 @@
+SELECT ((Origin = 'Munich Airport') and (Dest = 'Venice Marco Polo Airport')) AS Calculation_462181953506873347 FROM kibana_sample_data_flights
+SELECT ((Origin = 'Munich Airport') or (Dest = 'Venice Marco Polo Airport')) AS Calculation_462181953506873347 FROM kibana_sample_data_flights

--- a/integ-test/src/test/resources/correctness/bugfixes/368.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/368.txt
@@ -1,1 +1,1 @@
-SELECT Origin FROM kibana_sample_data_flights WHERE Origin LIKE 'London%'
+SELECT Origin FROM kibana_sample_data_flights WHERE Origin LIKE 'London Hea%'

--- a/integ-test/src/test/resources/correctness/bugfixes/368.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/368.txt
@@ -1,0 +1,1 @@
+SELECT Origin FROM kibana_sample_data_flights WHERE Origin LIKE 'London%'

--- a/integ-test/src/test/resources/correctness/bugfixes/368.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/368.txt
@@ -1,1 +1,2 @@
 SELECT Origin FROM kibana_sample_data_flights WHERE Origin LIKE 'London Hea%'
+SELECT Origin FROM kibana_sample_data_flights WHERE Origin LIKE '%International%'

--- a/integ-test/src/test/resources/correctness/bugfixes/521.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/521.txt
@@ -1,1 +1,1 @@
-SELECT timestamp, COUNT(*) FROM kibana_sample_data_flights GROUP BY timestamp
+SELECT timestamp FROM kibana_sample_data_flights GROUP BY timestamp

--- a/integ-test/src/test/resources/correctness/bugfixes/690.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/690.txt
@@ -1,0 +1,4 @@
+SELECT FlightNum, Origin FROM kibana_sample_data_flights WHERE NULL IS NULL
+SELECT FlightNum, Origin FROM kibana_sample_data_flights WHERE NULL IS NOT NULL
+SELECT FlightNum, Origin FROM kibana_sample_data_flights WHERE NULL IS NULL AND NULL IS NULL
+SELECT FlightNum, Origin FROM kibana_sample_data_flights WHERE NULL IS NULL OR NULL IS NULL

--- a/integ-test/src/test/resources/correctness/expressions/predicates.txt
+++ b/integ-test/src/test/resources/correctness/expressions/predicates.txt
@@ -1,0 +1,7 @@
+true AND true AS bool
+false AND true AS bool
+false OR false AS bool
+true or false AS bool
+NOT true AS bool
+NOT false AS bool
+NOT (true AND false) AS bool

--- a/integ-test/src/test/resources/correctness/kibana_sample_data_flights.json
+++ b/integ-test/src/test/resources/correctness/kibana_sample_data_flights.json
@@ -11,7 +11,13 @@
         "type": "keyword"
       },
       "Dest": {
-        "type": "keyword"
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
       },
       "DestAirportID": {
         "type": "keyword"
@@ -53,7 +59,13 @@
         "type": "float"
       },
       "Origin": {
-        "type": "keyword"
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
       },
       "OriginAirportID": {
         "type": "keyword"

--- a/integ-test/src/test/resources/correctness/queries/select.txt
+++ b/integ-test/src/test/resources/correctness/queries/select.txt
@@ -6,5 +6,10 @@ SELECT abs(DistanceMiles), Abs(FlightDelayMin) FROM kibana_sample_data_flights
 SELECT Cancelled AS Cancel, AvgTicketPrice AS ATP FROM kibana_sample_data_flights
 SELECT Cancelled AS `Cancel`, AvgTicketPrice AS "ATP" FROM kibana_sample_data_flights
 SELECT AvgTicketPrice, Carrier FROM kibana_sample_data_flights WHERE AvgTicketPrice <= 500
+SELECT AvgTicketPrice, Carrier FROM kibana_sample_data_flights WHERE NOT AvgTicketPrice <= 500
 SELECT AvgTicketPrice, Carrier FROM kibana_sample_data_flights WHERE AvgTicketPrice <= 500 AND FlightDelayMin = 0
 SELECT AvgTicketPrice, Carrier FROM kibana_sample_data_flights WHERE AvgTicketPrice <= 500 OR FlightDelayMin = 0
+SELECT AvgTicketPrice, Carrier FROM kibana_sample_data_flights WHERE AvgTicketPrice + 100 <= 500
+SELECT AvgTicketPrice, Carrier FROM kibana_sample_data_flights WHERE ABS(AvgTicketPrice * -2) > 1000
+SELECT AvgTicketPrice, Carrier FROM kibana_sample_data_flights WHERE Carrier LIKE 'JetBeat_'
+SELECT AvgTicketPrice, Carrier FROM kibana_sample_data_flights WHERE Carrier LIKE '%Air%'

--- a/integ-test/src/test/resources/correctness/queries/select.txt
+++ b/integ-test/src/test/resources/correctness/queries/select.txt
@@ -6,3 +6,5 @@ SELECT abs(DistanceMiles), Abs(FlightDelayMin) FROM kibana_sample_data_flights
 SELECT Cancelled AS Cancel, AvgTicketPrice AS ATP FROM kibana_sample_data_flights
 SELECT Cancelled AS `Cancel`, AvgTicketPrice AS "ATP" FROM kibana_sample_data_flights
 SELECT AvgTicketPrice, Carrier FROM kibana_sample_data_flights WHERE AvgTicketPrice <= 500
+SELECT AvgTicketPrice, Carrier FROM kibana_sample_data_flights WHERE AvgTicketPrice <= 500 AND FlightDelayMin = 0
+SELECT AvgTicketPrice, Carrier FROM kibana_sample_data_flights WHERE AvgTicketPrice <= 500 OR FlightDelayMin = 0

--- a/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryActionTest.java
+++ b/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryActionTest.java
@@ -71,8 +71,8 @@ public class RestSQLQueryActionTest {
   @Test
   public void skipQueryThatNotSupport() {
     SQLQueryRequest request = new SQLQueryRequest(
-        new JSONObject("{\"query\": \"SELECT * FROM test WHERE age = 10\"}"),
-        "SELECT * FROM test WHERE age = 10",
+        new JSONObject("{\"query\": \"SELECT * FROM test WHERE age = 10 GROUP BY age\"}"),
+        "SELECT * FROM test WHERE age = 10 GROUP BY age",
         QUERY_API_ENDPOINT,
         "");
 

--- a/sql/src/main/antlr/OpenDistroSQLParser.g4
+++ b/sql/src/main/antlr/OpenDistroSQLParser.g4
@@ -146,7 +146,9 @@ timestampLiteral
 
 // Simplified approach for expression
 expression
-    : predicate                                                     #predicateExpression
+    : left=expression AND right=expression                          #andExpression
+    | left=expression OR right=expression                           #orExpression
+    | predicate                                                     #predicateExpression
     ;
 
 predicate
@@ -163,6 +165,14 @@ expressionAtom
     | LR_BRACKET expression RR_BRACKET                              #nestedExpressionAtom
     | left=expressionAtom mathOperator right=expressionAtom         #mathExpressionAtom
     ;
+
+/*
+logicalExpression
+    : left=logicalExpression AND right=logicalExpression            #andExpression
+    | left=logicalExpression OR right=logicalExpression             #orExpression
+    | NOT logicalExpression                                         #notExpression
+    ;
+*/
 
 mathOperator
     : PLUS | MINUS | STAR | DIVIDE | MODULE

--- a/sql/src/main/antlr/OpenDistroSQLParser.g4
+++ b/sql/src/main/antlr/OpenDistroSQLParser.g4
@@ -167,14 +167,6 @@ expressionAtom
     | left=expressionAtom mathOperator right=expressionAtom         #mathExpressionAtom
     ;
 
-/*
-logicalExpression
-    : left=logicalExpression AND right=logicalExpression            #andExpression
-    | left=logicalExpression OR right=logicalExpression             #orExpression
-    | NOT logicalExpression                                         #notExpression
-    ;
-*/
-
 mathOperator
     : PLUS | MINUS | STAR | DIVIDE | MODULE
     ;

--- a/sql/src/main/antlr/OpenDistroSQLParser.g4
+++ b/sql/src/main/antlr/OpenDistroSQLParser.g4
@@ -146,7 +146,8 @@ timestampLiteral
 
 // Simplified approach for expression
 expression
-    : left=expression AND right=expression                          #andExpression
+    : NOT expression                                                #notExpression
+    | left=expression AND right=expression                          #andExpression
     | left=expression OR right=expression                           #orExpression
     | predicate                                                     #predicateExpression
     ;

--- a/sql/src/main/antlr/OpenDistroSQLParser.g4
+++ b/sql/src/main/antlr/OpenDistroSQLParser.g4
@@ -77,8 +77,12 @@ selectElement
 
 fromClause
     : FROM tableName
+      (whereClause)?
     ;
 
+whereClause
+    : WHERE expression
+    ;
 
 //    Literals
 

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilder.java
@@ -20,10 +20,12 @@ import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDis
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.SelectClauseContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.SelectElementContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.SimpleSelectContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.WhereClauseContext;
 
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Alias;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.AllFields;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
+import com.amazon.opendistroforelasticsearch.sql.ast.tree.Filter;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.Project;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.Relation;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.UnresolvedPlan;
@@ -90,7 +92,16 @@ public class AstBuilder extends OpenDistroSQLParserBaseVisitor<UnresolvedPlan> {
 
   @Override
   public UnresolvedPlan visitFromClause(FromClauseContext ctx) {
-    return new Relation(visitAstExpression(ctx.tableName().qualifiedName()));
+    UnresolvedPlan result = new Relation(visitAstExpression(ctx.tableName().qualifiedName()));
+    if (ctx.whereClause() != null) {
+      result = visit(ctx.whereClause()).attach(result);
+    }
+    return result;
+  }
+
+  @Override
+  public UnresolvedPlan visitWhereClause(WhereClauseContext ctx) {
+    return new Filter(visitAstExpression(ctx.expression()));
   }
 
   @Override

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilder.java
@@ -28,14 +28,18 @@ import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDis
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.StringContext;
 
 import com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.And;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Function;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.Or;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.QualifiedName;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
 import com.amazon.opendistroforelasticsearch.sql.common.utils.StringUtils;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser;
+import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.AndExpressionContext;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.ColumnNameContext;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.IdentContext;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.NestedExpressionAtomContext;
+import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.OrExpressionContext;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.QualifiedNameContext;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.TableNameContext;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParserBaseVisitor;
@@ -109,6 +113,16 @@ public class AstExpressionBuilder extends OpenDistroSQLParserBaseVisitor<Unresol
         ctx.NOT() == null ? LIKE.getName().getFunctionName() :
             NOT_LIKE.getName().getFunctionName(),
         Arrays.asList(visit(ctx.left), visit(ctx.right)));
+  }
+
+  @Override
+  public UnresolvedExpression visitAndExpression(AndExpressionContext ctx) {
+    return new And(visit(ctx.left), visit(ctx.right));
+  }
+
+  @Override
+  public UnresolvedExpression visitOrExpression(OrExpressionContext ctx) {
+    return new Or(visit(ctx.left), visit(ctx.right));
   }
 
   @Override

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilder.java
@@ -20,21 +20,29 @@ import static com.amazon.opendistroforelasticsearch.sql.expression.function.Buil
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.BuiltinFunctionName.IS_NULL;
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.BuiltinFunctionName.LIKE;
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.BuiltinFunctionName.NOT_LIKE;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.BinaryComparisonPredicateContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.BooleanContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.DateLiteralContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.IsNullPredicateContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.LikePredicateContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.MathExpressionAtomContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.NotExpressionContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.NullLiteralContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.ScalarFunctionCallContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.SignedDecimalContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.SignedRealContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.StringContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.TimeLiteralContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.TimestampLiteralContext;
 
 import com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.And;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Function;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.Not;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Or;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.QualifiedName;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
 import com.amazon.opendistroforelasticsearch.sql.common.utils.StringUtils;
-import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.AndExpressionContext;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.ColumnNameContext;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.IdentContext;
@@ -100,7 +108,7 @@ public class AstExpressionBuilder extends OpenDistroSQLParserBaseVisitor<Unresol
   }
 
   @Override
-  public UnresolvedExpression visitIsNullPredicate(OpenDistroSQLParser.IsNullPredicateContext ctx) {
+  public UnresolvedExpression visitIsNullPredicate(IsNullPredicateContext ctx) {
     return new Function(
         ctx.nullNotnull().NOT() == null ? IS_NULL.getName().getFunctionName() :
             IS_NOT_NULL.getName().getFunctionName(),
@@ -108,7 +116,7 @@ public class AstExpressionBuilder extends OpenDistroSQLParserBaseVisitor<Unresol
   }
 
   @Override
-  public UnresolvedExpression visitLikePredicate(OpenDistroSQLParser.LikePredicateContext ctx) {
+  public UnresolvedExpression visitLikePredicate(LikePredicateContext ctx) {
     return new Function(
         ctx.NOT() == null ? LIKE.getName().getFunctionName() :
             NOT_LIKE.getName().getFunctionName(),
@@ -123,6 +131,11 @@ public class AstExpressionBuilder extends OpenDistroSQLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitOrExpression(OrExpressionContext ctx) {
     return new Or(visit(ctx.left), visit(ctx.right));
+  }
+
+  @Override
+  public UnresolvedExpression visitNotExpression(NotExpressionContext ctx) {
+    return new Not(visit(ctx.expression()));
   }
 
   @Override
@@ -146,29 +159,29 @@ public class AstExpressionBuilder extends OpenDistroSQLParserBaseVisitor<Unresol
   }
 
   @Override
-  public UnresolvedExpression visitNullLiteral(OpenDistroSQLParser.NullLiteralContext ctx) {
+  public UnresolvedExpression visitNullLiteral(NullLiteralContext ctx) {
     return AstDSL.nullLiteral();
   }
 
   @Override
-  public UnresolvedExpression visitDateLiteral(OpenDistroSQLParser.DateLiteralContext ctx) {
+  public UnresolvedExpression visitDateLiteral(DateLiteralContext ctx) {
     return AstDSL.dateLiteral(StringUtils.unquoteText(ctx.date.getText()));
   }
 
   @Override
-  public UnresolvedExpression visitTimeLiteral(OpenDistroSQLParser.TimeLiteralContext ctx) {
+  public UnresolvedExpression visitTimeLiteral(TimeLiteralContext ctx) {
     return AstDSL.timeLiteral(StringUtils.unquoteText(ctx.time.getText()));
   }
 
   @Override
   public UnresolvedExpression visitTimestampLiteral(
-      OpenDistroSQLParser.TimestampLiteralContext ctx) {
+      TimestampLiteralContext ctx) {
     return AstDSL.timestampLiteral(StringUtils.unquoteText(ctx.timestamp.getText()));
   }
 
   @Override
   public UnresolvedExpression visitBinaryComparisonPredicate(
-      OpenDistroSQLParser.BinaryComparisonPredicateContext ctx) {
+      BinaryComparisonPredicateContext ctx) {
     String functionName = ctx.comparisonOperator().getText();
     return new Function(
         functionName.equals("<>") ? "!=" : functionName,

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -97,6 +97,12 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void canParseWhereClauseWithLogicalOperator() {
+    assertNotNull(parser.parse("SELECT name FROM test "
+        + "WHERE age = 10 AND name = 'John' OR balance > 1000"));
+  }
+
+  @Test
   public void canNotParseInvalidSelect() {
     assertThrows(SyntaxCheckException.class,
         () -> parser.parse("SELECT * FROM test WHERE age = 10 GROUP BY name"));

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -97,9 +97,15 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void canParseSelectClauseWithLogicalOperator() {
+    assertNotNull(parser.parse(
+        "SELECT age = 10 AND name = 'John' OR NOT (balance > 1000) FROM test"));
+  }
+
+  @Test
   public void canParseWhereClauseWithLogicalOperator() {
     assertNotNull(parser.parse("SELECT name FROM test "
-        + "WHERE age = 10 AND name = 'John' OR balance > 1000"));
+        + "WHERE age = 10 AND name = 'John' OR NOT (balance > 1000)"));
   }
 
   @Test

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/antlr/SQLSyntaxParserTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/antlr/SQLSyntaxParserTest.java
@@ -92,9 +92,14 @@ class SQLSyntaxParserTest {
   }
 
   @Test
+  public void canParseWhereClause() {
+    assertNotNull(parser.parse("SELECT name FROM test WHERE age = 10"));
+  }
+
+  @Test
   public void canNotParseInvalidSelect() {
     assertThrows(SyntaxCheckException.class,
-        () -> parser.parse("SELECT * FROM test WHERE age = 10"));
+        () -> parser.parse("SELECT * FROM test WHERE age = 10 GROUP BY name"));
   }
 
 }

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
@@ -19,6 +19,7 @@ package com.amazon.opendistroforelasticsearch.sql.sql.parser;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.alias;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.booleanLiteral;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.doubleLiteral;
+import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.filter;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.function;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.intLiteral;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.project;
@@ -142,6 +143,23 @@ class AstBuilderTest {
                 + " (age + 10) AS `Age_Expr` "
                 + "FROM test"
         )
+    );
+  }
+
+  @Test
+  public void can_build_where_clause() {
+    assertEquals(
+        project(
+            filter(
+                relation("test"),
+                function(
+                    "=",
+                    qualifiedName("name"),
+                    stringLiteral("John"))
+            ),
+            alias("name", qualifiedName("name"))
+        ),
+        buildAST("SELECT name FROM test WHERE name = 'John'")
     );
   }
 

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -16,12 +16,14 @@
 
 package com.amazon.opendistroforelasticsearch.sql.sql.parser;
 
+import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.and;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.booleanLiteral;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.dateLiteral;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.doubleLiteral;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.function;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.intLiteral;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.nullLiteral;
+import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.or;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.stringLiteral;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.timeLiteral;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.timestampLiteral;
@@ -192,6 +194,19 @@ class AstExpressionBuilderTest {
     assertEquals(
         function("not like", stringLiteral("str"), stringLiteral("st%")),
         buildExprAst("'str' not like 'st%'")
+    );
+  }
+
+  @Test
+  public void canBuildLogicalExpression() {
+    assertEquals(
+        and(booleanLiteral(true), booleanLiteral(false)),
+        buildExprAst("true AND false")
+    );
+
+    assertEquals(
+        or(booleanLiteral(true), booleanLiteral(false)),
+        buildExprAst("true OR false")
     );
   }
 

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -22,6 +22,7 @@ import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.dateLiter
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.doubleLiteral;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.function;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.intLiteral;
+import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.not;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.nullLiteral;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.or;
 import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.stringLiteral;
@@ -207,6 +208,11 @@ class AstExpressionBuilderTest {
     assertEquals(
         or(booleanLiteral(true), booleanLiteral(false)),
         buildExprAst("true OR false")
+    );
+
+    assertEquals(
+        not(booleanLiteral(false)),
+        buildExprAst("NOT false")
     );
   }
 


### PR DESCRIPTION
*Issue #, if available:*

With `WHERE` clause enabled in new engine, the following issues can be resolved:

1. https://github.com/opendistro-for-elasticsearch/sql/issues/368: `LIKE` text issue
2. https://github.com/opendistro-for-elasticsearch/sql/issues/237: Boolean expression in SELECT
3. https://github.com/opendistro-for-elasticsearch/sql/issues/234: Arithmetic expression in WHERE
4. https://github.com/opendistro-for-elasticsearch/sql/issues/690: Optional param for JDBC (null is null)

*Description of changes:* Changed new SQL parser grammar to enable `WHERE` clause and logical expressions (`AND`, `OR`, `NOT`).

*Testing*: Added new UT and IT (comparison test). Added test for the issues above to verify the fix.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
