### PR TITLE
Support describe index alias

### DIFF
--- a/docs/user/dql/metadata.rst
+++ b/docs/user/dql/metadata.rst
@@ -55,7 +55,7 @@ Result set:
 Example 2: Show Specific Index Information
 ------------------------------------------
 
-Here is an example that searches metadata for index name prefixed by 'acc'
+Here is an example that searches metadata for index name prefixed by 'acc'. Besides index name and pattern with wildcard characters, searching by index alias is also supported. So you can ``SHOW`` or ``DESCRIBE`` an index alias which gives you same result as doing this with an index name.
 
 SQL query::
 

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MetaDataQueriesIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MetaDataQueriesIT.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.json.JSONArray;
@@ -308,6 +307,8 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
 
     JSONObject expected = executeQuery("SHOW TABLES LIKE " + TestsConstants.TEST_INDEX_ACCOUNT);
     JSONObject actual = executeQuery("SHOW TABLES LIKE acc");
+
+    assertThat(getDataRows(actual).length(), equalTo(1));
     assertTrue(StringUtils.format("Expected: %s, actual: %s", expected, actual),
         expected.similar(actual));
   }
@@ -319,6 +320,8 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
 
     JSONObject expected = executeQuery("DESCRIBE TABLES LIKE " + TestsConstants.TEST_INDEX_ACCOUNT);
     JSONObject actual = executeQuery("DESCRIBE TABLES LIKE acc");
+
+    assertThat(getDataRows(actual).length(), greaterThan(0));
     assertTrue(StringUtils.format("Expected: %s, actual: %s", expected, actual),
         expected.similar(actual));
   }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MetaDataQueriesIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MetaDataQueriesIT.java
@@ -325,22 +325,22 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
 
   @Test
   public void showSingleIndexNameWithDot() throws IOException {
-    Request request = new Request("POST", "/index.date/_doc");
+    Request request = new Request("POST", "/index.date1/_doc");
     request.setJsonEntity("{ \"test\": 123 }");
     client().performRequest(request);
 
-    JSONObject response = executeQuery("SHOW TABLES LIKE index.date");
+    JSONObject response = executeQuery("SHOW TABLES LIKE index.date1");
     JSONArray dataRows = getDataRows(response);
     assertThat(dataRows.length(), equalTo(1));
   }
 
   @Test
   public void describeSingleIndexNameWithDot() throws IOException {
-    Request request = new Request("POST", "/index.date/_doc");
+    Request request = new Request("POST", "/index.date2/_doc");
     request.setJsonEntity("{ \"test\": 123 }");
     client().performRequest(request);
 
-    JSONObject response = executeQuery("DESCRIBE TABLES LIKE index.date");
+    JSONObject response = executeQuery("DESCRIBE TABLES LIKE index.date2");
     JSONArray dataRows = getDataRows(response);
     assertThat(dataRows.length(), equalTo(1));
   }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MetaDataQueriesIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MetaDataQueriesIT.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.json.JSONArray;
@@ -301,14 +302,47 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
   }
 
   @Test
-  public void describeSingleIndexAlias() throws IOException {
+  public void showSingleIndexAlias() throws IOException {
     client().performRequest(new Request("PUT",
-        TestsConstants.TEST_INDEX_ACCOUNT + "/_alias/accounts"));
+        TestsConstants.TEST_INDEX_ACCOUNT + "/_alias/acc"));
 
-    JSONObject expected = executeQuery("DESCRIBE TABLES LIKE " + TestsConstants.TEST_INDEX_ACCOUNT);
-    JSONObject actual = executeQuery("DESCRIBE TABLES LIKE accounts");
+    JSONObject expected = executeQuery("SHOW TABLES LIKE " + TestsConstants.TEST_INDEX_ACCOUNT);
+    JSONObject actual = executeQuery("SHOW TABLES LIKE acc");
     assertTrue(StringUtils.format("Expected: %s, actual: %s", expected, actual),
         expected.similar(actual));
+  }
+
+  @Test
+  public void describeSingleIndexAlias() throws IOException {
+    client().performRequest(new Request("PUT",
+        TestsConstants.TEST_INDEX_ACCOUNT + "/_alias/acc"));
+
+    JSONObject expected = executeQuery("DESCRIBE TABLES LIKE " + TestsConstants.TEST_INDEX_ACCOUNT);
+    JSONObject actual = executeQuery("DESCRIBE TABLES LIKE acc");
+    assertTrue(StringUtils.format("Expected: %s, actual: %s", expected, actual),
+        expected.similar(actual));
+  }
+
+  @Test
+  public void showSingleIndexNameWithDot() throws IOException {
+    Request request = new Request("POST", "/index.date/_doc");
+    request.setJsonEntity("{ \"test\": 123 }");
+    client().performRequest(request);
+
+    JSONObject response = executeQuery("SHOW TABLES LIKE index.date");
+    JSONArray dataRows = getDataRows(response);
+    assertThat(dataRows.length(), equalTo(1));
+  }
+
+  @Test
+  public void describeSingleIndexNameWithDot() throws IOException {
+    Request request = new Request("POST", "/index.date/_doc");
+    request.setJsonEntity("{ \"test\": 123 }");
+    client().performRequest(request);
+
+    JSONObject response = executeQuery("DESCRIBE TABLES LIKE index.date");
+    JSONArray dataRows = getDataRows(response);
+    assertThat(dataRows.length(), equalTo(1));
   }
 
   @Test

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MetaDataQueriesIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MetaDataQueriesIT.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 
+import com.amazon.opendistroforelasticsearch.sql.legacy.utils.StringUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -297,6 +298,17 @@ public class MetaDataQueriesIT extends SQLIntegTestCase {
     assertThat(row.get(2), equalTo(TestsConstants.TEST_INDEX_ACCOUNT));
     assertThat(row.get(3), not(equalTo(JSONObject.NULL)));
     assertThat(row.get(5), not(equalTo(JSONObject.NULL)));
+  }
+
+  @Test
+  public void describeSingleIndexAlias() throws IOException {
+    client().performRequest(new Request("PUT",
+        TestsConstants.TEST_INDEX_ACCOUNT + "/_alias/accounts"));
+
+    JSONObject expected = executeQuery("DESCRIBE TABLES LIKE " + TestsConstants.TEST_INDEX_ACCOUNT);
+    JSONObject actual = executeQuery("DESCRIBE TABLES LIKE accounts");
+    assertTrue(StringUtils.format("Expected: %s, actual: %s", expected, actual),
+        expected.similar(actual));
   }
 
   @Test

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/DescribeResultSet.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/DescribeResultSet.java
@@ -95,8 +95,11 @@ public class DescribeResultSet extends ResultSet {
         for (ObjectObjectCursor<String, ImmutableOpenMap<String, MappingMetadata>> indexCursor : indexMappings) {
             String index = indexCursor.key;
 
-            // Check to see if index matches given pattern
-            if (matchesPattern(index, statement.getIndexPattern())) {
+            // Check to see if index matches given pattern. To support describe alias and avoid mismatch
+            // between actual index name and pattern (alias), the temp fix is to skip match logic if
+            // no regex character found in the pattern given.
+            String indexPattern = statement.getIndexPattern();
+            if (isNotRegexPattern(indexPattern) || matchesPattern(index, indexPattern)) {
                 ImmutableOpenMap<String, MappingMetadata> typeMapping = indexCursor.value;
                 // Assuming ES 6.x, iterate through the only type of the index to get mapping data
                 for (ObjectObjectCursor<String, MappingMetadata> typeCursor : typeMapping) {
@@ -180,5 +183,9 @@ public class DescribeResultSet extends ResultSet {
         }
 
         return currPath + "." + field;
+    }
+
+    private boolean isNotRegexPattern(String pattern) {
+        return !pattern.contains(".") && !pattern.contains("*");
     }
 }

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/DescribeResultSet.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/DescribeResultSet.java
@@ -99,7 +99,7 @@ public class DescribeResultSet extends ResultSet {
             // between actual index name and pattern (alias), the temp fix is to skip match logic if
             // no regex character found in the pattern given.
             String indexPattern = statement.getIndexPattern();
-            if (isNotRegexPattern(indexPattern) || matchesPattern(index, indexPattern)) {
+            if (matchesPatternIfRegex(index, indexPattern)) {
                 ImmutableOpenMap<String, MappingMetadata> typeMapping = indexCursor.value;
                 // Assuming ES 6.x, iterate through the only type of the index to get mapping data
                 for (ObjectObjectCursor<String, MappingMetadata> typeCursor : typeMapping) {
@@ -183,9 +183,5 @@ public class DescribeResultSet extends ResultSet {
         }
 
         return currPath + "." + field;
-    }
-
-    private boolean isNotRegexPattern(String pattern) {
-        return !pattern.contains(".") && !pattern.contains("*");
     }
 }

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/DescribeResultSet.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/DescribeResultSet.java
@@ -95,11 +95,7 @@ public class DescribeResultSet extends ResultSet {
         for (ObjectObjectCursor<String, ImmutableOpenMap<String, MappingMetadata>> indexCursor : indexMappings) {
             String index = indexCursor.key;
 
-            // Check to see if index matches given pattern. To support describe alias and avoid mismatch
-            // between actual index name and pattern (alias), the temp fix is to skip match logic if
-            // no regex character found in the pattern given.
-            String indexPattern = statement.getIndexPattern();
-            if (matchesPatternIfRegex(index, indexPattern)) {
+            if (matchesPatternIfRegex(index, statement.getIndexPattern())) {
                 ImmutableOpenMap<String, MappingMetadata> typeMapping = indexCursor.value;
                 // Assuming ES 6.x, iterate through the only type of the index to get mapping data
                 for (ObjectObjectCursor<String, MappingMetadata> typeCursor : typeMapping) {

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/ResultSet.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/ResultSet.java
@@ -44,10 +44,10 @@ public abstract class ResultSet {
     }
 
     /**
-     * Check if given string matches pattern, if the pattern is a regex.
+     * Check if given string matches the pattern. Do this check only if the pattern is a regex.
      * Otherwise skip the matching process and consider it's a match.
-     * This is a temp fix to support SHOW/DESCRIBE alias by skip mismatch
-     * between actual index name and pattern (alias).
+     * This is a quick fix to support SHOW/DESCRIBE alias by skip mismatch between actual index name
+     * and pattern (alias).
      * @param string   string to match
      * @param pattern  pattern
      * @return true if match or pattern is not regular expression. otherwise false.

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/ResultSet.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/ResultSet.java
@@ -43,9 +43,26 @@ public abstract class ResultSet {
                 .getClusterName();
     }
 
+    /**
+     * Check if given string matches pattern, if the pattern is a regex.
+     * Otherwise skip the matching process and consider it's a match.
+     * This is a temp fix to support SHOW/DESCRIBE alias by skip mismatch
+     * between actual index name and pattern (alias).
+     * @param string   string to match
+     * @param pattern  pattern
+     * @return true if match or pattern is not regular expression. otherwise false.
+     */
+    protected boolean matchesPatternIfRegex(String string, String pattern) {
+        return isNotRegexPattern(pattern) || matchesPattern(string, pattern);
+    }
+
     protected boolean matchesPattern(String string, String pattern) {
         Pattern p = Pattern.compile(pattern);
         Matcher matcher = p.matcher(string);
         return matcher.find();
+    }
+
+    private boolean isNotRegexPattern(String pattern) {
+        return !pattern.contains(".") && !pattern.contains("*");
     }
 }

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/ShowResultSet.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/ShowResultSet.java
@@ -77,7 +77,7 @@ public class ShowResultSet extends ResultSet {
         String[] indices = ((GetIndexResponse) queryResult).getIndices();
 
         return Arrays.stream(indices)
-                .filter(index -> matchesPattern(index, indexPattern))
+                .filter(index -> matchesPatternIfRegex(index, indexPattern))
                 .collect(Collectors.toList());
     }
 

--- a/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/ResultSetTest.java
+++ b/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/executor/format/ResultSetTest.java
@@ -1,0 +1,88 @@
+/*
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.legacy.executor.format;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class ResultSetTest {
+
+  private final ResultSet resultSet = new ResultSet() {
+    @Override
+    public Schema getSchema() {
+      return super.getSchema();
+    }
+  };
+
+  /**
+   * Case #1:
+   * LIKE 'test%' is converted to:
+   *  1. Regex pattern: test.*
+   *  2. ES search pattern: test*
+   * In this case, what ES returns is the final result.
+   */
+  @Test
+  public void testWildcardForZeroOrMoreCharacters() {
+    assertTrue(resultSet.matchesPatternIfRegex("test123", "test.*"));
+  }
+
+  /**
+   * Case #2:
+   * LIKE 'test_123' is converted to:
+   *  1. Regex pattern: test.123
+   *  2. ES search pattern: (all)
+   * Because ES doesn't support single wildcard character, in this case, none is passed
+   * as ES search pattern. So all index names are returned and need to be filtered by
+   * regex pattern again.
+   */
+  @Test
+  public void testWildcardForSingleCharacter() {
+    assertFalse(resultSet.matchesPatternIfRegex("accounts", "test.23"));
+    assertFalse(resultSet.matchesPatternIfRegex(".kibana", "test.23"));
+    assertTrue(resultSet.matchesPatternIfRegex("test123", "test.23"));
+  }
+
+  /**
+   * Case #3:
+   * LIKE 'acc' has same regex and ES pattern.
+   * In this case, only index name(s) aliased by 'acc' is returned.
+   * So regex match is skipped to avoid wrong empty result.
+   * The assumption here is ES won't return unrelated index names if
+   * LIKE pattern doesn't include any wildcard.
+   */
+  @Test
+  public void testIndexAlias() {
+    assertTrue(resultSet.matchesPatternIfRegex("accounts", "acc"));
+  }
+
+  /**
+   * Case #4:
+   * LIKE 'test.2020.10' has same regex pattern. Because it includes dot (wildcard),
+   * ES search pattern is all.
+   * In this case, all index names are returned. Because the pattern includes dot,
+   * it's treated as regex and regex match won't be skipped.
+   */
+  @Test
+  public void testIndexNameWithDot() {
+    assertFalse(resultSet.matchesPatternIfRegex("accounts", "test.2020.10"));
+    assertFalse(resultSet.matchesPatternIfRegex(".kibana", "test.2020.10"));
+    assertTrue(resultSet.matchesPatternIfRegex("test.2020.10", "test.2020.10"));
+  }
+
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/725

*Description of changes:* To understand the root cause and its fix, first let's see how we implemented SHOW/DESCRIBE:

1. Given SQL LIKE pattern (probably with wildcard `%` or `_`)
2. Convert to ES search pattern: replace `%` with ES wildcard `*`.
3. Get index metadata by ES pattern above: fetch all if including `_` because ES only supports `*`
4. Convert to regex pattern: replace `%` with `.*` and replace `_` with `.`
5. Filter the ES response by regex pattern above: because we may fetch all if pattern includes `_`, it's required to filter out the actual matched index name by regex again.

So the root cause is that alias doesn't necessarily match its index name so it's ruled out during regex matching. Ideally, we should fetch alias info and determine if LIKE pattern is an alias. However, this incurs extra ES metadata reading which may need additional permission and testing.

To quick fix the issue, changes in this PR is to skip the regex pattern matching if LIKE pattern doesn't include any wildcard. In this way, the matching process between an index name and its alias (regex pattern converted from pattern in LIKE) won't happen. Thus the index name will be present in the final result.

*Documentation*: Update existing doc with support for alias: https://github.com/dai-chen/sql/blob/support-describe-index-alias/docs/user/dql/metadata.rst#example-2-show-specific-index-information

*Testing*: Add UT and IT. Here is the 4 typical cases described in UT.

```
  /**
   * Case #1:
   * LIKE 'test%' is converted to:
   *  1. Regex pattern: test.*
   *  2. ES search pattern: test*
   * In this case, what ES returns is the final result.
   */
  ...

  /**
   * Case #2:
   * LIKE 'test_123' is converted to:
   *  1. Regex pattern: test.123
   *  2. ES search pattern: (all)
   * Because ES doesn't support single wildcard character, in this case, none is passed
   * as ES search pattern. So all index names are returned and need to be filtered by
   * regex pattern again.
   */
  ...

  /**
   * Case #3:
   * LIKE 'acc' has same regex and ES pattern.
   * In this case, only index name(s) aliased by 'acc' is returned.
   * So regex match is skipped to avoid wrong empty result.
   * The assumption here is ES won't return unrelated index names if
   * LIKE pattern doesn't include any wildcard.
   */
  ...

  /**
   * Case #4:
   * LIKE 'test.2020.10' has same regex pattern. Because it includes dot (wildcard),
   * ES search pattern is all.
   * In this case, all index names are returned. Because the pattern includes dot,
   * it's treated as regex and regex match won't be skipped.
   */
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
