### PR TITLE
Support date, time, timestamp types in JDBC

### DIFF
--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/DateTimeFunction.java
@@ -78,7 +78,8 @@ public class DateTimeFunction {
   private FunctionResolver dayOfMonth() {
     return define(DAYOFMONTH.getName(),
         impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth),
-            INTEGER, DATE)
+            INTEGER, DATE),
+        impl(nullMissingHandling(DateTimeFunction::exprDayOfMonth), INTEGER, STRING)
     );
   }
 
@@ -128,6 +129,10 @@ public class DateTimeFunction {
    * @return ExprValue.
    */
   private ExprValue exprDayOfMonth(ExprValue date) {
+    if (date instanceof ExprStringValue) {
+      return new ExprIntegerValue(
+          new ExprDateValue(date.stringValue()).dateValue().getMonthValue());
+    }
     return new ExprIntegerValue(date.dateValue().getMonthValue());
   }
 

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/DateTimeFunction.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/DateTimeFunction.java
@@ -131,9 +131,9 @@ public class DateTimeFunction {
   private ExprValue exprDayOfMonth(ExprValue date) {
     if (date instanceof ExprStringValue) {
       return new ExprIntegerValue(
-          new ExprDateValue(date.stringValue()).dateValue().getMonthValue());
+          new ExprDateValue(date.stringValue()).dateValue().getDayOfMonth());
     }
-    return new ExprIntegerValue(date.dateValue().getMonthValue());
+    return new ExprIntegerValue(date.dateValue().getDayOfMonth());
   }
 
   /**

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -21,7 +21,6 @@ import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtil
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.missingValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.nullValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.DATE;
-import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.DATETIME;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.TIME;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.TIMESTAMP;
@@ -29,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprDateValue;
-import com.amazon.opendistroforelasticsearch.sql.data.model.ExprDatetimeValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprTimeValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprTimestampValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/DateTimeFunctionTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/DateTimeFunctionTest.java
@@ -63,13 +63,18 @@ class DateTimeFunctionTest extends ExpressionTestBase {
   public void dayOfMonth() {
     when(nullRef.type()).thenReturn(DATE);
     when(missingRef.type()).thenReturn(DATE);
-
-    FunctionExpression expression = dsl.dayofmonth(DSL.literal(new ExprDateValue("2020-07-07")));
-    assertEquals(INTEGER, expression.type());
-    assertEquals("dayofmonth(DATE '2020-07-07')", expression.toString());
-    assertEquals(integerValue(7), eval(expression));
     assertEquals(nullValue(), eval(dsl.dayofmonth(nullRef)));
     assertEquals(missingValue(), eval(dsl.dayofmonth(missingRef)));
+
+    FunctionExpression expression = dsl.dayofmonth(DSL.literal(new ExprDateValue("2020-07-08")));
+    assertEquals(INTEGER, expression.type());
+    assertEquals("dayofmonth(DATE '2020-07-08')", expression.toString());
+    assertEquals(integerValue(8), eval(expression));
+
+    expression = dsl.dayofmonth(DSL.literal("2020-07-08"));
+    assertEquals(INTEGER, expression.type());
+    assertEquals("dayofmonth(\"2020-07-08\")", expression.toString());
+    assertEquals(integerValue(8), eval(expression));
   }
 
   @Test

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/correctness/runner/connection/JDBCConnection.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/correctness/runner/connection/JDBCConnection.java
@@ -135,7 +135,8 @@ public class JDBCConnection implements DBConnection {
   private String parseColumnNameAndTypesInSchemaJson(String schema) {
     JSONObject json = (JSONObject) new JSONObject(schema).query("/mappings/properties");
     return json.keySet().stream().
-        map(colName -> colName + " " + mapToJDBCType(json, colName)).collect(joining(","));
+        map(colName -> colName + " " + mapToJDBCType(json.getJSONObject(colName).getString("type")))
+        .collect(joining(","));
   }
 
   private String getValueList(Object[] fieldValues) {
@@ -167,28 +168,6 @@ public class JDBCConnection implements DBConnection {
       }
       result.addRow(row);
     }
-  }
-
-  private String mapToJDBCType(JSONObject json, String column) {
-    String esType = json.getJSONObject(column).getString("type");
-    if (esType.equalsIgnoreCase("date")) {
-      try {
-        String format = json.getJSONObject(column).getString("format");
-        switch (format) {
-          case "yyyy-MM-dd HH:mm:ss":
-            return "TIMESTAMP";
-          case "yyyy-MM-dd":
-            return "DATE";
-          case "epoch_millis":
-            return "TIME";
-          default:
-            break;
-        }
-      } catch (JSONException e) {
-        return "TIMESTAMP";
-      }
-    }
-    return mapToJDBCType(esType);
   }
 
   private String mapToJDBCType(String esType) {

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/correctness/runner/connection/JDBCConnection.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/correctness/runner/connection/JDBCConnection.java
@@ -135,8 +135,7 @@ public class JDBCConnection implements DBConnection {
     JSONObject json = (JSONObject) new JSONObject(schema).query("/mappings/properties");
     return json.keySet().stream().
         map(colName -> colName + " " + mapToJDBCType(json.getJSONObject(colName).getString("type")))
-        .
-            collect(joining(","));
+        .collect(joining(","));
   }
 
   private String getValueList(Object[] fieldValues) {

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/correctness/testset/TestDataSet.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/correctness/testset/TestDataSet.java
@@ -118,6 +118,8 @@ public class TestDataSet {
       case "text":
       case "keyword":
       case "date":
+      case "time":
+      case "timestamp":
         return str;
       case "integer":
         return Integer.valueOf(str);

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLCorrectnessIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLCorrectnessIT.java
@@ -47,8 +47,7 @@ public class SQLCorrectnessIT extends CorrectnessTestBase {
   }
 
   /**
-   * Verify queries in files eiifccrchvgttenrjgfnfevfcturkglvfcndftdlieit
-   * in directories with a converter to preprocess query.
+   * Verify queries in files in directories with a converter to preprocess query.
    * For example, for expressions it is converted to a SELECT clause before testing.
    */
   @SuppressWarnings("UnstableApiUsage")

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLCorrectnessIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/SQLCorrectnessIT.java
@@ -47,7 +47,8 @@ public class SQLCorrectnessIT extends CorrectnessTestBase {
   }
 
   /**
-   * Verify queries in files in directories with a converter to preprocess query.
+   * Verify queries in files eiifccrchvgttenrjgfnfevfcturkglvfcndftdlieit
+   * in directories with a converter to preprocess query.
    * For example, for expressions it is converted to a SELECT clause before testing.
    */
   @SuppressWarnings("UnstableApiUsage")

--- a/integ-test/src/test/resources/correctness/expressions/functions.txt
+++ b/integ-test/src/test/resources/correctness/expressions/functions.txt
@@ -73,3 +73,4 @@ sin(-1.57)
 tan(0)
 tan(1.57)
 tan(-1.57)
+dayofmonth('2020-08-26') as dom

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/BaseTypeConverter.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/BaseTypeConverter.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.jdbc.types;
 
 import java.sql.Date;
 import java.sql.SQLException;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,6 +43,7 @@ public abstract class BaseTypeConverter implements TypeConverter {
 
         typeHandlerMap.put(Timestamp.class, TimestampType.INSTANCE);
         typeHandlerMap.put(Date.class, DateType.INSTANCE);
+        typeHandlerMap.put(Time.class, TimeType.INSTANCE);
 
     }
 

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
@@ -72,7 +72,9 @@ public enum ElasticsearchType {
     IP(JDBCType.VARCHAR, String.class, 15, 0, false),
     NESTED(JDBCType.STRUCT, null, 0, 0, false),
     OBJECT(JDBCType.STRUCT, null, 0, 0, false),
-    DATE(JDBCType.TIMESTAMP, Date.class, 24, 24, false),
+    DATE(JDBCType.DATE, Date.class, 12, 12, false),
+    TIME(JDBCType.TIME, Time.class, 12, 12, false),
+    TIMESTAMP(JDBCType.TIMESTAMP, Timestamp.class, 24, 24, false),
     NULL(JDBCType.NULL, null, 0, 0, false),
     UNSUPPORTED(JDBCType.OTHER, null, 0, 0, false);
 
@@ -91,8 +93,8 @@ public enum ElasticsearchType {
         jdbcTypeToESTypeMap.put(JDBCType.REAL, FLOAT);
         jdbcTypeToESTypeMap.put(JDBCType.FLOAT, DOUBLE);
         jdbcTypeToESTypeMap.put(JDBCType.VARCHAR, KEYWORD);
-        jdbcTypeToESTypeMap.put(JDBCType.TIMESTAMP, DATE);
-        jdbcTypeToESTypeMap.put(JDBCType.TIME, DATE);
+        jdbcTypeToESTypeMap.put(JDBCType.TIMESTAMP, TIMESTAMP);
+        jdbcTypeToESTypeMap.put(JDBCType.TIME, TIME);
         jdbcTypeToESTypeMap.put(JDBCType.DATE, DATE);
     }
 

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.jdbc.types;
 
+import java.sql.Date;
 import java.sql.JDBCType;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -71,9 +72,7 @@ public enum ElasticsearchType {
     IP(JDBCType.VARCHAR, String.class, 15, 0, false),
     NESTED(JDBCType.STRUCT, null, 0, 0, false),
     OBJECT(JDBCType.STRUCT, null, 0, 0, false),
-    DATE(JDBCType.DATE, Timestamp.class, 24, 24, false),
-    TIME(JDBCType.TIME, Time.class, 24, 24, false),
-    TIMESTAMP(JDBCType.TIMESTAMP, Timestamp.class, 24, 24, false),
+    DATE(JDBCType.TIMESTAMP, Date.class, 24, 24, false),
     NULL(JDBCType.NULL, null, 0, 0, false),
     UNSUPPORTED(JDBCType.OTHER, null, 0, 0, false);
 
@@ -92,8 +91,8 @@ public enum ElasticsearchType {
         jdbcTypeToESTypeMap.put(JDBCType.REAL, FLOAT);
         jdbcTypeToESTypeMap.put(JDBCType.FLOAT, DOUBLE);
         jdbcTypeToESTypeMap.put(JDBCType.VARCHAR, KEYWORD);
-        jdbcTypeToESTypeMap.put(JDBCType.TIMESTAMP, TIMESTAMP);
-        jdbcTypeToESTypeMap.put(JDBCType.TIME, TIME);
+        jdbcTypeToESTypeMap.put(JDBCType.TIMESTAMP, DATE);
+        jdbcTypeToESTypeMap.put(JDBCType.TIME, DATE);
         jdbcTypeToESTypeMap.put(JDBCType.DATE, DATE);
     }
 

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
@@ -17,6 +17,7 @@
 package com.amazon.opendistroforelasticsearch.jdbc.types;
 
 import java.sql.JDBCType;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Locale;
@@ -70,7 +71,9 @@ public enum ElasticsearchType {
     IP(JDBCType.VARCHAR, String.class, 15, 0, false),
     NESTED(JDBCType.STRUCT, null, 0, 0, false),
     OBJECT(JDBCType.STRUCT, null, 0, 0, false),
-    DATE(JDBCType.TIMESTAMP, Timestamp.class, 24, 24, false),
+    DATE(JDBCType.DATE, Timestamp.class, 24, 24, false),
+    TIME(JDBCType.TIME, Time.class, 24, 24, false),
+    TIMESTAMP(JDBCType.TIMESTAMP, Timestamp.class, 24, 24, false),
     NULL(JDBCType.NULL, null, 0, 0, false),
     UNSUPPORTED(JDBCType.OTHER, null, 0, 0, false);
 
@@ -89,7 +92,8 @@ public enum ElasticsearchType {
         jdbcTypeToESTypeMap.put(JDBCType.REAL, FLOAT);
         jdbcTypeToESTypeMap.put(JDBCType.FLOAT, DOUBLE);
         jdbcTypeToESTypeMap.put(JDBCType.VARCHAR, KEYWORD);
-        jdbcTypeToESTypeMap.put(JDBCType.TIMESTAMP, DATE);
+        jdbcTypeToESTypeMap.put(JDBCType.TIMESTAMP, TIMESTAMP);
+        jdbcTypeToESTypeMap.put(JDBCType.TIME, TIME);
         jdbcTypeToESTypeMap.put(JDBCType.DATE, DATE);
     }
 

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
@@ -72,8 +72,8 @@ public enum ElasticsearchType {
     IP(JDBCType.VARCHAR, String.class, 15, 0, false),
     NESTED(JDBCType.STRUCT, null, 0, 0, false),
     OBJECT(JDBCType.STRUCT, null, 0, 0, false),
-    DATE(JDBCType.DATE, Date.class, 12, 12, false),
-    TIME(JDBCType.TIME, Time.class, 12, 12, false),
+    DATE(JDBCType.TIMESTAMP, Timestamp.class, 24, 24, false),
+    TIME(JDBCType.TIME, Time.class, 24, 24, false),
     TIMESTAMP(JDBCType.TIMESTAMP, Timestamp.class, 24, 24, false),
     NULL(JDBCType.NULL, null, 0, 0, false),
     UNSUPPORTED(JDBCType.OTHER, null, 0, 0, false);

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/TimeType.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/TimeType.java
@@ -18,7 +18,6 @@ package com.amazon.opendistroforelasticsearch.jdbc.types;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 public class TimeType implements TypeHelper<Time>{

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/TimeType.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/TimeType.java
@@ -1,0 +1,74 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.jdbc.types;
+
+import java.sql.SQLException;
+import java.sql.Time;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+public class TimeType implements TypeHelper<Time>{
+
+  public static final TimeType INSTANCE = new TimeType();
+
+  private TimeType() {
+
+  }
+
+  @Override
+  public Time fromValue(Object value, Map<String, Object> conversionParams) throws SQLException {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Time) {
+      return asTime((Time) value);
+    } else if (value instanceof String) {
+      return asTime((String) value);
+    } else if (value instanceof Number) {
+      return this.asTime((Number) value);
+    } else {
+      throw objectConversionException(value);
+    }
+  }
+
+  public Time asTime(Time value) {
+    return localTimetoSqlTime(value.toLocalTime());
+  }
+
+  public Time asTime(String value) throws SQLException {
+    return localTimetoSqlTime(toLocalTime(value));
+  }
+
+  private Time localTimetoSqlTime(LocalTime localTime) {
+    return new Time(localTime.getHour(), localTime.getMinute(), localTime.getSecond());
+  }
+
+  public Time asTime(Number value) {
+    return new Time(value.longValue());
+  }
+
+  private LocalTime toLocalTime(String value) throws SQLException {
+    if (value == null)
+      throw stringConversionException(value, null);
+    return LocalTime.parse(value);
+  }
+
+  @Override
+  public String getTypeName() {
+    return "Time";
+  }
+}

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/TypeConverters.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/TypeConverters.java
@@ -70,7 +70,7 @@ public class TypeConverters {
 
         private static final Set<Class> supportedJavaClasses = Collections.unmodifiableSet(
                 new HashSet<>(Arrays.asList(
-                        String.class, Timestamp.class, java.sql.Date.class
+                        String.class, Timestamp.class
                 )));
 
         private TimestampTypeConverter() {
@@ -93,7 +93,7 @@ public class TypeConverters {
 
         private static final Set<Class> supportedJavaClasses = Collections.unmodifiableSet(
                 new HashSet<>(Arrays.asList(
-                        String.class, Timestamp.class, java.sql.Date.class
+                        String.class, Date.class
                 )));
 
         private DateTypeConverter() {
@@ -116,7 +116,7 @@ public class TypeConverters {
 
         private static final Set<Class> supportedJavaClasses = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(
-                String.class, Time.class, Timestamp.class
+                String.class, Time.class
             )));
 
         private TimeTypeConverter() {

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/TypeConverters.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/TypeConverters.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.jdbc.types;
 
 import java.sql.Date;
 import java.sql.JDBCType;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,6 +46,7 @@ public class TypeConverters {
         // TODO - JDBCType.VARBINARY - byte[] -> Try ES data type
         tcMap.put(JDBCType.TIMESTAMP, new TimestampTypeConverter());
         tcMap.put(JDBCType.DATE, new DateTypeConverter());
+        tcMap.put(JDBCType.TIME, new TimeTypeConverter());
 
         tcMap.put(JDBCType.FLOAT, new FloatTypeConverter());
         tcMap.put(JDBCType.REAL, new RealTypeConverter());
@@ -108,6 +110,28 @@ public class TypeConverters {
             return supportedJavaClasses;
         }
 
+    }
+
+    public static class TimeTypeConverter extends BaseTypeConverter {
+
+        private static final Set<Class> supportedJavaClasses = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(
+                String.class, Time.class, Timestamp.class
+            )));
+
+        private TimeTypeConverter() {
+
+        }
+
+        @Override
+        public Class getDefaultJavaClass() {
+            return Time.class;
+        }
+
+        @Override
+        public Set<Class> getSupportedJavaClasses() {
+            return supportedJavaClasses;
+        }
     }
 
     public static class VarcharTypeConverter extends BaseTypeConverter {

--- a/sql-jdbc/src/test/java/com/amazon/opendistroforelasticsearch/jdbc/types/TimeTypeTest.java
+++ b/sql-jdbc/src/test/java/com/amazon/opendistroforelasticsearch/jdbc/types/TimeTypeTest.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.jdbc.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.amazon.opendistroforelasticsearch.jdbc.test.UTCTimeZoneTestExtension;
+import java.sql.Time;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@ExtendWith(UTCTimeZoneTestExtension.class)
+public class TimeTypeTest {
+
+  @ParameterizedTest
+  @CsvSource(value = {
+      "00:00:00, 00:00:00",
+      "01:01:01, 01:01:01",
+      "23:59:59, 23:59:59"
+  })
+  void testTimeFromString(String inputString, String resultString) {
+    Time time = Assertions.assertDoesNotThrow(
+        () -> TimeType.INSTANCE.fromValue(inputString, null));
+    assertEquals(resultString, time.toString());
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changed mappings between es and types of date, time, timestamp.
----
Previously:

| ES type from mapping | to JDBC type |
| --- | --- |
| Date | Timestamp |

| from JDBC type | to ES type (schema) |
| --- | --- |
| Date | Date |
|Timestamp | Date | 

Currently:

| Mapping in ES | JDBC | Resulted schema |
| --- | --- | --- |
| Date | Timestamp | Timestamp |
|  | Date | Date |
|  | Time | Time |

Fixed the `dayofmonth` function
----
1. The implementation of `dayofmonth` for `ExprValue` was incorrect, fixed it to the correct one.
2. Allows the function with string type argument, and grants it as the date type to stay consistent with the other databases. For example, previously we only support `dayofmonth(date('2020-08-27'))` and return `27` as the result, but `dayofmonth('2020-08-27')` throws semantic exception; now we support both of these two inputs and return `27`.
3. Added comparison test for `dayofmonth` function.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
