### PR TITLE
ODBC: Fix Windows 64-bit workflows

### DIFF
--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -144,7 +144,7 @@ jobs:
     - name: prepare-output
       if: always()
       run: |
-        .\scripts\prepare_ci_output.ps1 $Env:ODBC_BIN_PATH $Env:ODBC_LIB_PATH $Env:ODBC_WIN_BUILD_PATH
+        .\scripts\prepare_ci_output.ps1 $Env:ODBC_BIN_PATH $Env:ODBC_LIB_PATH $Env:ODBC_BUILD_PATH
     - name: upload-build
       if: always()
       uses: actions/upload-artifact@v1

--- a/.github/workflows/sql-odbc-release-workflow.yml
+++ b/.github/workflows/sql-odbc-release-workflow.yml
@@ -153,7 +153,7 @@ jobs:
       - name: prepare-output
         if: always()
         run: |
-          .\scripts\prepare_ci_output.ps1 $Env:ODBC_BIN_PATH $Env:ODBC_LIB_PATH $Env:ODBC_WIN_BUILD_PATH
+          .\scripts\prepare_ci_output.ps1 $Env:ODBC_BIN_PATH $Env:ODBC_LIB_PATH $Env:ODBC_BUILD_PATH
       - name: upload-build
         if: always()
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- fix envar name for build path in 64bit workflow build (both main and release workflows)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
