### PR TITLE
Bump to ODFE 1.10.1.1 for integration test fixes

### DIFF
--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           config-name: draft-release-notes-config.yml
           tag: (None)
-          version: 1.10.1.0
+          version: 1.10.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
 }
 
 allprojects {
-    version = "${opendistroVersion}.0"
+    version = "${opendistroVersion}.1"
 
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "1.8"

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -1,4 +1,5 @@
 import org.elasticsearch.gradle.test.RestIntegTestTask
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.rest-test'
@@ -198,6 +199,11 @@ testClusters.comparisonTest {
 task compileJdbc(type:Exec) {
     workingDir '../sql-jdbc/'
 
-    commandLine './gradlew', 'build'
-    commandLine './gradlew', 'shadowJar'
+    if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows()) {
+        commandLine './gradlew.bat', 'build'
+        commandLine './gradlew.bat', 'shadowJar'
+    } else {
+        commandLine './gradlew', 'build'
+        commandLine './gradlew', 'shadowJar'
+    }
 }

--- a/release-notes/opendistro-for-elasticsearch-sql.release-notes-1.10.1.1.md
+++ b/release-notes/opendistro-for-elasticsearch-sql.release-notes-1.10.1.1.md
@@ -1,0 +1,6 @@
+## 2020-09-28 Version 1.10.1.1
+
+### Infrastructure
+* Support security plugin ([#760](https://github.com/opendistro-for-elasticsearch/sql/pull/760))
+* Bump to ODFE 1.10.1.1 for integration test fixes ([#759](https://github.com/opendistro-for-elasticsearch/sql/pull/759))
+* Bug Fix, Clean all the indices, included hidden indices ([#758](https://github.com/opendistro-for-elasticsearch/sql/pull/758))

--- a/sql-cli/src/odfe_sql_cli/__init__.py
+++ b/sql-cli/src/odfe_sql_cli/__init__.py
@@ -12,4 +12,4 @@ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
-__version__ = "1.10.1.0"
+__version__ = "1.10.1.1"

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -32,7 +32,7 @@ plugins {
 group 'com.amazon.opendistroforelasticsearch.client'
 
 // keep version in sync with version in Driver source
-version '1.10.1.0'
+version '1.10.1.1'
 
 boolean snapshot = "true".equals(System.getProperty("build.snapshot", "true"));
 if (snapshot) {

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/internal/Version.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/internal/Version.java
@@ -19,7 +19,7 @@ package com.amazon.opendistroforelasticsearch.jdbc.internal;
 public enum Version {
 
     // keep this in sync with the gradle version
-    Current(1, 10, 1, 0);
+    Current(1, 10, 1, 1);
 
     private int major;
     private int minor;

--- a/sql-odbc/src/CMakeLists.txt
+++ b/sql-odbc/src/CMakeLists.txt
@@ -78,8 +78,8 @@ set(INSTALL_SRC "${CMAKE_CURRENT_SOURCE_DIR}/installer")
 set(DSN_INSTALLER_SRC "${CMAKE_CURRENT_SOURCE_DIR}/DSNInstaller")
 
 # ODBC Driver version 
-set(DRIVER_PACKAGE_VERSION "1.10.1.0")
-set(DRIVER_PACKAGE_VERSION_COMMA_SEPARATED "1,10,1,0")
+set(DRIVER_PACKAGE_VERSION "1.10.1.1")
+set(DRIVER_PACKAGE_VERSION_COMMA_SEPARATED "1,10,1,1")
 add_compile_definitions( ES_ODBC_VERSION="${DRIVER_PACKAGE_VERSION}"
                          # Comma separated version is required for odbc administrator's driver file.
                          ES_ODBC_DRVFILE_VERSION=${DRIVER_PACKAGE_VERSION_COMMA_SEPARATED} )

--- a/sql-odbc/src/TableauConnector/odfe_sql_odbc/manifest.xml
+++ b/sql-odbc/src/TableauConnector/odfe_sql_odbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='odfe_sql_odbc' superclass='odbc' plugin-version='1.10.1.0' name='SQL' version='18.1' min-version-tableau='2020.1'>
+<connector-plugin class='odfe_sql_odbc' superclass='odbc' plugin-version='1.10.1.1' name='SQL' version='18.1' min-version-tableau='2020.1'>
   <vendor-information>
       <company name="Open Distro for ES"/>
       <support-link url="https://github.com/opendistro-for-elasticsearch/sql"/>

--- a/sql-odbc/src/TableauConnector/odfe_sql_odbc_dev/manifest.xml
+++ b/sql-odbc/src/TableauConnector/odfe_sql_odbc_dev/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='odfe_sql_odbc_dev' superclass='odbc' plugin-version='1.10.1.0' name='Open Distro for Elasticsearch SQL ODBC DEV' version='18.1' min-version-tableau='2020.1'>
+<connector-plugin class='odfe_sql_odbc_dev' superclass='odbc' plugin-version='1.10.1.1' name='Open Distro for Elasticsearch SQL ODBC DEV' version='18.1' min-version-tableau='2020.1'>
   <vendor-information>
       <company name="Open Distro for Elasticsearch"/>
       <support-link url="https://github.com/opendistro-for-elasticsearch/sql"/>

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opendistro-query-workbench",
-  "version": "1.10.1.0",
+  "version": "1.10.1.1",
   "description": "Query Workbench",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- bumped all plugins to 1.10.1.1
- added os check in `compileJdbc` for Windows integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
