### PR TITLE
Add support of basic data types byte, short, binary and add data type testing

### DIFF
--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/AbstractExprNumberValue.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/AbstractExprNumberValue.java
@@ -33,6 +33,11 @@ public abstract class AbstractExprNumberValue extends AbstractExprValue {
   }
 
   @Override
+  public Byte byteValue() {
+    return value.byteValue();
+  }
+
+  @Override
   public Short shortValue() {
     return value.shortValue();
   }

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprByteValue.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprByteValue.java
@@ -1,0 +1,54 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.data.model;
+
+import com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType;
+import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
+
+/**
+ * Expression Short Value.
+ */
+public class ExprByteValue extends AbstractExprNumberValue {
+
+  public ExprByteValue(Number value) {
+    super(value);
+  }
+
+  @Override
+  public int compare(ExprValue other) {
+    return Byte.compare(byteValue(), other.byteValue());
+  }
+
+  @Override
+  public boolean equal(ExprValue other) {
+    return byteValue().equals(other.byteValue());
+  }
+
+  @Override
+  public Object value() {
+    return byteValue();
+  }
+
+  @Override
+  public ExprType type() {
+    return ExprCoreType.BYTE;
+  }
+
+  @Override
+  public String toString() {
+    return value().toString();
+  }
+}

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprByteValue.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprByteValue.java
@@ -19,7 +19,7 @@ import com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType;
 import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
 
 /**
- * Expression Short Value.
+ * Expression Byte Value.
  */
 public class ExprByteValue extends AbstractExprNumberValue {
 

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprValue.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprValue.java
@@ -78,6 +78,14 @@ public interface ExprValue extends Serializable, Comparable<ExprValue> {
   }
 
   /**
+   * Get byte value.
+   */
+  default Byte byteValue() {
+    throw new ExpressionEvaluationException(
+        "invalid to get byteValue from value of type " + type());
+  }
+
+  /**
    * Get short value.
    */
   default Short shortValue() {

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprValueUtils.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprValueUtils.java
@@ -44,6 +44,14 @@ public class ExprValueUtils {
     return value ? LITERAL_TRUE : LITERAL_FALSE;
   }
 
+  public static ExprValue byteValue(Byte value) {
+    return new ExprByteValue(value);
+  }
+
+  public static ExprValue shortValue(Short value) {
+    return new ExprShortValue(value);
+  }
+
   public static ExprValue integerValue(Integer value) {
     return new ExprIntegerValue(value);
   }
@@ -105,6 +113,10 @@ public class ExprValueUtils {
       return tupleValue((Map) o);
     } else if (o instanceof List) {
       return collectionValue(((List) o));
+    } else if (o instanceof Byte) {
+      return byteValue((Byte) o);
+    } else if (o instanceof Short) {
+      return shortValue((Short) o);
     } else if (o instanceof Integer) {
       return integerValue((Integer) o);
     } else if (o instanceof Long) {

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/type/ExprCoreType.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/data/type/ExprCoreType.java
@@ -34,7 +34,8 @@ public enum ExprCoreType implements ExprType {
   /**
    * Numbers.
    */
-  SHORT,
+  BYTE,
+  SHORT(BYTE),
   INTEGER(SHORT),
   LONG(INTEGER),
   FLOAT(LONG),

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/DSL.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/DSL.java
@@ -32,6 +32,10 @@ import lombok.RequiredArgsConstructor;
 public class DSL {
   private final BuiltinFunctionRepository repository;
 
+  public static LiteralExpression literal(Byte value) {
+    return new LiteralExpression(ExprValueUtils.byteValue(value));
+  }
+
   public static LiteralExpression literal(Short value) {
     return new LiteralExpression(new ExprShortValue(value));
   }

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/operator/arthmetic/ArithmeticFunction.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/operator/arthmetic/ArithmeticFunction.java
@@ -15,12 +15,14 @@
 
 package com.amazon.opendistroforelasticsearch.sql.expression.operator.arthmetic;
 
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.BYTE;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.DOUBLE;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.FLOAT;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.LONG;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.SHORT;
 
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprByteValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprDoubleValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprFloatValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprIntegerValue;
@@ -60,6 +62,10 @@ public class ArithmeticFunction {
     return FunctionDSL.define(BuiltinFunctionName.ADD.getName(),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
+                (v1, v2) -> new ExprByteValue(v1.byteValue() + v2.byteValue())),
+            BYTE, BYTE, BYTE),
+        FunctionDSL.impl(
+            FunctionDSL.nullMissingHandling(
                 (v1, v2) -> new ExprShortValue(v1.shortValue() + v2.shortValue())),
             SHORT, SHORT, SHORT),
         FunctionDSL.impl(
@@ -84,6 +90,10 @@ public class ArithmeticFunction {
 
   private static FunctionResolver subtract() {
     return FunctionDSL.define(BuiltinFunctionName.SUBTRACT.getName(),
+        FunctionDSL.impl(
+            FunctionDSL.nullMissingHandling(
+                (v1, v2) -> new ExprByteValue(v1.byteValue() - v2.byteValue())),
+            BYTE, BYTE, BYTE),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
                 (v1, v2) -> new ExprShortValue(v1.shortValue() - v2.shortValue())),
@@ -112,6 +122,10 @@ public class ArithmeticFunction {
     return FunctionDSL.define(BuiltinFunctionName.MULTIPLY.getName(),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
+                (v1, v2) -> new ExprByteValue(v1.byteValue() * v2.byteValue())),
+            BYTE, BYTE, BYTE),
+        FunctionDSL.impl(
+            FunctionDSL.nullMissingHandling(
                 (v1, v2) -> new ExprShortValue(v1.shortValue() * v2.shortValue())),
             SHORT, SHORT, SHORT),
         FunctionDSL.impl(
@@ -136,6 +150,10 @@ public class ArithmeticFunction {
 
   private static FunctionResolver divide() {
     return FunctionDSL.define(BuiltinFunctionName.DIVIDE.getName(),
+        FunctionDSL.impl(
+            FunctionDSL.nullMissingHandling(
+                (v1, v2) -> new ExprByteValue(v1.byteValue() / v2.byteValue())),
+            BYTE, BYTE, BYTE),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
                 (v1, v2) -> v2.shortValue() == 0 ? ExprNullValue.of() :
@@ -167,6 +185,10 @@ public class ArithmeticFunction {
 
   private static FunctionResolver modules() {
     return FunctionDSL.define(BuiltinFunctionName.MODULES.getName(),
+        FunctionDSL.impl(
+            FunctionDSL.nullMissingHandling(
+                (v1, v2) -> new ExprByteValue(v1.byteValue() % v2.byteValue())),
+            BYTE, BYTE, BYTE),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
                 (v1, v2) -> v2.shortValue() == 0 ? ExprNullValue.of() :

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/operator/arthmetic/MathematicalFunction.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/operator/arthmetic/MathematicalFunction.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.expression.operator.arthmetic;
 
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.BYTE;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.DOUBLE;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.FLOAT;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
@@ -22,6 +23,7 @@ import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.L
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.SHORT;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRING;
 
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprByteValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprDoubleValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprFloatValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprIntegerValue;
@@ -97,6 +99,9 @@ public class MathematicalFunction {
    */
   private static FunctionResolver abs() {
     return FunctionDSL.define(BuiltinFunctionName.ABS.getName(),
+        FunctionDSL.impl(
+            FunctionDSL.nullMissingHandling(v -> new ExprByteValue(Math.abs(v.byteValue()))),
+            BYTE, BYTE),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(v -> new ExprShortValue(Math.abs(v.shortValue()))),
             SHORT, SHORT),
@@ -286,6 +291,11 @@ public class MathematicalFunction {
    */
   private static FunctionResolver mod() {
     return FunctionDSL.define(BuiltinFunctionName.MOD.getName(),
+        FunctionDSL.impl(
+            FunctionDSL.nullMissingHandling(
+                (v1, v2) -> v2.byteValue() == 0 ? ExprNullValue.of() :
+                    new ExprByteValue(v1.byteValue() % v2.byteValue())),
+            BYTE, BYTE, BYTE),
         FunctionDSL.impl(
             FunctionDSL.nullMissingHandling(
                 (v1, v2) -> v2.shortValue() == 0 ? ExprNullValue.of() :

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprValueUtilsTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/model/ExprValueUtilsTest.java
@@ -68,7 +68,7 @@ public class ExprValueUtilsTest {
     testTuple.put("1", new ExprIntegerValue(1));
   }
 
-  private static List<ExprValue> numberValues = Stream.of(1, 1L, 1f, 1D)
+  private static List<ExprValue> numberValues = Stream.of((byte) 1, (short) 1, 1, 1L, 1f, 1D)
       .map(ExprValueUtils::fromObjectValue).collect(Collectors.toList());
 
   private static List<ExprValue> nonNumberValues = Arrays.asList(
@@ -86,6 +86,8 @@ public class ExprValueUtilsTest {
       Lists.newArrayList(Iterables.concat(numberValues, nonNumberValues));
 
   private static List<Function<ExprValue, Object>> numberValueExtractor = Arrays.asList(
+      ExprValue::byteValue,
+      ExprValue::shortValue,
       ExprValueUtils::getIntegerValue,
       ExprValueUtils::getLongValue,
       ExprValueUtils::getFloatValue,
@@ -106,8 +108,8 @@ public class ExprValueUtilsTest {
       Iterables.concat(numberValueExtractor, nonNumberValueExtractor, dateAndTimeValueExtractor));
 
   private static List<ExprCoreType> numberTypes =
-      Arrays.asList(ExprCoreType.INTEGER, ExprCoreType.LONG, ExprCoreType.FLOAT,
-          ExprCoreType.DOUBLE);
+      Arrays.asList(ExprCoreType.BYTE, ExprCoreType.SHORT, ExprCoreType.INTEGER, ExprCoreType.LONG,
+          ExprCoreType.FLOAT, ExprCoreType.DOUBLE);
   private static List<ExprCoreType> nonNumberTypes =
       Arrays.asList(STRING, BOOLEAN, ARRAY, STRUCT);
   private static List<ExprCoreType> dateAndTimeTypes =
@@ -116,7 +118,7 @@ public class ExprValueUtilsTest {
       Lists.newArrayList(Iterables.concat(numberTypes, nonNumberTypes, dateAndTimeTypes));
 
   private static Stream<Arguments> getValueTestArgumentStream() {
-    List<Object> expectedValues = Arrays.asList(1, 1L, 1f, 1D, "1", true,
+    List<Object> expectedValues = Arrays.asList((byte) 1, (short) 1, 1, 1L, 1f, 1D, "1", true,
         Arrays.asList(integerValue(1)),
         ImmutableMap.of("1", integerValue(1)),
         LocalDate.parse("2012-08-07"),
@@ -248,6 +250,8 @@ public class ExprValueUtilsTest {
 
   @Test
   public void hashCodeTest() {
+    assertEquals(new ExprByteValue(1).hashCode(), new ExprByteValue(1).hashCode());
+    assertEquals(new ExprShortValue(1).hashCode(), new ExprShortValue(1).hashCode());
     assertEquals(new ExprIntegerValue(1).hashCode(), new ExprIntegerValue(1).hashCode());
     assertEquals(new ExprStringValue("1").hashCode(), new ExprStringValue("1").hashCode());
     assertEquals(new ExprCollectionValue(ImmutableList.of(new ExprIntegerValue(1))).hashCode(),

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/utils/ExprValueOrderingTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/data/utils/ExprValueOrderingTest.java
@@ -19,6 +19,7 @@ import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtil
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.LITERAL_MISSING;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.LITERAL_NULL;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.LITERAL_TRUE;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.byteValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.collectionValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.doubleValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.floatValue;
@@ -141,6 +142,14 @@ class ExprValueOrderingTest {
     assertEquals(1, ordering.compare(longValue(5L), longValue(4L)));
     assertEquals(0, ordering.compare(longValue(5L), longValue(5L)));
     assertEquals(-1, ordering.compare(longValue(4L), longValue(5L)));
+  }
+
+  @Test
+  public void natural_order_byte_value() {
+    ExprValueOrdering ordering = ExprValueOrdering.natural();
+    assertEquals(1, ordering.compare(byteValue((byte) 5), byteValue((byte) 4)));
+    assertEquals(0, ordering.compare(byteValue((byte) 5), byteValue((byte) 5)));
+    assertEquals(-1, ordering.compare(byteValue((byte) 4), byteValue((byte) 5)));
   }
 
   @Test

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/function/WideningTypeRuleTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/function/WideningTypeRuleTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.expression.function;
 
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.BYTE;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.DOUBLE;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.FLOAT;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
@@ -44,6 +45,11 @@ class WideningTypeRuleTest {
   private static Table<ExprCoreType, ExprCoreType, Integer> numberWidenRule =
       new ImmutableTable.Builder<ExprCoreType, ExprCoreType,
           Integer>()
+          .put(BYTE, SHORT, 1)
+          .put(BYTE, INTEGER, 2)
+          .put(BYTE, LONG, 3)
+          .put(BYTE, FLOAT, 4)
+          .put(BYTE, DOUBLE, 5)
           .put(SHORT, INTEGER, 1)
           .put(SHORT, LONG, 2)
           .put(SHORT, FLOAT, 3)

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/operator/arthmetic/ArithmeticFunctionTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/operator/arthmetic/ArithmeticFunctionTest.java
@@ -27,6 +27,7 @@ import static com.amazon.opendistroforelasticsearch.sql.expression.DSL.ref;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprByteValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprDoubleValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprFloatValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprIntegerValue;
@@ -56,10 +57,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ArithmeticFunctionTest extends ExpressionTestBase {
 
   private static Stream<Arguments> arithmeticFunctionArguments() {
-    List<ExprValue> numberOp1 = Arrays.asList(new ExprShortValue(3), new ExprIntegerValue(3),
-        new ExprLongValue(3L), new ExprFloatValue(3f), new ExprDoubleValue(3D));
+    List<ExprValue> numberOp1 = Arrays.asList(new ExprByteValue(3), new ExprShortValue(3),
+        new ExprIntegerValue(3), new ExprLongValue(3L), new ExprFloatValue(3f),
+        new ExprDoubleValue(3D));
     List<ExprValue> numberOp2 =
-        Arrays.asList(new ExprShortValue(2), new ExprIntegerValue(2), new ExprLongValue(3L),
+        Arrays.asList(new ExprByteValue(2), new ExprShortValue(2), new ExprIntegerValue(2),
+            new ExprLongValue(3L),
             new ExprFloatValue(2f), new ExprDoubleValue(2D));
     return Lists.cartesianProduct(numberOp1, numberOp2).stream()
         .map(list -> Arguments.of(list.get(0), list.get(1)));
@@ -209,6 +212,29 @@ class ArithmeticFunctionTest extends ExpressionTestBase {
                                   ExprValue op2,
                                   ExprValue actual) {
     switch ((ExprCoreType) type) {
+      case BYTE:
+        Byte vb1 = op1.byteValue();
+        Byte vb2 = op2.byteValue();
+        Integer vbActual = actual.integerValue();
+        switch (builtinFunctionName) {
+          case ADD:
+            assertEquals(vb1 + vb2, vbActual);
+            return;
+          case SUBTRACT:
+            assertEquals(vb1 - vb2, vbActual);
+            return;
+          case DIVIDE:
+            assertEquals(vb1 / vb2, vbActual);
+            return;
+          case MULTIPLY:
+            assertEquals(vb1 * vb2, vbActual);
+            return;
+          case MODULES:
+            assertEquals(vb1 % vb2, vbActual);
+            return;
+          default:
+            throw new IllegalStateException("illegal function name: " + builtinFunctionName);
+        }
       case SHORT:
         Short vs1 = op1.shortValue();
         Short vs2 = op2.shortValue();

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/operator/predicate/BinaryPredicateOperatorTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/operator/predicate/BinaryPredicateOperatorTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprBooleanValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprByteValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprCollectionValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprDoubleValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprFloatValue;
@@ -55,6 +56,7 @@ import com.amazon.opendistroforelasticsearch.sql.expression.FunctionExpression;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.sun.org.apache.xpath.internal.Arg;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -100,6 +102,7 @@ class BinaryPredicateOperatorTest extends ExpressionTestBase {
 
   private static Stream<Arguments> testEqualArguments() {
     Stream.Builder<Arguments> builder = Stream.builder();
+    builder.add(Arguments.of(new ExprByteValue(1), new ExprByteValue(1)));
     builder.add(Arguments.of(new ExprShortValue(1), new ExprShortValue(1)));
     builder.add(Arguments.of(new ExprIntegerValue(1), new ExprIntegerValue(1)));
     builder.add(Arguments.of(new ExprLongValue(1L), new ExprLongValue(1L)));
@@ -117,7 +120,8 @@ class BinaryPredicateOperatorTest extends ExpressionTestBase {
 
   private static Stream<Arguments> testNotEqualArguments() {
     List<List<Object>> arguments = Arrays.asList(
-        Arrays.asList(1, 2), Arrays.asList(1L, 2L), Arrays.asList(1F, 2F), Arrays.asList(1D, 2D),
+        Arrays.asList((byte) 1, (byte) 2), Arrays.asList(1, 2), Arrays.asList(1L, 2L),
+        Arrays.asList(1F, 2F), Arrays.asList(1D, 2D),
         Arrays.asList("str0", "str1"), Arrays.asList(true, false),
         Arrays.asList(ImmutableList.of(1), ImmutableList.of(2)),
         Arrays.asList(ImmutableMap.of("str", 1), ImmutableMap.of("str", 2))

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/utils/ComparisonUtil.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/utils/ComparisonUtil.java
@@ -21,6 +21,7 @@ import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtil
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.getLongValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.getStringValue;
 
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprByteValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprDoubleValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprFloatValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprIntegerValue;
@@ -42,7 +43,9 @@ public class ComparisonUtil {
       throw new ExpressionEvaluationException("invalid to call compare operation on null value");
     }
 
-    if (v1 instanceof ExprShortValue) {
+    if (v1 instanceof ExprByteValue) {
+      return v1.byteValue().compareTo(v2.byteValue());
+    } else if (v1 instanceof ExprShortValue) {
       return v1.shortValue().compareTo(v2.shortValue());
     } else if (v1 instanceof ExprIntegerValue) {
       return getIntegerValue(v1).compareTo(getIntegerValue(v2));

--- a/docs/user/general/datatypes.rst
+++ b/docs/user/general/datatypes.rst
@@ -23,6 +23,10 @@ The ODFE SQL Engine support the following data types.
 +===============+
 | boolean       |
 +---------------+
+| byte          |
++---------------+
+| short         |
++---------------+
 | integer       |
 +---------------+
 | long          |
@@ -49,6 +53,8 @@ The ODFE SQL Engine support the following data types.
 +---------------+
 | geo_point     |
 +---------------+
+| binary        |
++---------------+
 | struct        |
 +---------------+
 | array         |
@@ -64,13 +70,19 @@ The table below list the mapping between Elasticsearch Data Type, ODFE SQL Data 
 +====================+===============+===========+
 | boolean            | boolean       | BOOLEAN   |
 +--------------------+---------------+-----------+
+| byte               | byte          | TINYINT   |
++--------------------+---------------+-----------+
+| short              | byte          | SMALLINT  |
++--------------------+---------------+-----------+
 | integer            | integer       | INTEGER   |
 +--------------------+---------------+-----------+
-| long               | long          | LONG      |
+| long               | long          | BIGINT    |
 +--------------------+---------------+-----------+
-| float              | float         | FLOAT     |
+| float              | float         | REAL      |
 +--------------------+---------------+-----------+
 | half_float         | float         | FLOAT     |
++--------------------+---------------+-----------+
+| scaled_float       | float         | DOUBLE    |
 +--------------------+---------------+-----------+
 | double             | double        | DOUBLE    |
 +--------------------+---------------+-----------+
@@ -80,13 +92,15 @@ The table below list the mapping between Elasticsearch Data Type, ODFE SQL Data 
 +--------------------+---------------+-----------+
 | date               | timestamp     | TIMESTAMP |
 +--------------------+---------------+-----------+
-| ip                 | ip            | IP        |
+| ip                 | ip            | VARCHAR   |
 +--------------------+---------------+-----------+
 | date               | timestamp     | TIMESTAMP |
 +--------------------+---------------+-----------+
+| binary             | binary        | VARBINARY |
++--------------------+---------------+-----------+
 | object             | struct        | STRUCT    |
 +--------------------+---------------+-----------+
-| nested             | array         | TBD       |
+| nested             | array         | STRUCT    |
 +--------------------+---------------+-----------+
 
 Notes: Not all the ODFE SQL Type has correspond Elasticsearch Type. e.g. data and time. To use function which required such data type, user should explict convert the data type.

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/type/ElasticsearchDataType.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/type/ElasticsearchDataType.java
@@ -46,7 +46,9 @@ public enum ElasticsearchDataType implements ExprType {
 
   ES_IP(Arrays.asList(UNKNOWN), "ip"),
 
-  ES_GEO_POINT(Arrays.asList(UNKNOWN), "geo_point");
+  ES_GEO_POINT(Arrays.asList(UNKNOWN), "geo_point"),
+
+  ES_BINARY(Arrays.asList(UNKNOWN), "binary");
 
   /**
    * Parent of current type.

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprBinaryValue.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprBinaryValue.java
@@ -21,6 +21,10 @@ import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType;
 import lombok.EqualsAndHashCode;
 
+/**
+ * Elasticsearch BinaryValue.
+ * Todo, add this to avoid the unknown value type exception, the implementation will be changed.
+ */
 @EqualsAndHashCode(callSuper = false)
 public class ElasticsearchExprBinaryValue extends AbstractExprValue {
   private final String encodedString;

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprBinaryValue.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprBinaryValue.java
@@ -1,0 +1,51 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value;
+
+import com.amazon.opendistroforelasticsearch.sql.data.model.AbstractExprValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
+import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = false)
+public class ElasticsearchExprBinaryValue extends AbstractExprValue {
+  private final String encodedString;
+
+  public ElasticsearchExprBinaryValue(String encodedString) {
+    this.encodedString = encodedString;
+  }
+
+  @Override
+  public int compare(ExprValue other) {
+    return encodedString.compareTo((String) other.value());
+  }
+
+  @Override
+  public boolean equal(ExprValue other) {
+    return encodedString.equals(other.value());
+  }
+
+  @Override
+  public Object value() {
+    return encodedString;
+  }
+
+  @Override
+  public ExprType type() {
+    return ElasticsearchDataType.ES_BINARY;
+  }
+}

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactory.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactory.java
@@ -20,13 +20,16 @@ package com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.nullValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.ARRAY;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.BOOLEAN;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.BYTE;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.DOUBLE;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.FLOAT;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.LONG;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.SHORT;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRING;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRUCT;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.TIMESTAMP;
+import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType.ES_BINARY;
 import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType.ES_GEO_POINT;
 import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType.ES_IP;
 import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType.ES_TEXT;
@@ -35,11 +38,13 @@ import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value
 import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value.ElasticsearchDateFormatters.STRICT_DATE_OPTIONAL_TIME_FORMATTER;
 
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprBooleanValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprByteValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprCollectionValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprDoubleValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprFloatValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprIntegerValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprLongValue;
+import com.amazon.opendistroforelasticsearch.sql.data.model.ExprShortValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprStringValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprTimestampValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprTupleValue;
@@ -103,6 +108,10 @@ public class ElasticsearchExprValueFactory {
       return constructInteger(value.intValue());
     } else if (type.equals(LONG)) {
       return constructLong(value.longValue());
+    } else if (type.equals(SHORT)) {
+      return constructShort(value.shortValue());
+    } else if (type.equals(BYTE)) {
+      return constructByte(((byte)value.shortValue()));
     } else if (type.equals(FLOAT)) {
       return constructFloat(value.floatValue());
     } else if (type.equals(DOUBLE)) {
@@ -130,6 +139,8 @@ public class ElasticsearchExprValueFactory {
     } else if (type.equals(ES_GEO_POINT)) {
       return new ElasticsearchExprGeoPointValue(value.get("lat").doubleValue(),
           value.get("lon").doubleValue());
+    } else if (type.equals(ES_BINARY)) {
+      return new ElasticsearchExprBinaryValue(value.textValue());
     } else {
       throw new IllegalStateException(
           String.format(
@@ -209,6 +220,14 @@ public class ElasticsearchExprValueFactory {
 
   private ExprLongValue constructLong(Long value) {
     return new ExprLongValue(value);
+  }
+
+  private ExprShortValue constructShort(Short value) {
+    return new ExprShortValue(value);
+  }
+
+  private ExprByteValue constructByte(Byte value) {
+    return new ExprByteValue(value);
   }
 
   private ExprFloatValue constructFloat(Float value) {

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndex.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndex.java
@@ -54,10 +54,13 @@ public class ElasticsearchIndex implements Table {
           .put("text", ElasticsearchDataType.ES_TEXT)
           .put("text_keyword", ElasticsearchDataType.ES_TEXT_KEYWORD)
           .put("keyword", ExprCoreType.STRING)
+          .put("byte", ExprCoreType.BYTE)
+          .put("short", ExprCoreType.SHORT)
           .put("integer", ExprCoreType.INTEGER)
           .put("long", ExprCoreType.LONG)
           .put("float", ExprCoreType.FLOAT)
           .put("half_float", ExprCoreType.FLOAT)
+          .put("scaled_float", ExprCoreType.DOUBLE)
           .put("double", ExprCoreType.DOUBLE)
           .put("boolean", ExprCoreType.BOOLEAN)
           .put("nested", ExprCoreType.ARRAY)
@@ -65,6 +68,7 @@ public class ElasticsearchIndex implements Table {
           .put("date", ExprCoreType.TIMESTAMP)
           .put("ip", ElasticsearchDataType.ES_IP)
           .put("geo_point", ElasticsearchDataType.ES_GEO_POINT)
+          .put("binary", ElasticsearchDataType.ES_BINARY)
           .build();
 
   /** Elasticsearch client connection. */

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprBinaryValueTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprBinaryValueTest.java
@@ -1,0 +1,55 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value;
+
+import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType.ES_BINARY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ElasticsearchExprBinaryValueTest {
+
+  @Test
+  public void compare() {
+    assertEquals(
+        0,
+        new ElasticsearchExprBinaryValue("U29tZSBiaW5hcnkgYmxvYg==")
+            .compare(new ElasticsearchExprBinaryValue("U29tZSBiaW5hcnkgYmxvYg==")));
+  }
+
+  @Test
+  public void equal() {
+    ElasticsearchExprBinaryValue value =
+        new ElasticsearchExprBinaryValue("U29tZSBiaW5hcnkgYmxvYg==");
+    assertTrue(value.equal(new ElasticsearchExprBinaryValue("U29tZSBiaW5hcnkgYmxvYg==")));
+  }
+
+  @Test
+  public void value() {
+    ElasticsearchExprBinaryValue value =
+        new ElasticsearchExprBinaryValue("U29tZSBiaW5hcnkgYmxvYg==");
+    assertEquals("U29tZSBiaW5hcnkgYmxvYg==", value.value());
+  }
+
+  @Test
+  public void type() {
+    ElasticsearchExprBinaryValue value =
+        new ElasticsearchExprBinaryValue("U29tZSBiaW5hcnkgYmxvYg==");
+    assertEquals(ES_BINARY, value.type());
+  }
+
+}

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactoryTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactoryTest.java
@@ -18,21 +18,26 @@
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.value;
 
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.booleanValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.byteValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.doubleValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.floatValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.integerValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.longValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.nullValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.shortValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.stringValue;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.ARRAY;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.BOOLEAN;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.BYTE;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.DOUBLE;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.FLOAT;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.LONG;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.SHORT;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRING;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRUCT;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.TIMESTAMP;
+import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType.ES_BINARY;
 import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType.ES_GEO_POINT;
 import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType.ES_IP;
 import static com.amazon.opendistroforelasticsearch.sql.elasticsearch.data.type.ElasticsearchDataType.ES_TEXT;
@@ -58,6 +63,8 @@ class ElasticsearchExprValueFactoryTest {
 
   private static final Map<String, ExprType> MAPPING =
       new ImmutableMap.Builder<String, ExprType>()
+          .put("byteV", BYTE)
+          .put("shortV", SHORT)
           .put("intV", INTEGER)
           .put("longV", LONG)
           .put("floatV", FLOAT)
@@ -75,6 +82,7 @@ class ElasticsearchExprValueFactoryTest {
           .put("textKeywordV", ES_TEXT_KEYWORD)
           .put("ipV", ES_IP)
           .put("geoV", ES_GEO_POINT)
+          .put("binaryV", ES_BINARY)
           .build();
   private ElasticsearchExprValueFactory exprValueFactory =
       new ElasticsearchExprValueFactory(MAPPING);
@@ -83,6 +91,16 @@ class ElasticsearchExprValueFactoryTest {
   public void constructNullValue() {
     assertEquals(nullValue(), tupleValue("{\"intV\":null}").get("intV"));
     assertEquals(nullValue(), constructFromObject("intV",  null));
+  }
+
+  @Test
+  public void constructByte() {
+    assertEquals(byteValue((byte) 1), tupleValue("{\"byteV\":1}").get("byteV"));
+  }
+
+  @Test
+  public void constructShort() {
+    assertEquals(shortValue((short) 1), tupleValue("{\"shortV\":1}").get("shortV"));
   }
 
   @Test
@@ -215,6 +233,12 @@ class ElasticsearchExprValueFactoryTest {
   public void constructGeoPoint() {
     assertEquals(new ElasticsearchExprGeoPointValue(42.60355556, -97.25263889),
         tupleValue("{\"geoV\":{\"lat\":42.60355556,\"lon\":-97.25263889}}").get("geoV"));
+  }
+
+  @Test
+  public void constructBinary() {
+    assertEquals(new ElasticsearchExprBinaryValue("U29tZSBiaW5hcnkgYmxvYg=="),
+        tupleValue("{\"binaryV\":\"U29tZSBiaW5hcnkgYmxvYg==\"}").get("binaryV"));
   }
 
   @Test

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/ElasticsearchIndexTest.java
@@ -107,6 +107,9 @@ class ElasticsearchIndexTest {
                         .put("family", "nested")
                         .put("employer", "object")
                         .put("birthday", "date")
+                        .put("id1", "byte")
+                        .put("id2", "short")
+                        .put("blob", "binary")
                         .build())));
 
     Table index = new ElasticsearchIndex(client, settings, "test");
@@ -114,17 +117,21 @@ class ElasticsearchIndexTest {
     assertThat(
         fieldTypes,
         allOf(
-            aMapWithSize(10),
-            hasEntry("name", (ExprType) ExprCoreType.STRING),
+            aMapWithSize(13),
+            hasEntry("name", ExprCoreType.STRING),
             hasEntry("address", (ExprType) ElasticsearchDataType.ES_TEXT),
-            hasEntry("age", (ExprType) ExprCoreType.INTEGER),
+            hasEntry("age", ExprCoreType.INTEGER),
             hasEntry("account_number", ExprCoreType.LONG),
-            hasEntry("balance1", (ExprType) ExprCoreType.FLOAT),
-            hasEntry("balance2", (ExprType) ExprCoreType.DOUBLE),
-            hasEntry("gender", (ExprType) ExprCoreType.BOOLEAN),
-            hasEntry("family", (ExprType) ExprCoreType.ARRAY),
-            hasEntry("employer", (ExprType) ExprCoreType.STRUCT),
-            hasEntry("birthday", (ExprType) ExprCoreType.TIMESTAMP)));
+            hasEntry("balance1", ExprCoreType.FLOAT),
+            hasEntry("balance2", ExprCoreType.DOUBLE),
+            hasEntry("gender", ExprCoreType.BOOLEAN),
+            hasEntry("family", ExprCoreType.ARRAY),
+            hasEntry("employer", ExprCoreType.STRUCT),
+            hasEntry("birthday", ExprCoreType.TIMESTAMP),
+            hasEntry("id1", ExprCoreType.BYTE),
+            hasEntry("id2", ExprCoreType.SHORT),
+            hasEntry("blob", (ExprType) ElasticsearchDataType.ES_BINARY)
+        ));
   }
 
   @Test

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/SQLIntegTestCase.java
@@ -20,6 +20,8 @@ import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.createI
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getAccountIndexMapping;
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getBankIndexMapping;
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getBankWithNullValuesIndexMapping;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getDataTypeNonnumericIndexMapping;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getDataTypeNumericIndexMapping;
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getDateIndexMapping;
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getDateTimeIndexMapping;
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestUtils.getDeepNestedIndexMapping;
@@ -519,7 +521,15 @@ public abstract class SQLIntegTestCase extends ODFERestTestCase {
     DEEP_NESTED(TestsConstants.TEST_INDEX_DEEP_NESTED,
         "_doc",
         getDeepNestedIndexMapping(),
-        "src/test/resources/deep_nested_index_data.json");
+        "src/test/resources/deep_nested_index_data.json"),
+    DATA_TYPE_NUMERIC(TestsConstants.TEST_INDEX_DATATYPE_NUMERIC,
+        "_doc",
+        getDataTypeNumericIndexMapping(),
+        "src/test/resources/datatypes_numeric.json"),
+    DATA_TYPE_NONNUMERIC(TestsConstants.TEST_INDEX_DATATYPE_NONNUMERIC,
+        "_doc",
+        getDataTypeNonnumericIndexMapping(),
+        "src/test/resources/datatypes.json");
 
     private final String name;
     private final String type;

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/TestUtils.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/TestUtils.java
@@ -243,6 +243,16 @@ public class TestUtils {
     return getMappingFile(mappingFile);
   }
 
+  public static String getDataTypeNumericIndexMapping() {
+    String mappingFile = "datatypes_numeric_index_mapping.json";
+    return getMappingFile(mappingFile);
+  }
+
+  public static String getDataTypeNonnumericIndexMapping() {
+    String mappingFile = "datatypes_index_mapping.json";
+    return getMappingFile(mappingFile);
+  }
+
   public static void loadBulk(Client client, String jsonPath, String defaultIndex)
       throws Exception {
     System.out.println(String.format("Loading file %s into elasticsearch cluster", jsonPath));

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/TestsConstants.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/TestsConstants.java
@@ -56,7 +56,8 @@ public class TestsConstants {
   public final static String TEST_INDEX_DATE_TIME = TEST_INDEX + "_datetime";
   public final static String TEST_INDEX_DEEP_NESTED = TEST_INDEX + "_deep_nested";
   public final static String TEST_INDEX_STRINGS = TEST_INDEX + "_strings";
-
+  public final static String TEST_INDEX_DATATYPE_NUMERIC = TEST_INDEX + "_datatypes_numeric";
+  public final static String TEST_INDEX_DATATYPE_NONNUMERIC = TEST_INDEX + "_datatypes_nonnumeric";
 
   public final static String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
   public final static String TS_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/DataTypeIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/DataTypeIT.java
@@ -1,0 +1,67 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.ppl;
+
+import static com.amazon.opendistroforelasticsearch.sql.legacy.SQLIntegTestCase.Index.DATA_TYPE_NONNUMERIC;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.SQLIntegTestCase.Index.DATA_TYPE_NUMERIC;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_DATATYPE_NONNUMERIC;
+import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_DATATYPE_NUMERIC;
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.schema;
+import static com.amazon.opendistroforelasticsearch.sql.util.MatcherUtils.verifySchema;
+
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class DataTypeIT extends PPLIntegTestCase {
+
+  @Override
+  public void init() throws IOException {
+    loadIndex(DATA_TYPE_NUMERIC);
+    loadIndex(DATA_TYPE_NONNUMERIC);
+  }
+
+  @Test
+  public void test_numeric_data_types() throws IOException {
+    JSONObject result = executeQuery(
+        String.format("source=%s", TEST_INDEX_DATATYPE_NUMERIC));
+    verifySchema(result,
+        schema("long_number", "long"),
+        schema("integer_number", "integer"),
+        schema("short_number", "short"),
+        schema("byte_number", "byte"),
+        schema("double_number", "double"),
+        schema("float_number", "float"),
+        schema("half_float_number", "float"),
+        schema("scaled_float_number", "double"));
+  }
+
+  @Test
+  public void test_nonnumeric_data_types() throws IOException {
+    JSONObject result = executeQuery(
+        String.format("source=%s", TEST_INDEX_DATATYPE_NONNUMERIC));
+    verifySchema(result,
+        schema("boolean_value", "boolean"),
+        schema("keyword_value", "string"),
+        schema("text_value", "string"),
+        schema("binary_value", "binary"),
+        schema("date_value", "timestamp"),
+        schema("ip_value", "ip"),
+        schema("object_value", "struct"),
+        schema("nested_value", "array"));
+  }
+
+}

--- a/integ-test/src/test/resources/datatypes.json
+++ b/integ-test/src/test/resources/datatypes.json
@@ -1,0 +1,2 @@
+{"index":{"_id":"1"}}
+{"boolean_value": true, "keyword_value": "keyword", "text_value": "text", "binary_value": "U29tZSBiaW5hcnkgYmxvYg==", "date_value": "2020-10-13", "ip_value": "127.0.0.0.1", "object_value": {"firstname": "Dale", "lastnema": "Dale"}, "nested_value": [{"first" : "John", "last" :  "Smith"}, {"first" : "Alice", "last" :  "White"}}

--- a/integ-test/src/test/resources/datatypes.json
+++ b/integ-test/src/test/resources/datatypes.json
@@ -1,2 +1,2 @@
 {"index":{"_id":"1"}}
-{"boolean_value": true, "keyword_value": "keyword", "text_value": "text", "binary_value": "U29tZSBiaW5hcnkgYmxvYg==", "date_value": "2020-10-13", "ip_value": "127.0.0.0.1", "object_value": {"firstname": "Dale", "lastnema": "Dale"}, "nested_value": [{"first" : "John", "last" :  "Smith"}, {"first" : "Alice", "last" :  "White"}}
+{"boolean_value": true, "keyword_value": "keyword", "text_value": "text", "binary_value": "U29tZSBiaW5hcnkgYmxvYg==", "date_value": "2020-10-13 13:00:00", "ip_value": "127.0.0.0.1", "object_value": {"first": "Dale", "last": "Dale"}, "nested_value": [{"first" : "John", "last" :  "Smith"}, {"first" : "Alice", "last" :  "White"}}

--- a/integ-test/src/test/resources/datatypes_numeric.json
+++ b/integ-test/src/test/resources/datatypes_numeric.json
@@ -1,0 +1,2 @@
+{"index":{"_id":"1"}}
+{"long_number": 1, "integer_number": 2, "short_number": 3, "byte_number": 4, "double_number": 5.1, "float_number": 6.2, "half_float_number": 7.3, "scaled_float_number": 8.4}

--- a/integ-test/src/test/resources/indexDefinitions/datatypes_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/datatypes_index_mapping.json
@@ -21,10 +21,10 @@
       },
       "object_value": {
         "properties": {
-          "firstname": {
+          "first": {
             "type": "text"
           },
-          "lastname": {
+          "last": {
             "type": "text"
           }
         }

--- a/integ-test/src/test/resources/indexDefinitions/datatypes_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/datatypes_index_mapping.json
@@ -1,0 +1,37 @@
+{
+  "mappings": {
+    "properties": {
+      "boolean_value": {
+        "type": "boolean"
+      },
+      "keyword_value": {
+        "type": "keyword"
+      },
+      "text_value": {
+        "type": "text"
+      },
+      "binary_value": {
+        "type": "binary"
+      },
+      "date_value": {
+        "type": "date"
+      },
+      "ip_value": {
+        "type": "ip"
+      },
+      "object_value": {
+        "properties": {
+          "firstname": {
+            "type": "text"
+          },
+          "lastname": {
+            "type": "text"
+          }
+        }
+      },
+      "nested_value": {
+        "type": "nested"
+      }
+    }
+  }
+}

--- a/integ-test/src/test/resources/indexDefinitions/datatypes_numeric_index_mapping.json
+++ b/integ-test/src/test/resources/indexDefinitions/datatypes_numeric_index_mapping.json
@@ -1,0 +1,31 @@
+{
+  "mappings": {
+    "properties": {
+      "long_number":{
+        "type": "long"
+      },
+      "integer_number": {
+        "type": "integer"
+      },
+      "short_number": {
+        "type": "short"
+      },
+      "byte_number": {
+        "type": "byte"
+      },
+      "double_number": {
+        "type": "double"
+      },
+      "float_number": {
+        "type": "float"
+      },
+      "half_float_number": {
+        "type": "half_float"
+      },
+      "scaled_float_number": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      }
+    }
+  }
+}

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/BinaryType.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/BinaryType.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.jdbc.types;
+
+import java.sql.SQLException;
+import java.util.Map;
+
+public class BinaryType implements TypeHelper<String> {
+
+  public static final BinaryType INSTANCE = new BinaryType();
+
+  private BinaryType() {
+
+  }
+
+  @Override
+  public String fromValue(Object value, Map<String, Object> conversionParams) throws SQLException {
+    if (value == null)
+      return null;
+    else
+      return String.valueOf(value);
+  }
+
+  @Override
+  public String getTypeName() {
+    return "Binary";
+  }
+}

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/ElasticsearchType.java
@@ -75,6 +75,7 @@ public enum ElasticsearchType {
     DATE(JDBCType.DATE, Date.class, 24, 24, false),
     TIME(JDBCType.TIME, Time.class, 24, 24, false),
     TIMESTAMP(JDBCType.TIMESTAMP, Timestamp.class, 24, 24, false),
+    BINARY(JDBCType.VARBINARY, String.class, Integer.MAX_VALUE, 0, false),
     NULL(JDBCType.NULL, null, 0, 0, false),
     UNSUPPORTED(JDBCType.OTHER, null, 0, 0, false);
 
@@ -96,6 +97,7 @@ public enum ElasticsearchType {
         jdbcTypeToESTypeMap.put(JDBCType.TIMESTAMP, TIMESTAMP);
         jdbcTypeToESTypeMap.put(JDBCType.TIME, TIME);
         jdbcTypeToESTypeMap.put(JDBCType.DATE, DATE);
+        jdbcTypeToESTypeMap.put(JDBCType.VARBINARY, BINARY);
     }
 
     /**

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/TypeConverters.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/types/TypeConverters.java
@@ -21,6 +21,7 @@ import java.sql.JDBCType;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -60,6 +61,8 @@ public class TypeConverters {
         tcMap.put(JDBCType.SMALLINT, new SmallIntTypeConverter());
         tcMap.put(JDBCType.INTEGER, new IntegerTypeConverter());
         tcMap.put(JDBCType.BIGINT, new BigIntTypeConverter());
+
+        tcMap.put(JDBCType.BINARY, new BinaryTypeConverter());
     }
 
     public static TypeConverter getInstance(JDBCType jdbcType) {
@@ -214,6 +217,24 @@ public class TypeConverters {
         @Override
         public Class getDefaultJavaClass() {
             return Boolean.class;
+        }
+
+        @Override
+        public Set<Class> getSupportedJavaClasses() {
+            return supportedJavaClasses;
+        }
+    }
+
+    public static class BinaryTypeConverter extends BaseTypeConverter {
+
+        private static final Set<Class> supportedJavaClasses = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(
+                String.class
+            )));
+
+        @Override
+        public Class getDefaultJavaClass() {
+            return String.class;
         }
 
         @Override

--- a/sql-jdbc/src/test/java/com/amazon/opendistroforelasticsearch/jdbc/types/BinaryTypeTests.java
+++ b/sql-jdbc/src/test/java/com/amazon/opendistroforelasticsearch/jdbc/types/BinaryTypeTests.java
@@ -1,0 +1,38 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.jdbc.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class BinaryTypeTests {
+
+  @ParameterizedTest
+  @CsvSource(value = {
+      "U29tZSBiaW5hcnkgYmxvYg==, U29tZSBiaW5hcnkgYmxvYg==",
+      "TWFuIGlzIGRpc3Rpbmd1aXN, TWFuIGlzIGRpc3Rpbmd1aXN",
+      "YW55IGNhcm5hbCBwbGVhc3VyZS4=, YW55IGNhcm5hbCBwbGVhc3VyZS4="
+  })
+  void testTimeFromString(String inputString, String result) {
+    String binary = Assertions.assertDoesNotThrow(
+        () -> BinaryType.INSTANCE.fromValue(inputString, null));
+    assertEquals(result, binary);
+  }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:

- Added support of basic data types including `BYTE`, `SHORT` (short type was already partly implemented before this PR), and es type `BINARY`
- Enabled `BYTE` and `SHORT` in arithmetic operations and some mathematical functions
- Added support of `BINARY` type in JDBC driver
- Added integration test for all data types we have supported in the core engine

Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-data-types.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
