### PR TITLE
Fix 1.10.1 workbench scroll bar and cypress version

### DIFF
--- a/workbench/.cypress/integration/ui.spec.js
+++ b/workbench/.cypress/integration/ui.spec.js
@@ -71,7 +71,7 @@ describe('Test and verify downloads', () => {
         url: url,
         headers: {
           'content-type': 'application/json;charset=UTF-8',
-          'kbn-version': '7.8.0',
+          'kbn-version': '7.9.1',
         },
         body: {
           'query': 'select * from accounts where balance > 49500'

--- a/workbench/public/app.scss
+++ b/workbench/public/app.scss
@@ -23,7 +23,6 @@
 
 .sql-console-query-container {
   padding: $euiSizeL;
-  height: 1142px;
 }
 
 .sql-console-query-editor {
@@ -69,7 +68,6 @@
   }
 }
 .sql-console-query-result{
-  height: 577px;
   scroll-behavior: smooth;
   .sql-console-results-container {
     overflow: auto;


### PR DESCRIPTION
*Issue #, if available:*
- #739 

*Description of changes:*
- removed hard coded `height` in scss to fix double scroll bar
- updated kibana to 7.9.1 in cypress request header

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
