### PR TITLE
Bug Fix, Clean all the indices, included hidden indices

### DIFF
--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/ODFERestTestCase.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/ODFERestTestCase.java
@@ -76,7 +76,9 @@ public abstract class ODFERestTestCase extends ESRestTestCase {
   }
 
   protected static void wipeAllODFEIndices() throws IOException {
-    Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json"));
+    // include all the indices, included hidden indices.
+    // https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html#cat-indices-api-query-params
+    Response response = client().performRequest(new Request("GET", "/_cat/indices?format=json&expand_wildcards=all"));
     JSONArray jsonArray = new JSONArray(EntityUtils.toString(response.getEntity(), "UTF-8"));
     for (Object object : jsonArray) {
       JSONObject jsonObject = (JSONObject) object;


### PR DESCRIPTION
*Description of changes:*
Delete all the indices included hidden indices during IT cleanup stage. https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html#cat-indices-api-query-params

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
