### PR TITLE
Release ODFE 1.11.0

### DIFF
--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           config-name: draft-release-notes-config.yml
           tag: (None)
-          version: 1.10.1.1
+          version: 1.11.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ repositories {
 }
 
 ext {
-    opendistroVersion = '1.10.1'
+    opendistroVersion = '1.11.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@
 #   permissions and limitations under the License.
 #
 
-version=1.10.1
+version=1.11.0

--- a/release-notes/opendistro-for-elasticsearch-sql.release-notes-1.11.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-sql.release-notes-1.11.0.0.md
@@ -11,6 +11,8 @@
 
 ### Enhancements
 * Support describe index alias ([#775](https://github.com/opendistro-for-elasticsearch/sql/pull/775))
+* Restyle workbench SQL/PPL UI ([#781](https://github.com/opendistro-for-elasticsearch/sql/pull/781))
+* UI Separate SQL and PPL pages ([#761](https://github.com/opendistro-for-elasticsearch/sql/pull/761))
 
 ### Bug Fixes
 * Fix bug, support multiple aggregation ([#771](https://github.com/opendistro-for-elasticsearch/sql/pull/771))
@@ -19,11 +21,6 @@
 * Bug fix, order by doesn't work when group by field has alias ([#766](https://github.com/opendistro-for-elasticsearch/sql/pull/766))
 * Bug fix, using matcher to compare the Json result ([#762](https://github.com/opendistro-for-elasticsearch/sql/pull/762))
 
-
 ### Infrastructure
 * Enforce 100% branch coverage for sql and es module ([#774](https://github.com/opendistro-for-elasticsearch/sql/pull/774))
-
-### Workbench
-* Restyle workbench SQL/PPL UI ([#781](https://github.com/opendistro-for-elasticsearch/sql/pull/781))
-* UI Separate SQL and PPL pages ([#761](https://github.com/opendistro-for-elasticsearch/sql/pull/761))
 

--- a/release-notes/opendistro-for-elasticsearch-sql.release-notes-1.11.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-sql.release-notes-1.11.0.0.md
@@ -1,0 +1,29 @@
+## 2020-10-16 Version 1.11.0.0
+
+### Features
+* Add support of basic data types byte, short, binary and add data type testing ([#780](https://github.com/opendistro-for-elasticsearch/sql/pull/780))
+* Support ranking window functions ([#753](https://github.com/opendistro-for-elasticsearch/sql/pull/753))
+* Add LogicalPlan optimization ([#763](https://github.com/opendistro-for-elasticsearch/sql/pull/763))
+* Support DATE_FORMAT function ([#764](https://github.com/opendistro-for-elasticsearch/sql/pull/764))
+* Support date and time function: week ([#757](https://github.com/opendistro-for-elasticsearch/sql/pull/757))
+* Support aggregations min, max ([#541](https://github.com/opendistro-for-elasticsearch/sql/pull/541))
+* Support date and time functions ([#746](https://github.com/opendistro-for-elasticsearch/sql/pull/746))
+
+### Enhancements
+* Support describe index alias ([#775](https://github.com/opendistro-for-elasticsearch/sql/pull/775))
+
+### Bug Fixes
+* Fix bug, support multiple aggregation ([#771](https://github.com/opendistro-for-elasticsearch/sql/pull/771))
+* Fix cast statement in aggregate function return 0 ([#773](https://github.com/opendistro-for-elasticsearch/sql/pull/773))
+* Bug fix, using Local.Root when format the string ([#767](https://github.com/opendistro-for-elasticsearch/sql/pull/767))
+* Bug fix, order by doesn't work when group by field has alias ([#766](https://github.com/opendistro-for-elasticsearch/sql/pull/766))
+* Bug fix, using matcher to compare the Json result ([#762](https://github.com/opendistro-for-elasticsearch/sql/pull/762))
+
+
+### Infrastructure
+* Enforce 100% branch coverage for sql and es module ([#774](https://github.com/opendistro-for-elasticsearch/sql/pull/774))
+
+### Workbench
+* Restyle workbench SQL/PPL UI ([#781](https://github.com/opendistro-for-elasticsearch/sql/pull/781))
+* UI Separate SQL and PPL pages ([#761](https://github.com/opendistro-for-elasticsearch/sql/pull/761))
+

--- a/sql-cli/src/odfe_sql_cli/__init__.py
+++ b/sql-cli/src/odfe_sql_cli/__init__.py
@@ -12,4 +12,4 @@ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
-__version__ = "1.10.1.1"
+__version__ = "1.11.0.0"

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -32,7 +32,7 @@ plugins {
 group 'com.amazon.opendistroforelasticsearch.client'
 
 // keep version in sync with version in Driver source
-version '1.10.1.1'
+version '1.11.0.0'
 
 boolean snapshot = "true".equals(System.getProperty("build.snapshot", "true"));
 if (snapshot) {

--- a/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/internal/Version.java
+++ b/sql-jdbc/src/main/java/com/amazon/opendistroforelasticsearch/jdbc/internal/Version.java
@@ -19,7 +19,7 @@ package com.amazon.opendistroforelasticsearch.jdbc.internal;
 public enum Version {
 
     // keep this in sync with the gradle version
-    Current(1, 10, 1, 1);
+    Current(1, 11, 0, 0);
 
     private int major;
     private int minor;

--- a/sql-odbc/src/CMakeLists.txt
+++ b/sql-odbc/src/CMakeLists.txt
@@ -78,8 +78,8 @@ set(INSTALL_SRC "${CMAKE_CURRENT_SOURCE_DIR}/installer")
 set(DSN_INSTALLER_SRC "${CMAKE_CURRENT_SOURCE_DIR}/DSNInstaller")
 
 # ODBC Driver version 
-set(DRIVER_PACKAGE_VERSION "1.10.1.1")
-set(DRIVER_PACKAGE_VERSION_COMMA_SEPARATED "1,10,1,1")
+set(DRIVER_PACKAGE_VERSION "1.11.0.0")
+set(DRIVER_PACKAGE_VERSION_COMMA_SEPARATED "1,11,0,0")
 add_compile_definitions( ES_ODBC_VERSION="${DRIVER_PACKAGE_VERSION}"
                          # Comma separated version is required for odbc administrator's driver file.
                          ES_ODBC_DRVFILE_VERSION=${DRIVER_PACKAGE_VERSION_COMMA_SEPARATED} )

--- a/sql-odbc/src/TableauConnector/odfe_sql_odbc/manifest.xml
+++ b/sql-odbc/src/TableauConnector/odfe_sql_odbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='odfe_sql_odbc' superclass='odbc' plugin-version='1.10.1.1' name='SQL' version='18.1' min-version-tableau='2020.1'>
+<connector-plugin class='odfe_sql_odbc' superclass='odbc' plugin-version='1.11.0.0' name='SQL' version='18.1' min-version-tableau='2020.1'>
   <vendor-information>
       <company name="Open Distro for ES"/>
       <support-link url="https://github.com/opendistro-for-elasticsearch/sql"/>

--- a/sql-odbc/src/TableauConnector/odfe_sql_odbc_dev/manifest.xml
+++ b/sql-odbc/src/TableauConnector/odfe_sql_odbc_dev/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='odfe_sql_odbc_dev' superclass='odbc' plugin-version='1.10.1.1' name='Open Distro for Elasticsearch SQL ODBC DEV' version='18.1' min-version-tableau='2020.1'>
+<connector-plugin class='odfe_sql_odbc_dev' superclass='odbc' plugin-version='1.11.0.0' name='Open Distro for Elasticsearch SQL ODBC DEV' version='18.1' min-version-tableau='2020.1'>
   <vendor-information>
       <company name="Open Distro for Elasticsearch"/>
       <support-link url="https://github.com/opendistro-for-elasticsearch/sql"/>

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opendistro-query-workbench",
-  "version": "1.10.1.1",
+  "version": "1.11.0.0",
   "description": "Query Workbench",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
*Description of changes:*
ODFE 1.11.0 Release, Elasitcsearch 7.9.1, Kibana 7.9.1
Release notes: https://github.com/penghuo/sql/blob/od-1-11-0-release/release-notes/opendistro-for-elasticsearch-sql.release-notes-1.11.0.0.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
