### PR TITLE
Changed rpm and deb artifact name

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -88,7 +88,7 @@ validateNebulaPom.enabled = false
 // This is afterEvaluate because the bundlePlugin ZIP task is updated afterEvaluate and changes the ZIP name to match the plugin name
 afterEvaluate {
     ospackage {
-        packageName = "${name}"
+        packageName = "${rootProject.name}"
         release = isSnapshot ? "0.1" : '1'
         version = "${project.version}" - "-SNAPSHOT"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The released artifacts ended up named as "plugin_1.10.0.0-1_amd64.deb" and same to rpm package. This PR changed the package name back to "opendistro-sql-1.10.0.0_amd64.deb" etc.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
