### PR TITLE
Fix download link in package description

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -110,7 +110,7 @@ afterEvaluate {
 
         license 'ASL-2.0'
         maintainer 'OpenDistro for Elasticsearch Team <opendistro@amazon.com>'
-        url 'https://opendistro.github.io/elasticsearch/downloads'
+        url 'https://opendistro.github.io/for-elasticsearch/downloads.html'
         summary '''
          SQL plugin for OpenDistro for Elasticsearch.
          Reference documentation can be found at https://opendistro.github.io/for-elasticsearch-docs/.


### PR DESCRIPTION
*Issue #, if available:*
A community user found a bug in the links stated in package descriptions. check the post [here](https://discuss.opendistrocommunity.dev/t/unable-to-setup-apt-repo-for-opendistro-in-our-org/3124)

*Description of changes:*
Fix the download link in the package description. Not sure if it needs to be changed anywhere else in this repo

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
