### PR TITLE
Support security plugin in comparison test

### DIFF
--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/correctness/runner/connection/ESConnection.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/correctness/runner/connection/ESConnection.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.sql.correctness.runner.connection;
 import com.amazon.opendistroforelasticsearch.sql.correctness.runner.resultset.DBResult;
 import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
@@ -39,7 +40,7 @@ public class ESConnection implements DBConnection {
   private final RestClient client;
 
   public ESConnection(String connectionUrl, RestClient client) {
-    this.connection = new JDBCConnection("Elasticsearch", connectionUrl);
+    this.connection = new JDBCConnection("Elasticsearch", connectionUrl, populateProperties());
     this.client = client;
   }
 
@@ -82,6 +83,20 @@ public class ESConnection implements DBConnection {
     // Only close database connection and leave ES REST connection alone
     // because it's initialized and manged by ES test base class.
     connection.close();
+  }
+
+  private Properties populateProperties() {
+    Properties properties = new Properties();
+    if (Boolean.parseBoolean(System.getProperty("https", "false"))) {
+      properties.put("useSSL", "true");
+    }
+    if (!System.getProperty("user", "").isEmpty()) {
+      properties.put("user", System.getProperty("user"));
+      properties.put("password", System.getProperty("password", ""));
+      properties.put("trustSelfSigned", "true");
+      properties.put("hostnameVerification", "false");
+    }
+    return properties;
   }
 
   private void performRequest(Request request) {

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/correctness/runner/connection/JDBCConnection.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/correctness/runner/connection/JDBCConnection.java
@@ -29,7 +29,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
-import org.json.JSONException;
+import java.util.Properties;
 import org.json.JSONObject;
 
 /**
@@ -51,19 +51,35 @@ public class JDBCConnection implements DBConnection {
   private final String connectionUrl;
 
   /**
+   * JDBC driver config properties.
+   */
+  private final Properties properties;
+
+  /**
    * Current live connection
    */
   private Connection connection;
 
   public JDBCConnection(String databaseName, String connectionUrl) {
+    this(databaseName, connectionUrl, new Properties());
+  }
+
+  /**
+   * Create a JDBC connection with parameters given (but not connect to database at the moment).
+   * @param databaseName    database name
+   * @param connectionUrl   connection URL
+   * @param properties      config properties
+   */
+  public JDBCConnection(String databaseName, String connectionUrl, Properties properties) {
     this.databaseName = databaseName;
     this.connectionUrl = connectionUrl;
+    this.properties = properties;
   }
 
   @Override
   public void connect() {
     try {
-      connection = DriverManager.getConnection(connectionUrl);
+      connection = DriverManager.getConnection(connectionUrl, properties);
     } catch (Exception e) {
       throw new IllegalStateException("Failed to open connection", e);
     }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/RestIntegTestCase.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/RestIntegTestCase.java
@@ -54,7 +54,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -72,7 +71,7 @@ import org.junit.Before;
  * <p>
  * TODO: this base class should extends ODFERestTestCase
  */
-public abstract class RestIntegTestCase extends ESRestTestCase {
+public abstract class RestIntegTestCase extends ODFERestTestCase {
 
   @Before
   public void setUpIndices() throws Exception {

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/RestIntegTestCase.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/RestIntegTestCase.java
@@ -133,7 +133,7 @@ public abstract class RestIntegTestCase extends ODFERestTestCase {
    */
   @AfterClass
   public static void cleanUpIndices() throws IOException {
-    wipeAllIndices();
+    wipeAllODFEIndices();
     wipeAllClusterSettings();
   }
 

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/CorrectnessTestBase.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/CorrectnessTestBase.java
@@ -67,6 +67,10 @@ public abstract class CorrectnessTestBase extends RestIntegTestCase {
    */
   @AfterClass
   public static void cleanUp() {
+    if (runner == null) {
+      return;
+    }
+
     try {
       TestConfig config = new TestConfig(emptyMap());
       for (TestDataSet dataSet : config.getTestDataSets()) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Comparison test for new engine doesn't support testing against ODFE cluster with security plugin enabled. The following changes are made to fix this:

 1. Pass `https`, `user` and `password` parameter value to SQL JDBC driver to support security plugin.
 2. Change `CorrectnessTestBase` to inherit from `ODFERestTestCase`.
 3. Change `wipeAllIndices` to `wipeAllODFEIndices` to avoid permission issue: `SQLIntegTestCase` already have this fix in legacy module, however it's missing in the cloned `RestIntegTestCase`.

*Testing*:

Run ODFE 1.10.1 docker with security plugin enabled:

```
# Run docker with security plugin against OD version
# https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/.github/scripts/setup_runners_service.sh#L122
➜ echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:1.10.1" >> Dockerfile
➜ echo "RUN echo ''  >> /usr/share/elasticsearch/config/elasticsearch.yml" >> Dockerfile
➜ echo "RUN echo \"path.repo: [\\\"/usr/share/elasticsearch\\\"]\" >> /usr/share/elasticsearch/config/elasticsearch.yml" >> Dockerfile
➜ echo "RUN echo \"script.context.field.max_compilations_rate: 1000/1m\" >> /usr/share/elasticsearch/config/elasticsearch.yml" >> Dockerfile

➜ docker build -t odfe-http:security -f Dockerfile .
Sending build context to Docker daemon  2.048kB
Step 1/4 : FROM opendistroforelasticsearch/opendistroforelasticsearch:1.10.1
 ---> b3e80722f0c5
Step 2/4 : RUN echo ''  >> /usr/share/elasticsearch/config/elasticsearch.yml
 ---> Running in 0240221db08c
Removing intermediate container 0240221db08c
 ---> 4c4e94ead724
Step 3/4 : RUN echo "path.repo: [\"/usr/share/elasticsearch\"]" >> /usr/share/elasticsearch/config/elasticsearch.yml
 ---> Running in 09ed4624d11b
Removing intermediate container 09ed4624d11b
 ---> 7e0945ada901
Step 4/4 : RUN echo "script.context.field.max_compilations_rate: 1000/1m" >> /usr/share/elasticsearch/config/elasticsearch.yml
 ---> Running in 65b17fe267fe
Removing intermediate container 65b17fe267fe
 ---> b7121fdbc2ed
Successfully built b7121fdbc2ed
Successfully tagged odfe-http:security

➜ docker run -d -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" --name Test-Docker-1.10.1 odfe-http:security
0f7dbc8eef669323031966b37d508574b0624b27737babfaf3de437c19040656
```

Run integration test against the remote docker:

```
./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername=es-integrationtest -Dtests.class="*SQLCorrectnessIT" -Dhttps=true -Duser=admin -Dpassword=admin
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
