### PR TITLE
Fix cast statement in aggregate function return 0

### DIFF
--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/AggregationExpressionIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/AggregationExpressionIT.java
@@ -252,6 +252,16 @@ public class AggregationExpressionIT extends SQLIntegTestCase {
         rows("2018-06-23 00:00:00.000", 1));
   }
 
+  @Test
+  public void aggregateCastStatementShouldNotReturnZero() {
+    JSONObject response = executeJdbcRequest(String.format(
+        "SELECT SUM(CAST(male AS INT)) AS male_sum FROM %s",
+        Index.BANK.getName()));
+
+    verifySchema(response, schema("male_sum", "male_sum", "double"));
+    verifyDataRows(response, rows(4));
+  }
+
   private JSONObject executeJdbcRequest(String query) {
     return new JSONObject(executeQuery(query, "jdbc"));
   }

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/parser/FieldMaker.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/parser/FieldMaker.java
@@ -347,6 +347,14 @@ public class FieldMaker {
                 methodParameters.add(new KVValue(((SQLCastExpr) object).getExpr().toString()));
                 String castType = ((SQLCastExpr) object).getDataType().getName();
                 String scriptCode = sqlFunctions.getCastScriptStatement(castName, castType, methodParameters);
+
+                // Parameter "first" indicates if return statement is required. Take CAST statement nested in
+                // aggregate function SUM(CAST...) for example, return statement is required in this case.
+                // Otherwise DSL with metric aggregation always returns 0 as result. And also the caller
+                // makeFieldImpl(SQLExpr("SUM...")) does pass first=true to here.
+                if (first) {
+                    scriptCode += "; return " + castName;
+                }
                 methodParameters.add(new KVValue(scriptCode));
                 paramers.add(new KVValue("script", new SQLCharExpr(scriptCode)));
             } else if (object instanceof SQLAggregateExpr) {

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/parser/FieldMaker.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/parser/FieldMaker.java
@@ -332,7 +332,7 @@ public class FieldMaker {
                     paramers.add(new KVValue("children", childrenType));
                 } else if (SQLFunctions.isFunctionTranslatedToScript(methodName)) {
                     //throw new SqlParseException("only support script/nested as inner functions");
-                    MethodField abc = makeMethodField(methodName, mExpr.getParameters(), null, null, tableAlias, first);
+                    MethodField abc = makeMethodField(methodName, mExpr.getParameters(), null, null, tableAlias, false);
                     paramers.add(new KVValue(abc.getParams().get(0).toString(),
                             new SQLCharExpr(abc.getParams().get(1).toString())));
                 } else {

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/parser/FieldMaker.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/parser/FieldMaker.java
@@ -332,7 +332,7 @@ public class FieldMaker {
                     paramers.add(new KVValue("children", childrenType));
                 } else if (SQLFunctions.isFunctionTranslatedToScript(methodName)) {
                     //throw new SqlParseException("only support script/nested as inner functions");
-                    MethodField abc = makeMethodField(methodName, mExpr.getParameters(), null, null, tableAlias, false);
+                    MethodField abc = makeMethodField(methodName, mExpr.getParameters(), null, null, tableAlias, first);
                     paramers.add(new KVValue(abc.getParams().get(0).toString(),
                             new SQLCharExpr(abc.getParams().get(1).toString())));
                 } else {
@@ -350,8 +350,8 @@ public class FieldMaker {
 
                 // Parameter "first" indicates if return statement is required. Take CAST statement nested in
                 // aggregate function SUM(CAST...) for example, return statement is required in this case.
-                // Otherwise DSL with metric aggregation always returns 0 as result. And also the caller
-                // makeFieldImpl(SQLExpr("SUM...")) does pass first=true to here.
+                // Otherwise DSL with metric aggregation always returns 0 as result. And this works also because
+                // the caller makeFieldImpl(SQLExpr("SUM...")) does pass first=true to here.
                 if (first) {
                     scriptCode += "; return " + castName;
                 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/772

*Description of changes:* As per investigation in the issue, the root cause is return statement is missing in the painless script generated. Please the comment on the code changes for more details.

*TO-DO*: Other built-in functions also have this issue if we disable semantic analyzer (which disallow this) and do "SUM(ABS(a))". I tried a quick fix but it broke existing ITs. Here we only fix aggregate function on `CAST` statement. The issue should go away once new query engine enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
