### PR TITLE
Enforce 100% branch coverage for sql and es module

### DIFF
--- a/elasticsearch/build.gradle
+++ b/elasticsearch/build.gradle
@@ -54,9 +54,13 @@ jacocoTestCoverageVerification {
                     'com.amazon.opendistroforelasticsearch.sql.elasticsearch.security.SecurityAccess'
             ]
             limit {
+                counter = 'LINE'
                 minimum = 1.0
             }
-
+            limit {
+                counter = 'BRANCH'
+                minimum = 1.0
+            }
         }
     }
     afterEvaluate {

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScan.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexScan.java
@@ -142,8 +142,7 @@ public class ElasticsearchIndexScan extends TableScanOperator {
   }
 
   private boolean isBoolFilterQuery(QueryBuilder current) {
-    return (current instanceof BoolQueryBuilder)
-        && !((BoolQueryBuilder) current).filter().isEmpty();
+    return (current instanceof BoolQueryBuilder);
   }
 
 }

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/core/ExpressionScript.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/core/ExpressionScript.java
@@ -137,7 +137,7 @@ public class ExpressionScript {
     String fieldName = getDocValueName(field);
     ScriptDocValues<?> docValue = docProvider.get().get(fieldName);
     if (docValue == null || docValue.isEmpty()) {
-      return null;
+      return null; // No way to differentiate null and missing from doc value
     }
 
     Object value = docValue.get(0);

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/ExpressionFilterScript.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/ExpressionFilterScript.java
@@ -53,11 +53,10 @@ class ExpressionFilterScript extends FilterScript {
     return (Boolean) expressionScript.execute(this::getDoc, this::evaluateExpression);
   }
 
-
   private ExprValue evaluateExpression(Expression expression,
                                        Environment<Expression, ExprValue> valueEnv) {
     ExprValue result = expression.valueOf(valueEnv);
-    if (result.isNull() || result.isMissing()) {
+    if (result.isNull()) {
       return ExprBooleanValue.of(false);
     }
 

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/ElasticsearchResponseTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/ElasticsearchResponseTest.java
@@ -16,6 +16,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.response;
 
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -75,17 +76,20 @@ class ElasticsearchResponseTest {
                 new TotalHits(2L, TotalHits.Relation.EQUAL_TO),
                 1.0F));
 
-    ElasticsearchResponse response1 = new ElasticsearchResponse(esResponse, factory);
-    assertFalse(response1.isEmpty());
+    assertFalse(new ElasticsearchResponse(esResponse, factory).isEmpty());
 
     when(esResponse.getHits()).thenReturn(SearchHits.empty());
-    ElasticsearchResponse response2 = new ElasticsearchResponse(esResponse, factory);
-    assertTrue(response2.isEmpty());
+    when(esResponse.getAggregations()).thenReturn(null);
+    assertTrue(new ElasticsearchResponse(esResponse, factory).isEmpty());
 
     when(esResponse.getHits())
         .thenReturn(new SearchHits(null, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0));
     ElasticsearchResponse response3 = new ElasticsearchResponse(esResponse, factory);
     assertTrue(response3.isEmpty());
+
+    when(esResponse.getHits()).thenReturn(SearchHits.empty());
+    when(esResponse.getAggregations()).thenReturn(new Aggregations(emptyList()));
+    assertFalse(new ElasticsearchResponse(esResponse, factory).isEmpty());
   }
 
   @Test

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/lucene/LuceneQueryTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/filter/lucene/LuceneQueryTest.java
@@ -16,14 +16,24 @@
 
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage.script.filter.lucene;
 
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.amazon.opendistroforelasticsearch.sql.expression.DSL;
+import com.amazon.opendistroforelasticsearch.sql.expression.config.ExpressionConfig;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class LuceneQueryTest {
+
+  @Test
+  void should_not_support_single_argument_by_default() {
+    DSL dsl = new ExpressionConfig().dsl(new ExpressionConfig().functionRepository());
+    assertFalse(new LuceneQuery(){}.canSupport(dsl.abs(DSL.ref("age", INTEGER))));
+  }
 
   @Test
   void should_throw_exception_if_not_implemented() {

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -67,9 +67,13 @@ jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
+                counter = 'LINE'
                 minimum = 1.0
             }
-
+            limit {
+                counter = 'BRANCH'
+                minimum = 1.0
+            }
         }
     }
     afterEvaluate {

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/domain/SQLQueryRequest.java
@@ -17,6 +17,8 @@
 package com.amazon.opendistroforelasticsearch.sql.sql.domain;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,9 @@ import org.json.JSONObject;
 @EqualsAndHashCode
 @RequiredArgsConstructor
 public class SQLQueryRequest {
+
+  private static final Set<String> QUERY_FIELD = ImmutableSet.of("query");
+  private static final Set<String> QUERY_AND_FETCH_SIZE = ImmutableSet.of("query", "fetch_size");
 
   /**
    * JSON payload in REST request.
@@ -54,15 +59,15 @@ public class SQLQueryRequest {
 
   /**
    * Pre-check if the request can be supported by meeting the following criteria:
-   *  1.Only "query" field in payload. In other word, it's not a cursor request
-   *   (with either non-zero "fetch_size" or "cursor" field) or request with extra field
-   *   such as "filter".
+   *  1.Only "query" field or "query" and "fetch_size=0" in payload. In other word,
+   *  it's not a cursor request with either non-zero "fetch_size" or "cursor" field,
+   *  or request with extra field such as "filter".
    *  2.Response format expected is default JDBC format.
    *
    * @return  true if supported.
    */
   public boolean isSupported() {
-    return isOnlyQueryFieldInPayload()
+    return (isOnlyQueryFieldInPayload() || isOnlyQueryAndFetchSizeZeroInPayload())
         && isDefaultFormat();
   }
 
@@ -75,9 +80,12 @@ public class SQLQueryRequest {
   }
 
   private boolean isOnlyQueryFieldInPayload() {
-    return (jsonContent.keySet().size() == 1 && jsonContent.has("query"))
-        || (jsonContent.keySet().size() == 2 && jsonContent.has("query")
-            && jsonContent.has("fetch_size") && jsonContent.getInt("fetch_size") == 0);
+    return QUERY_FIELD.equals(jsonContent.keySet());
+  }
+
+  private boolean isOnlyQueryAndFetchSizeZeroInPayload() {
+    return QUERY_AND_FETCH_SIZE.equals(jsonContent.keySet())
+        && (jsonContent.getInt("fetch_size") == 0);
   }
 
   private boolean isDefaultFormat() {

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilder.java
@@ -27,6 +27,7 @@ import com.amazon.opendistroforelasticsearch.sql.ast.expression.QualifiedName;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.Aggregation;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.UnresolvedPlan;
+import com.amazon.opendistroforelasticsearch.sql.common.utils.StringUtils;
 import com.amazon.opendistroforelasticsearch.sql.exception.SemanticCheckException;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.GroupByClauseContext;
 import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParserBaseVisitor;
@@ -101,7 +102,7 @@ public class AstAggregationBuilder extends OpenDistroSQLParserBaseVisitor<Unreso
 
     if (invalidSelectItem.isPresent()) {
       // Report semantic error to avoid fall back to old engine again
-      throw new SemanticCheckException(String.format(
+      throw new SemanticCheckException(StringUtils.format(
           "Explicit GROUP BY clause is required because expression [%s] "
               + "contains non-aggregated column", invalidSelectItem.get()));
     }
@@ -148,14 +149,21 @@ public class AstAggregationBuilder extends OpenDistroSQLParserBaseVisitor<Unreso
   }
 
   private boolean isIntegerLiteral(UnresolvedExpression expr) {
-    return (expr instanceof Literal)
-        && (((Literal) expr).getType() == DataType.INTEGER);
+    if (!(expr instanceof Literal)) {
+      return false;
+    }
+
+    if (((Literal) expr).getType() != DataType.INTEGER) {
+      throw new SemanticCheckException(StringUtils.format(
+          "Non-integer constant [%s] found in GROUP BY clause", expr));
+    }
+    return true;
   }
 
   private UnresolvedExpression getSelectItemByOrdinal(UnresolvedExpression expr) {
     int ordinal = (Integer) ((Literal) expr).getValue();
     if (ordinal <= 0 || ordinal > querySpec.getSelectItems().size()) {
-      throw new SemanticCheckException(String.format(
+      throw new SemanticCheckException(StringUtils.format(
           "Group by ordinal [%d] is out of bound of select item list", ordinal));
     }
     final UnresolvedExpression groupExpr = querySpec.getSelectItems().get(ordinal - 1);

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilder.java
@@ -139,12 +139,12 @@ public class AstAggregationBuilder extends OpenDistroSQLParserBaseVisitor<Unreso
   }
 
   private boolean isNonAggregatedExpression(UnresolvedExpression expr) {
-    List<? extends Node> children = expr.getChild();
-    if (children.isEmpty()) {
-      return true;
+    if (expr instanceof AggregateFunction) {
+      return false;
     }
-    return !(expr instanceof AggregateFunction)
-        && children.stream()
+
+    List<? extends Node> children = expr.getChild();
+    return children.stream()
                    .allMatch(child -> isNonAggregatedExpression((UnresolvedExpression) child));
   }
 

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -39,6 +39,15 @@ public class SQLQueryRequestTest {
   }
 
   @Test
+  public void shouldSupportQueryWithQueryFieldOnly() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+                              .jsonContent("{\"query\": \"SELECT 1\"}")
+                              .build();
+    assertTrue(request.isSupported());
+  }
+
+  @Test
   public void shouldSupportQueryWithZeroFetchSize() {
     SQLQueryRequest request =
         SQLQueryRequestBuilder.request("SELECT 1")

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilderTest.java
@@ -189,16 +189,6 @@ class AstAggregationBuilderTest {
     assertEquals("Group by ordinal [3] is out of bound of select item list", error2.getMessage());
   }
 
-  @Disabled
-  @Test
-  void should_report_error_for_non_integer_ordinal_in_group_by_clause() {
-    SemanticCheckException error = assertThrows(SemanticCheckException.class, () ->
-        buildAggregation("SELECT age, AVG(balance) FROM tests GROUP BY 0.0"));
-    assertEquals(
-        "Expression [age] that contains non-aggregated column is not present in group by clause",
-        error.getMessage());
-  }
-
   private Matcher<UnresolvedPlan> hasGroupByItems(UnresolvedExpression... exprs) {
     return featureValueOf("groupByItems", Aggregation::getGroupExprList, exprs);
   }

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilderTest.java
@@ -134,6 +134,15 @@ class AstAggregationBuilderTest {
             alias("ABS(age)", function("ABS", qualifiedName("age")))));
   }
 
+  @Test
+  void should_report_error_for_non_integer_ordinal_in_group_by() {
+    SemanticCheckException error = assertThrows(SemanticCheckException.class, () ->
+        buildAggregation("SELECT state AS s FROM test GROUP BY 1.5"));
+    assertEquals(
+        "Non-integer constant [1.5] found in GROUP BY clause",
+        error.getMessage());
+  }
+
   @Disabled("This validation is supposed to be in analyzing phase")
   @Test
   void should_report_error_for_mismatch_between_select_and_group_by_items() {

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilderTest.java
@@ -254,13 +254,26 @@ class AstExpressionBuilderTest {
             ImmutableList.of(qualifiedName("state")),
             ImmutableList.of(ImmutablePair.of("ASC", qualifiedName("age")))),
         buildExprAst("RANK() OVER (PARTITION BY state ORDER BY age)"));
+  }
 
+  @Test
+  public void canBuildWindowFunctionWithoutPartitionBy() {
     assertEquals(
         window(
             function("DENSE_RANK"),
             ImmutableList.of(),
             ImmutableList.of(ImmutablePair.of("DESC", qualifiedName("age")))),
         buildExprAst("DENSE_RANK() OVER (ORDER BY age DESC)"));
+  }
+
+  @Test
+  public void canBuildWindowFunctionWithoutOrderBy() {
+    assertEquals(
+        window(
+            function("RANK"),
+            ImmutableList.of(qualifiedName("state")),
+            ImmutableList.of()),
+        buildExprAst("RANK() OVER (PARTITION BY state)"));
   }
 
   @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Previously only 100% line coverage was enforced for `sql` and `elasticsearch` module. This PR is to enable branch coverage for both modules by adding missing UT and making code changes as needed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
