### PR TITLE
Support HAVING in new SQL engine

### DIFF
--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/Analyzer.java
@@ -121,8 +121,11 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   @Override
   public LogicalPlan visitFilter(Filter node, AnalysisContext context) {
     LogicalPlan child = node.getChild().get(0).accept(this, context);
+    ExpressionReferenceOptimizer optimizer =
+        new ExpressionReferenceOptimizer(expressionAnalyzer.getRepository(), child);
     Expression condition = expressionAnalyzer.analyze(node.getCondition(), context);
-    return new LogicalFilter(child, condition);
+    Expression optimized = optimizer.optimize(condition, context);
+    return new LogicalFilter(child, optimized);
   }
 
   /**

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/Analyzer.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/Analyzer.java
@@ -121,9 +121,10 @@ public class Analyzer extends AbstractNodeVisitor<LogicalPlan, AnalysisContext> 
   @Override
   public LogicalPlan visitFilter(Filter node, AnalysisContext context) {
     LogicalPlan child = node.getChild().get(0).accept(this, context);
+    Expression condition = expressionAnalyzer.analyze(node.getCondition(), context);
+
     ExpressionReferenceOptimizer optimizer =
         new ExpressionReferenceOptimizer(expressionAnalyzer.getRepository(), child);
-    Expression condition = expressionAnalyzer.analyze(node.getCondition(), context);
     Expression optimized = optimizer.optimize(condition, context);
     return new LogicalFilter(child, optimized);
   }

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/AnalyzerTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/AnalyzerTest.java
@@ -96,6 +96,31 @@ class AnalyzerTest extends AnalyzerTestBase {
   }
 
   @Test
+  public void analyze_filter_aggregation_relation() {
+    assertAnalyzeEqual(
+        LogicalPlanDSL.filter(
+            LogicalPlanDSL.aggregation(
+                LogicalPlanDSL.relation("schema"),
+                ImmutableList.of(
+                    DSL.named("AVG(integer_value)", dsl.avg(DSL.ref("integer_value", INTEGER))),
+                    DSL.named("MIN(integer_value)", dsl.min(DSL.ref("integer_value", INTEGER)))),
+            ImmutableList.of(DSL.named("string_value", DSL.ref("string_value", STRING)))),
+            dsl.greater(// Expect to be replaced with reference by expression optimizer
+                DSL.ref("MIN(integer_value)", INTEGER), DSL.literal(integerValue(10)))),
+        AstDSL.filter(
+            AstDSL.agg(
+                AstDSL.relation("schema"),
+                ImmutableList.of(
+                    alias("AVG(integer_value)", aggregate("AVG", qualifiedName("integer_value"))),
+                    alias("MIN(integer_value)", aggregate("MIN", qualifiedName("integer_value")))),
+            emptyList(),
+                ImmutableList.of(alias("string_value", qualifiedName("string_value"))),
+                emptyList()),
+            compare(">",
+                aggregate("MIN", qualifiedName("integer_value")), intLiteral(10))));
+  }
+
+  @Test
   public void rename_relation() {
     assertAnalyzeEqual(
         LogicalPlanDSL.rename(

--- a/docs/user/dql/aggregations.rst
+++ b/docs/user/dql/aggregations.rst
@@ -126,3 +126,50 @@ The aggregation could has expression as arguments::
     | M        | 202    |
     +----------+--------+
 
+
+HAVING Clause
+=============
+
+Description
+-----------
+
+A ``HAVING`` clause can serve as aggregation filter that filters out aggregated values satisfy the condition expression given.
+
+HAVING with GROUP BY
+--------------------
+
+Identifier, aggregate expression, or its alias defined in ``SELECT`` clause can be used in the ``HAVING`` condition.
+
+1. Although it's valid, it's recommended to use non-aggregate in ``WHERE`` instead of ``HAVING``.
+2. The aggregation in ``HAVING`` clause is not necessarily same as that on select list.
+
+Here is an example::
+
+    od> SELECT
+    ...  gender, sum(age)
+    ... FROM accounts
+    ... GROUP BY gender
+    ... HAVING sum(age) > 100;
+    fetched rows / total rows = 1/1
+    +----------+------------+
+    | gender   | sum(age)   |
+    |----------+------------|
+    | M        | 101        |
+    +----------+------------+
+
+HAVING without GROUP BY
+-----------------------
+
+Additionally, a ``HAVING`` clause can work without ``GROUP BY`` clause. This is useful because aggregation is not allowed to be present in ``WHERE`` clause::
+
+    od> SELECT
+    ...  'Total of age > 100'
+    ... FROM accounts
+    ... HAVING sum(age) > 100;
+    fetched rows / total rows = 1/1
+    +------------------------+
+    | 'Total of age > 100'   |
+    |------------------------|
+    | Total of age > 100     |
+    +------------------------+
+

--- a/docs/user/dql/aggregations.rst
+++ b/docs/user/dql/aggregations.rst
@@ -138,18 +138,32 @@ A ``HAVING`` clause can serve as aggregation filter that filters out aggregated 
 HAVING with GROUP BY
 --------------------
 
-Identifier, aggregate expression, or its alias defined in ``SELECT`` clause can be used in the ``HAVING`` condition.
+Aggregate expressions or its alias defined in ``SELECT`` clause can be used in ``HAVING`` condition.
 
-1. Although it's valid, it's recommended to use non-aggregate in ``WHERE`` instead of ``HAVING``.
-2. The aggregation in ``HAVING`` clause is not necessarily same as that on select list.
+1. It's recommended to use non-aggregate expression in ``WHERE`` although it's allowed to do this in ``HAVING`` clause.
+2. The aggregation in ``HAVING`` clause is not necessarily same as that on select list. As extension to SQL standard, it's also not restricted to involve identifiers only on group by list.
 
-Here is an example::
+Here is an example for typical use of ``HAVING`` clause::
 
     od> SELECT
     ...  gender, sum(age)
     ... FROM accounts
     ... GROUP BY gender
     ... HAVING sum(age) > 100;
+    fetched rows / total rows = 1/1
+    +----------+------------+
+    | gender   | sum(age)   |
+    |----------+------------|
+    | M        | 101        |
+    +----------+------------+
+
+Here is another example for using alias in ``HAVING`` condition. Note that if an identifier is ambiguous, for example present both as a select alias and an index field, preference is alias. This means the identifier will be replaced by expression aliased in ``SELECT`` clause::
+
+    od> SELECT
+    ...  gender, sum(age) AS s
+    ... FROM accounts
+    ... GROUP BY gender
+    ... HAVING s > 100;
     fetched rows / total rows = 1/1
     +----------+------------+
     | gender   | sum(age)   |

--- a/docs/user/dql/aggregations.rst
+++ b/docs/user/dql/aggregations.rst
@@ -165,11 +165,11 @@ Here is another example for using alias in ``HAVING`` condition. Note that if an
     ... GROUP BY gender
     ... HAVING s > 100;
     fetched rows / total rows = 1/1
-    +----------+------------+
-    | gender   | sum(age)   |
-    |----------+------------|
-    | M        | 101        |
-    +----------+------------+
+    +----------+-----+
+    | gender   | s   |
+    |----------+-----|
+    | M        | 101 |
+    +----------+-----+
 
 HAVING without GROUP BY
 -----------------------

--- a/integ-test/src/test/resources/correctness/queries/groupby.txt
+++ b/integ-test/src/test/resources/correctness/queries/groupby.txt
@@ -45,3 +45,5 @@ SELECT OriginCountry, COUNT(FlightNum) FROM kibana_sample_data_flights GROUP BY 
 SELECT OriginCountry, COUNT(FlightNum) AS cnt FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING cnt = 1
 SELECT OriginCountry, COUNT(FlightNum) AS cnt FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING 1 < cnt
 SELECT OriginCountry, COUNT(FlightNum) FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING MIN(FlightDelayMin) > 100
+SELECT OriginCountry, COUNT(FlightNum) FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING COUNT(FlightNum) > 1 OR MIN(FlightDelayMin) > 100
+SELECT OriginCountry, COUNT(FlightNum) FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING COUNT(FlightNum) = 1 AND MIN(FlightDelayMin) <= 100

--- a/integ-test/src/test/resources/correctness/queries/groupby.txt
+++ b/integ-test/src/test/resources/correctness/queries/groupby.txt
@@ -38,6 +38,9 @@ SELECT flights.OriginCountry AS country, flights.OriginCityName AS city, SUM(Fli
 SELECT ABS(flights.FlightDelayMin) AS delay FROM kibana_sample_data_flights AS flights GROUP BY delay
 SELECT `flights`.OriginCountry, AVG(FlightDelayMin) FROM kibana_sample_data_flights AS `flights` GROUP BY `flights`.OriginCountry
 SELECT `flights`.OriginCountry, AVG(FlightDelayMin) FROM kibana_sample_data_flights AS `flights` GROUP BY 1
+SELECT 'This is not an empty index' FROM kibana_sample_data_flights HAVING COUNT(FlightNum) > 0
+SELECT 'This is an empty index' FROM kibana_sample_data_flights HAVING COUNT(FlightNum) = 0
+SELECT 'The average delay time > 10 min' FROM kibana_sample_data_flights HAVING AVG(FlightDelayMin) > 10
 SELECT OriginCountry, COUNT(FlightNum) FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING COUNT(FlightNum) > 1
 SELECT OriginCountry, COUNT(FlightNum) AS cnt FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING cnt = 1
 SELECT OriginCountry, COUNT(FlightNum) AS cnt FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING 1 < cnt

--- a/integ-test/src/test/resources/correctness/queries/groupby.txt
+++ b/integ-test/src/test/resources/correctness/queries/groupby.txt
@@ -38,3 +38,7 @@ SELECT flights.OriginCountry AS country, flights.OriginCityName AS city, SUM(Fli
 SELECT ABS(flights.FlightDelayMin) AS delay FROM kibana_sample_data_flights AS flights GROUP BY delay
 SELECT `flights`.OriginCountry, AVG(FlightDelayMin) FROM kibana_sample_data_flights AS `flights` GROUP BY `flights`.OriginCountry
 SELECT `flights`.OriginCountry, AVG(FlightDelayMin) FROM kibana_sample_data_flights AS `flights` GROUP BY 1
+SELECT OriginCountry, COUNT(FlightNum) FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING COUNT(FlightNum) > 1
+SELECT OriginCountry, COUNT(FlightNum) AS cnt FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING cnt = 1
+SELECT OriginCountry, COUNT(FlightNum) AS cnt FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING 1 < cnt
+SELECT OriginCountry, COUNT(FlightNum) FROM kibana_sample_data_flights GROUP BY OriginCountry HAVING MIN(FlightDelayMin) > 100

--- a/sql/src/main/antlr/OpenDistroSQLParser.g4
+++ b/sql/src/main/antlr/OpenDistroSQLParser.g4
@@ -79,6 +79,7 @@ fromClause
     : FROM tableName (AS? alias)?
       (whereClause)?
       (groupByClause)?
+      (havingClause)?
     ;
 
 whereClause
@@ -95,6 +96,10 @@ groupByElements
 
 groupByElement
     : expression
+    ;
+
+havingClause
+    : HAVING expression
     ;
 
 orderByClause

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilder.java
@@ -78,7 +78,7 @@ public class AstAggregationBuilder extends OpenDistroSQLParserBaseVisitor<Unreso
   @Override
   public UnresolvedPlan visit(ParseTree groupByClause) {
     if (groupByClause == null) {
-      if (isAllSelectItemNonAggregated() && isNoAggregator()) {
+      if (isAggregatorNotFoundAnywhere()) {
         // Simple select query without GROUP BY and aggregate function in SELECT
         return null;
       }
@@ -120,6 +120,10 @@ public class AstAggregationBuilder extends OpenDistroSQLParserBaseVisitor<Unreso
                     .collect(Collectors.toList());
   }
 
+  /**
+   * Find non-aggregate item in SELECT clause. Note that literal is special which is not required
+   * to be applied by aggregate function.
+   */
   private Optional<UnresolvedExpression> findNonAggregatedItemInSelect() {
     return querySpec.getSelectItems().stream()
                                      .filter(this::isNonLiteral)
@@ -127,12 +131,7 @@ public class AstAggregationBuilder extends OpenDistroSQLParserBaseVisitor<Unreso
                                      .findFirst();
   }
 
-  private boolean isAllSelectItemNonAggregated() {
-    return querySpec.getSelectItems().stream()
-                                     .allMatch(this::isNonAggregatedExpression);
-  }
-
-  private boolean isNoAggregator() {
+  private boolean isAggregatorNotFoundAnywhere() {
     return querySpec.getAggregators().isEmpty();
   }
 

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilder.java
@@ -17,6 +17,7 @@
 package com.amazon.opendistroforelasticsearch.sql.sql.parser;
 
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.FromClauseContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.HavingClauseContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.SelectClauseContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.SelectElementContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.WhereClauseContext;
@@ -115,11 +116,19 @@ public class AstBuilder extends OpenDistroSQLParserBaseVisitor<UnresolvedPlan> {
       result = aggregation.attach(result);
     }
 
+    if (ctx.havingClause() != null) {
+      result = visit(ctx.havingClause()).attach(result);
+    }
     return result;
   }
 
   @Override
   public UnresolvedPlan visitWhereClause(WhereClauseContext ctx) {
+    return new Filter(visitAstExpression(ctx.expression()));
+  }
+
+  @Override
+  public UnresolvedPlan visitHavingClause(HavingClauseContext ctx) {
     return new Filter(visitAstExpression(ctx.expression()));
   }
 

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilder.java
@@ -134,7 +134,8 @@ public class AstBuilder extends OpenDistroSQLParserBaseVisitor<UnresolvedPlan> {
 
   @Override
   public UnresolvedPlan visitHavingClause(HavingClauseContext ctx) {
-    return new Filter(visitAstExpression(ctx.expression()));
+    AstHavingFilterBuilder builder = new AstHavingFilterBuilder(context.peek());
+    return new Filter(builder.visit(ctx.expression()));
   }
 
   @Override

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstHavingFilterBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstHavingFilterBuilder.java
@@ -27,7 +27,7 @@ import lombok.RequiredArgsConstructor;
  * AST Having filter builder that builds HAVING clause condition expressions
  * and replace alias by original expression in SELECT clause.
  * The reason for this is it's hard to replace afterwards since UnresolvedExpression
- * is mostly immutable.
+ * is immutable.
  */
 @RequiredArgsConstructor
 public class AstHavingFilterBuilder extends AstExpressionBuilder {

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstHavingFilterBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstHavingFilterBuilder.java
@@ -1,0 +1,54 @@
+/*
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.sql.parser;
+
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.IdentsAsQualifiedNameContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.KeywordsAsQualifiedNameContext;
+
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
+import com.amazon.opendistroforelasticsearch.sql.sql.parser.context.QuerySpecification;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * AST Having filter builder that builds HAVING clause condition expressions
+ * and replace alias by original expression in SELECT clause.
+ * The reason for this is it's hard to replace afterwards since UnresolvedExpression
+ * is mostly immutable.
+ */
+@RequiredArgsConstructor
+public class AstHavingFilterBuilder extends AstExpressionBuilder {
+
+  private final QuerySpecification querySpec;
+
+  @Override
+  public UnresolvedExpression visitIdentsAsQualifiedName(IdentsAsQualifiedNameContext ctx) {
+    return replaceAlias(super.visitIdentsAsQualifiedName(ctx));
+  }
+
+  @Override
+  public UnresolvedExpression visitKeywordsAsQualifiedName(KeywordsAsQualifiedNameContext ctx) {
+    return replaceAlias(super.visitKeywordsAsQualifiedName(ctx));
+  }
+
+  private UnresolvedExpression replaceAlias(UnresolvedExpression expr) {
+    if (querySpec.isSelectAlias(expr)) {
+      return querySpec.getSelectItemByAlias(expr);
+    }
+    return expr;
+  }
+
+}

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/context/QuerySpecification.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/context/QuerySpecification.java
@@ -136,12 +136,12 @@ public class QuerySpecification {
     return selectItems.get(ordinal - 1);
   }
 
-  private boolean isSelectAlias(UnresolvedExpression expr) {
+  public boolean isSelectAlias(UnresolvedExpression expr) {
     return (expr instanceof QualifiedName)
         && (selectItemsByAlias.containsKey(expr.toString()));
   }
 
-  private UnresolvedExpression getSelectItemByAlias(UnresolvedExpression expr) {
+  public UnresolvedExpression getSelectItemByAlias(UnresolvedExpression expr) {
     return selectItemsByAlias.get(expr.toString());
   }
 

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/context/QuerySpecification.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/context/QuerySpecification.java
@@ -136,11 +136,21 @@ public class QuerySpecification {
     return selectItems.get(ordinal - 1);
   }
 
+  /**
+   * Check if an expression is a select alias.
+   * @param expr  expression
+   * @return true if it's an alias
+   */
   public boolean isSelectAlias(UnresolvedExpression expr) {
     return (expr instanceof QualifiedName)
         && (selectItemsByAlias.containsKey(expr.toString()));
   }
 
+  /**
+   * Get original expression aliased in SELECT clause.
+   * @param expr  alias
+   * @return expression in SELECT
+   */
   public UnresolvedExpression getSelectItemByAlias(UnresolvedExpression expr) {
     return selectItemsByAlias.get(expr.toString());
   }

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilderTest.java
@@ -105,6 +105,16 @@ class AstAggregationBuilderTest {
   }
 
   @Test
+  void can_build_implicit_group_by_for_aggregator_in_having_clause() {
+    assertThat(
+        buildAggregation("SELECT true FROM test HAVING AVG(age) > 30"),
+        allOf(
+            hasGroupByItems(),
+            hasAggregators(
+                alias("AVG(age)", aggregate("AVG", qualifiedName("age"))))));
+  }
+
+  @Test
   void should_build_nothing_if_no_group_by_and_no_aggregators_in_select() {
     assertNull(buildAggregation("SELECT name FROM test"));
   }
@@ -187,6 +197,16 @@ class AstAggregationBuilderTest {
     SemanticCheckException error2 = assertThrows(SemanticCheckException.class, () ->
         buildAggregation("SELECT age, AVG(balance) FROM tests GROUP BY 3"));
     assertEquals("Ordinal [3] is out of bound of select item list", error2.getMessage());
+  }
+
+  @Test
+  void should_report_error_for_non_aggregated_item_in_select_if_only_having() {
+    SemanticCheckException error = assertThrows(SemanticCheckException.class, () ->
+        buildAggregation("SELECT age FROM tests HAVING AVG(balance) > 30"));
+    assertEquals(
+        "Explicit GROUP BY clause is required because expression [age] "
+            + "contains non-aggregated column",
+        error.getMessage());
   }
 
   private Matcher<UnresolvedPlan> hasGroupByItems(UnresolvedExpression... exprs) {

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
@@ -306,6 +306,26 @@ class AstBuilderTest {
   }
 
   @Test
+  public void can_build_having_condition_using_alias() {
+    assertEquals(
+        project(
+            filter(
+                agg(
+                    relation("test"),
+                    ImmutableList.of(
+                        alias("AVG(age)", aggregate("AVG", qualifiedName("age")))),
+                    emptyList(),
+                    ImmutableList.of(alias("name", qualifiedName("name"))),
+                    emptyList()),
+                function(">",
+                    aggregate("AVG", qualifiedName("age")),
+                    intLiteral(1000))),
+            alias("name", qualifiedName("name")),
+            alias("AVG(age)", aggregate("AVG", qualifiedName("age")), "a")),
+        buildAST("SELECT name, AVG(age) AS a FROM test GROUP BY name HAVING a > 1000"));
+  }
+
+  @Test
   public void can_build_order_by_field_name() {
     assertEquals(
         project(

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
@@ -281,6 +281,27 @@ class AstBuilderTest {
         buildAST("SELECT AVG(age) FROM test"));
   }
 
+  @Test
+  public void can_build_having_clause() {
+    assertEquals(
+        project(
+            filter(
+                agg(
+                    relation("test"),
+                    ImmutableList.of(
+                        alias("AVG(age)", aggregate("AVG", qualifiedName("age"))),
+                        alias("MIN(balance)", aggregate("MIN", qualifiedName("balance")))),
+                    emptyList(),
+                    ImmutableList.of(alias("name", qualifiedName("name"))),
+                    emptyList()),
+                function(">",
+                    aggregate("MIN", qualifiedName("balance")),
+                    intLiteral(1000))),
+            alias("name", qualifiedName("name")),
+            alias("AVG(age)", aggregate("AVG", qualifiedName("age")))),
+        buildAST("SELECT name, AVG(age) FROM test GROUP BY name HAVING MIN(balance) > 1000"));
+  }
+
   private UnresolvedPlan buildAST(String query) {
     ParseTree parseTree = parser.parse(query);
     return parseTree.accept(new AstBuilder(query));

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstHavingFilterBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstHavingFilterBuilderTest.java
@@ -1,0 +1,81 @@
+/*
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.sql.parser;
+
+import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.aggregate;
+import static com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL.qualifiedName;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.IdentContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.KeywordsAsQualifiedNameContext;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
+import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.IdentsAsQualifiedNameContext;
+import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.KeywordsCanBeIdContext;
+import com.amazon.opendistroforelasticsearch.sql.sql.parser.context.QuerySpecification;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class AstHavingFilterBuilderTest {
+
+  @Mock
+  private QuerySpecification querySpec;
+
+  private AstHavingFilterBuilder builder;
+
+  @BeforeEach
+  void setup() {
+    builder = new AstHavingFilterBuilder(querySpec);
+  }
+
+  @Test
+  void should_replace_alias_with_select_expression() {
+    IdentsAsQualifiedNameContext qualifiedName = mock(IdentsAsQualifiedNameContext.class);
+    IdentContext identifier = mock(IdentContext.class);
+    UnresolvedExpression expression = aggregate("AVG", qualifiedName("age"));
+
+    when(identifier.getText()).thenReturn("a");
+    when(qualifiedName.ident()).thenReturn(ImmutableList.of(identifier));
+    when(querySpec.isSelectAlias(any())).thenReturn(true);
+    when(querySpec.getSelectItemByAlias(any())).thenReturn(expression);
+    assertEquals(expression, builder.visitIdentsAsQualifiedName(qualifiedName));
+  }
+
+  @Test
+  void should_replace_keyword_alias_with_select_expression() {
+    KeywordsAsQualifiedNameContext qualifiedName = mock(KeywordsAsQualifiedNameContext.class);
+    KeywordsCanBeIdContext keyword = mock(KeywordsCanBeIdContext.class);
+    UnresolvedExpression expression = aggregate("AVG", qualifiedName("age"));
+
+    when(keyword.getText()).thenReturn("a");
+    when(qualifiedName.keywordsCanBeId()).thenReturn(keyword);
+    when(querySpec.isSelectAlias(any())).thenReturn(true);
+    when(querySpec.getSelectItemByAlias(any())).thenReturn(expression);
+    assertEquals(expression, builder.visitKeywordsAsQualifiedName(qualifiedName));
+  }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Change SQL grammar and build `Filter` AST node to integrate with analyzer in core engine. (To replace alias in `HAVING` condition, add a new `AstHavingFilterBuilder` which extends `AstExpressionBuilder` so it doesn't need to replace and clone conditions later)
2. Optimize filter conditions in analyzer because now there may be aggregator in condition that needs to be replaced with a reference.

*Documentation*: https://github.com/dai-chen/sql/blob/support-having-in-new-sql-engine/docs/user/dql/aggregations.rst#having-clause

*Testing*: Add new UT and comparison IT.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
