### PR TITLE
Bug fix, using Local.Root when format the string

### DIFF
--- a/common/src/main/java/com/amazon/opendistroforelasticsearch/sql/common/utils/StringUtils.java
+++ b/common/src/main/java/com/amazon/opendistroforelasticsearch/sql/common/utils/StringUtils.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.sql.common.utils;
 
 import com.google.common.base.Strings;
+import java.util.IllegalFormatException;
 import java.util.Locale;
 
 public class StringUtils {
@@ -68,10 +69,10 @@ public class StringUtils {
    * @param format format string
    * @param args   arguments referenced by the format specifiers in the format string
    * @return A formatted string
-   * @throws java.util.IllegalFormatException If a format string contains an illegal syntax, a format
-   *                                          specifier that is incompatible with the given arguments,
-   *                                          insufficient arguments given the format string, or other
-   *                                          illegal conditions.
+   * @throws IllegalFormatException If a format string contains an illegal syntax, a format
+   *                                specifier that is incompatible with the given arguments,
+   *                                insufficient arguments given the format string, or other
+   *                                illegal conditions.
    * @see java.lang.String#format(Locale, String, Object...)
    */
   public static String format(final String format, Object... args) {

--- a/common/src/main/java/com/amazon/opendistroforelasticsearch/sql/common/utils/StringUtils.java
+++ b/common/src/main/java/com/amazon/opendistroforelasticsearch/sql/common/utils/StringUtils.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.sql.common.utils;
 
 import com.google.common.base.Strings;
+import java.util.Locale;
 
 public class StringUtils {
   /**
@@ -58,6 +59,23 @@ public class StringUtils {
     } else {
       return identifier;
     }
+  }
+
+  /**
+   * Returns a formatted string using the specified format string and
+   * arguments, as well as the {@link Locale#ROOT} locale.
+   *
+   * @param format format string
+   * @param args   arguments referenced by the format specifiers in the format string
+   * @return A formatted string
+   * @throws java.util.IllegalFormatException If a format string contains an illegal syntax, a format
+   *                                          specifier that is incompatible with the given arguments,
+   *                                          insufficient arguments given the format string, or other
+   *                                          illegal conditions.
+   * @see java.lang.String#format(Locale, String, Object...)
+   */
+  public static String format(final String format, Object... args) {
+    return String.format(Locale.ROOT, format, args);
   }
 
   private static boolean isQuoted(String text, String mark) {

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/DateTimeFunctionIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/DateTimeFunctionIT.java
@@ -21,6 +21,7 @@ import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.schema
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.verifySchema;
 import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.verifySome;
 
+import com.amazon.opendistroforelasticsearch.sql.common.utils.StringUtils;
 import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -371,7 +372,7 @@ public class DateTimeFunctionIT extends PPLIntegTestCase {
   }
 
   private void week(String date, int mode, int expectedResult) throws IOException {
-    JSONObject result = executeQuery(String.format(
+    JSONObject result = executeQuery(StringUtils.format(
         "source=%s | eval f = week(date('%s'), %d) | fields f", TEST_INDEX_DATE, date, mode));
     verifySchema(result, schema("f", null, "integer"));
     verifySome(result.getJSONArray("datarows"), rows(expectedResult));


### PR DESCRIPTION
## Description of changes:
The DateTimeFunctionIT.testWeek failed when running with locale=th-TH-u-nu-thai-x-lvariant-TH
```
REPRODUCE WITH: ./gradlew ':integ-test:integTestWithNewEngineRunner' --tests "com.amazon.opendistroforelasticsearch.sql.ppl.DateTimeFunctionIT.testWeek" -Dtests.seed=533E63C3378AF235 -Dtests.security.manager=false -Dtests.locale=th-TH-u-nu-thai-x-lvariant-TH -Dtests.timezone=Pacific/Tongatapu -Druntime.java=14

com.amazon.opendistroforelasticsearch.sql.ppl.DateTimeFunctionIT > testWeek FAILED
    org.elasticsearch.client.ResponseException: method [POST], host [http://127.0.0.1:49687], URI [/_opendistro/_ppl], status line [HTTP/1.1 400 Bad Request]
    {
      "error": {
        "reason": "Invalid Query",
        "details": "Failed to parse query due to offending symbol [)] at: 'source=elasticsearch-sql_test_index_date | eval f = week(date('2008-02-20'), ๐)' <--- HERE... More details: Expecting tokens in {'D', 'NOT', 'TRUE', 'FALSE', 'INTERVAL', 'MICROSECOND', 'SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'QUARTER', 'YEAR', '.', '+', '-', '(', '`', 'AVG', 'COUNT', 'MAX', 'MIN', 'SUM', 'ABS', 'CEIL', 'CEILING', 'CONV', 'CRC32', 'E', 'EXP', 'FLOOR', 'LN', 'LOG', 'LOG10', 'LOG2', 'MOD', 'PI', 'POW', 'POWER', 'RAND', 'ROUND', 'SIGN', 'SQRT', 'TRUNCATE', 'ACOS', 'ASIN', 'ATAN', 'ATAN2', 'COS', 'COT', 'DEGREES', 'RADIANS', 'SIN', 'TAN', 'ADDDATE', 'DATE', 'DATE_ADD', 'DATE_SUB', 'DAYOFMONTH', 'DAYOFWEEK', 'DAYOFYEAR', 'DAYNAME', 'FROM_DAYS', 'MONTHNAME', 'SUBDATE', 'TIME', 'TIME_TO_SEC', 'TIMESTAMP', 'DATE_FORMAT', 'TO_DAYS', 'SUBSTR', 'SUBSTRING', 'LTRIM', 'RTRIM', 'TRIM', 'LOWER', 'UPPER', 'CONCAT', 'CONCAT_WS', 'LENGTH', 'STRCMP', ID, INTEGER_LITERAL, DECIMAL_LITERAL, DQUOTA_STRING, SQUOTA_STRING, BQUOTA_STRING}",
        "type": "SyntaxCheckException"
      },
      "status": 400
    }
        at __randomizedtesting.SeedInfo.seed([533E63C3378AF235:E964A9F36D151098]:0)
        at org.elasticsearch.client.RestClient.convertResponse(RestClient.java:302)
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:272)
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:246)
        at com.amazon.opendistroforelasticsearch.sql.ppl.PPLIntegTestCase.executeQueryToString(PPLIntegTestCase.java:42)
        at com.amazon.opendistroforelasticsearch.sql.ppl.PPLIntegTestCase.executeQuery(PPLIntegTestCase.java:38)
        at com.amazon.opendistroforelasticsearch.sql.ppl.DateTimeFunctionIT.week(DateTimeFunctionIT.java:374)
        at com.amazon.opendistroforelasticsearch.sql.ppl.DateTimeFunctionIT.testWeek(DateTimeFunctionIT.java:387)
```
The following test code explain why it failed and how to handle this cases.
```
    @Test
    public void demo_locale() {
        Locale.Builder builder = new Locale.Builder();
        builder.setLanguageTag("th-TH-u-nu-thai-x-lvariant-TH");
        final Locale localeThai = builder.build();
        assertEquals("week(date('2008-02-20'), ๐)", String.format(localeThai, "week(date('2008-02-20'), %d)", 0));
        assertEquals("week(date('2008-02-20'), 0)", String.format(Locale.ROOT, "week(date('2008-02-20'), %d)", 0));
    }
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
