### PR TITLE
Support COUNT star and literal in new engine

### DIFF
--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzer.java
@@ -171,6 +171,8 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
 
   @Override
   public Expression visitAllFields(AllFields node, AnalysisContext context) {
+    // Convert to string literal for argument in COUNT(*). For SELECT *, its select expression
+    // analyzer will expand it to the right field name list.
     return DSL.literal("*");
   }
 

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzer.java
@@ -19,6 +19,7 @@ import com.amazon.opendistroforelasticsearch.sql.analysis.symbol.Namespace;
 import com.amazon.opendistroforelasticsearch.sql.analysis.symbol.Symbol;
 import com.amazon.opendistroforelasticsearch.sql.ast.AbstractNodeVisitor;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.AggregateFunction;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.AllFields;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.And;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Compare;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.EqualTo;
@@ -166,6 +167,11 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
   public Expression visitField(Field node, AnalysisContext context) {
     String attr = node.getField().toString();
     return visitIdentifier(attr, context);
+  }
+
+  @Override
+  public Expression visitAllFields(AllFields node, AnalysisContext context) {
+    return DSL.literal("*");
   }
 
   @Override

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzer.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzer.java
@@ -171,8 +171,9 @@ public class ExpressionAnalyzer extends AbstractNodeVisitor<Expression, Analysis
 
   @Override
   public Expression visitAllFields(AllFields node, AnalysisContext context) {
-    // Convert to string literal for argument in COUNT(*). For SELECT *, its select expression
-    // analyzer will expand it to the right field name list.
+    // Convert to string literal for argument in COUNT(*), because there is no difference between
+    // COUNT(*) and COUNT(literal). For SELECT *, its select expression analyzer will expand * to
+    // the right field name list by itself.
     return DSL.literal("*");
   }
 

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzerTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/analysis/ExpressionAnalyzerTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.amazon.opendistroforelasticsearch.sql.analysis.symbol.Namespace;
 import com.amazon.opendistroforelasticsearch.sql.analysis.symbol.Symbol;
 import com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.AllFields;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.DataType;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
 import com.amazon.opendistroforelasticsearch.sql.common.antlr.SyntaxCheckException;
@@ -119,6 +120,13 @@ class ExpressionAnalyzerTest extends AnalyzerTestBase {
     assertAnalyzeEqual(
         dsl.interval(DSL.literal(1L), DSL.literal("DAY")),
         AstDSL.intervalLiteral(1L, DataType.LONG, "DAY"));
+  }
+
+  @Test
+  public void all_fields() {
+    assertAnalyzeEqual(
+        DSL.literal("*"),
+        AllFields.of());
   }
 
   @Test

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/aggregation/CountAggregatorTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/aggregation/CountAggregatorTest.java
@@ -105,6 +105,18 @@ class CountAggregatorTest extends AggregationTest {
   }
 
   @Test
+  public void count_star_with_null_and_missing() {
+    ExprValue result = aggregation(dsl.count(DSL.literal("*")), tuples_with_null_and_missing);
+    assertEquals(3, result.value());
+  }
+
+  @Test
+  public void count_literal_with_null_and_missing() {
+    ExprValue result = aggregation(dsl.count(DSL.literal(1)), tuples_with_null_and_missing);
+    assertEquals(3, result.value());
+  }
+
+  @Test
   public void valueOf() {
     ExpressionEvaluationException exception = assertThrows(ExpressionEvaluationException.class,
         () -> dsl.count(DSL.ref("double_value", DOUBLE)).valueOf(valueEnv()));

--- a/docs/user/dql/aggregations.rst
+++ b/docs/user/dql/aggregations.rst
@@ -126,6 +126,14 @@ The aggregation could has expression as arguments::
     | M        | 202    |
     +----------+--------+
 
+COUNT Aggregations
+------------------
+
+Besides regular identifiers, ``COUNT`` aggregate function also accepts arguments such as ``*`` or literals like ``1``. The meaning of these different forms are as follows:
+
+1. ``COUNT(field)`` will count only if given field (or expression) is not null or missing in the input rows.
+2. ``COUNT(*)`` will count the number of all its input rows.
+3. ``COUNT(1)`` is same as ``COUNT(*)`` because any non-null literal will count.
 
 HAVING Clause
 =============

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/aggregation/dsl/MetricAggregationBuilder.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/aggregation/dsl/MetricAggregationBuilder.java
@@ -70,7 +70,7 @@ public class MetricAggregationBuilder
       case "sum":
         return make(AggregationBuilders.sum(name), expression);
       case "count":
-        return make(AggregationBuilders.count(name), replaceLiteral(expression));
+        return make(AggregationBuilders.count(name), replaceStarOrLiteral(expression));
       case "min":
         return make(AggregationBuilders.min(name), expression);
       case "max":
@@ -87,14 +87,15 @@ public class MetricAggregationBuilder
   }
 
   /**
-   * Replace literal with Elasticsearch metadata field "_index". Typically literal here
-   * includes * and 1 because analyzer converts * to string literal too.
-   * Value count aggregation on _index counts all docs, therefore it has same semantics as
-   * COUNT(*) or COUNT(1) in SQL language.
+   * Replace star or literal with Elasticsearch metadata field "_index". Because:
+   * 1) Analyzer already converts * to string literal, literal check here can handle
+   *    both COUNT(*) and COUNT(1).
+   * 2) Value count aggregation on _index counts all docs (after filter), therefore
+   *    it has same semantics as COUNT(*) or COUNT(1).
    * @param countArg count function argument
    * @return Reference to _index if literal, otherwise return original argument expression
    */
-  private Expression replaceLiteral(Expression countArg) {
+  private Expression replaceStarOrLiteral(Expression countArg) {
     if (countArg instanceof LiteralExpression) {
       return new ReferenceExpression("_index", INTEGER);
     }

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/aggregation/dsl/MetricAggregationBuilder.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/aggregation/dsl/MetricAggregationBuilder.java
@@ -87,9 +87,10 @@ public class MetricAggregationBuilder
   }
 
   /**
-   * Replace literal with Elasticsearch metadata field "_index". Value count aggregation
-   * on _index will count all docs which has same semantics as COUNT(*) or COUNT(1) in
-   * SQL language.
+   * Replace literal with Elasticsearch metadata field "_index". Typically literal here
+   * includes * and 1 because analyzer converts * to string literal too.
+   * Value count aggregation on _index counts all docs, therefore it has same semantics as
+   * COUNT(*) or COUNT(1) in SQL language.
    * @param countArg count function argument
    * @return Reference to _index if literal, otherwise return original argument expression
    */

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/aggregation/dsl/MetricAggregationBuilder.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/aggregation/dsl/MetricAggregationBuilder.java
@@ -17,9 +17,13 @@
 
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage.script.aggregation.dsl;
 
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
+
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage.serialization.ExpressionSerializer;
 import com.amazon.opendistroforelasticsearch.sql.expression.Expression;
 import com.amazon.opendistroforelasticsearch.sql.expression.ExpressionNodeVisitor;
+import com.amazon.opendistroforelasticsearch.sql.expression.LiteralExpression;
+import com.amazon.opendistroforelasticsearch.sql.expression.ReferenceExpression;
 import com.amazon.opendistroforelasticsearch.sql.expression.aggregation.NamedAggregator;
 import java.util.List;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -66,7 +70,7 @@ public class MetricAggregationBuilder
       case "sum":
         return make(AggregationBuilders.sum(name), expression);
       case "count":
-        return make(AggregationBuilders.count(name), expression);
+        return make(AggregationBuilders.count(name), replaceLiteral(expression));
       case "min":
         return make(AggregationBuilders.min(name), expression);
       case "max":
@@ -80,5 +84,12 @@ public class MetricAggregationBuilder
   private ValuesSourceAggregationBuilder<?> make(ValuesSourceAggregationBuilder<?> builder,
                                                   Expression expression) {
     return helper.build(expression, builder::field, builder::script);
+  }
+
+  private Expression replaceLiteral(Expression countArg) {
+    if (countArg instanceof LiteralExpression) {
+      return new ReferenceExpression("_index", INTEGER);
+    }
+    return countArg;
   }
 }

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/aggregation/dsl/MetricAggregationBuilder.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/aggregation/dsl/MetricAggregationBuilder.java
@@ -86,10 +86,18 @@ public class MetricAggregationBuilder
     return helper.build(expression, builder::field, builder::script);
   }
 
+  /**
+   * Replace literal with Elasticsearch metadata field "_index". Value count aggregation
+   * on _index will count all docs which has same semantics as COUNT(*) or COUNT(1) in
+   * SQL language.
+   * @param countArg count function argument
+   * @return Reference to _index if literal, otherwise return original argument expression
+   */
   private Expression replaceLiteral(Expression countArg) {
     if (countArg instanceof LiteralExpression) {
       return new ReferenceExpression("_index", INTEGER);
     }
     return countArg;
   }
+
 }

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/aggregation/dsl/MetricAggregationBuilderTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/storage/script/aggregation/dsl/MetricAggregationBuilderTest.java
@@ -18,6 +18,7 @@
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.storage.script.aggregation.dsl;
 
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
+import static com.amazon.opendistroforelasticsearch.sql.expression.DSL.literal;
 import static com.amazon.opendistroforelasticsearch.sql.expression.DSL.named;
 import static com.amazon.opendistroforelasticsearch.sql.expression.DSL.ref;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -107,6 +108,38 @@ class MetricAggregationBuilderTest {
             Arrays.asList(
                 named("count(age)",
                     new CountAggregator(Arrays.asList(ref("age", INTEGER)), INTEGER)))));
+  }
+
+  @Test
+  void should_build_count_star_aggregation() {
+    assertEquals(
+        "{\n"
+            + "  \"count(*)\" : {\n"
+            + "    \"value_count\" : {\n"
+            + "      \"field\" : \"_index\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(
+            Arrays.asList(
+                named("count(*)",
+                    new CountAggregator(Arrays.asList(literal("*")), INTEGER)))));
+  }
+
+  @Test
+  void should_build_count_other_literal_aggregation() {
+    assertEquals(
+        "{\n"
+            + "  \"count(1)\" : {\n"
+            + "    \"value_count\" : {\n"
+            + "      \"field\" : \"_index\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}",
+        buildQuery(
+            Arrays.asList(
+                named("count(1)",
+                    new CountAggregator(Arrays.asList(literal(1)), INTEGER)))));
   }
 
   @Test

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/PrettyFormatResponseIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/PrettyFormatResponseIT.java
@@ -334,6 +334,7 @@ public class PrettyFormatResponseIT extends SQLIntegTestCase {
     }
   }
 
+  @Ignore("In MySQL and our new engine, the original text in SELECT is used as final column name")
   @Test
   public void aggregationFunctionInSelectCaseCheck() throws IOException {
     JSONObject response = executeQuery(

--- a/integ-test/src/test/resources/correctness/queries/groupby.txt
+++ b/integ-test/src/test/resources/correctness/queries/groupby.txt
@@ -1,8 +1,16 @@
 SELECT COUNT(*) FROM kibana_sample_data_flights
+SELECT COUNT(1) FROM kibana_sample_data_flights
+SELECT COUNT('hello') FROM kibana_sample_data_flights
 SELECT SUM(FlightDelayMin) FROM kibana_sample_data_flights
 SELECT AVG(FlightDelayMin) FROM kibana_sample_data_flights
+SELECT MIN(FlightDelayMin) FROM kibana_sample_data_flights
+SELECT MAX(FlightDelayMin) FROM kibana_sample_data_flights
 SELECT count(*), Avg(FlightDelayMin), sUm(FlightDelayMin) FROM kibana_sample_data_flights
 SELECT COUNT(*) AS cnt, AVG(FlightDelayMin) AS a, SUM(FlightDelayMin) AS s FROM kibana_sample_data_flights
+SELECT COUNT(*) FROM kibana_sample_data_flights WHERE FlightTimeMin > 0
+SELECT COUNT(1) FROM kibana_sample_data_flights WHERE FlightTimeMin > 0
+SELECT SUM(FlightDelayMin) FROM kibana_sample_data_flights WHERE FlightTimeMin > 0
+SELECT AVG(FlightDelayMin) FROM kibana_sample_data_flights WHERE FlightTimeMin > 0
 SELECT COUNT(*) FROM kibana_sample_data_flights GROUP BY OriginCountry
 SELECT COUNT(FlightNum) FROM kibana_sample_data_flights GROUP BY OriginCountry
 SELECT COUNT(FlightDelay) FROM kibana_sample_data_flights GROUP BY OriginCountry

--- a/sql/src/main/antlr/OpenDistroSQLParser.g4
+++ b/sql/src/main/antlr/OpenDistroSQLParser.g4
@@ -251,8 +251,8 @@ scalarFunctionName
     ;
 
 aggregateFunction
-    : functionName=aggregationFunctionName LR_BRACKET functionArg RR_BRACKET
-    /*| COUNT LR_BRACKET (STAR | functionArg) RR_BRACKET */
+    : functionName=aggregationFunctionName LR_BRACKET functionArg RR_BRACKET #regularAggregateFunctionCall
+    | COUNT LR_BRACKET STAR RR_BRACKET                                       #countStarFunctionCall
     ;
 
 aggregationFunctionName

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilder.java
@@ -171,7 +171,7 @@ public class AstExpressionBuilder extends OpenDistroSQLParserBaseVisitor<Unresol
 
   @Override
   public UnresolvedExpression visitCountStarFunctionCall(CountStarFunctionCallContext ctx) {
-    return new AggregateFunction("count", AllFields.of());
+    return new AggregateFunction("COUNT", AllFields.of());
   }
 
   @Override

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstExpressionBuilder.java
@@ -21,9 +21,9 @@ import static com.amazon.opendistroforelasticsearch.sql.expression.function.Buil
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.BuiltinFunctionName.LIKE;
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.BuiltinFunctionName.NOT_LIKE;
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.BuiltinFunctionName.REGEXP;
-import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.AggregateFunctionContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.BinaryComparisonPredicateContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.BooleanContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.CountStarFunctionCallContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.DateLiteralContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.IdentsAsQualifiedNameContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.IsNullPredicateContext;
@@ -36,6 +36,7 @@ import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDis
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.OverClauseContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.RankingWindowFunctionContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.RegexpPredicateContext;
+import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.RegularAggregateFunctionCallContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.ScalarFunctionCallContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.SignedDecimalContext;
 import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLParser.SignedRealContext;
@@ -46,6 +47,7 @@ import static com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDis
 
 import com.amazon.opendistroforelasticsearch.sql.ast.dsl.AstDSL;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.AggregateFunction;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.AllFields;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.And;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Function;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Interval;
@@ -160,10 +162,16 @@ public class AstExpressionBuilder extends OpenDistroSQLParserBaseVisitor<Unresol
   }
 
   @Override
-  public UnresolvedExpression visitAggregateFunction(AggregateFunctionContext ctx) {
+  public UnresolvedExpression visitRegularAggregateFunctionCall(
+      RegularAggregateFunctionCallContext ctx) {
     return new AggregateFunction(
         ctx.functionName.getText(),
         visitFunctionArg(ctx.functionArg()));
+  }
+
+  @Override
+  public UnresolvedExpression visitCountStarFunctionCall(CountStarFunctionCallContext ctx) {
+    return new AggregateFunction("count", AllFields.of());
   }
 
   @Override

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
@@ -196,6 +196,23 @@ class AstBuilderTest {
   }
 
   @Test
+  public void can_build_count_star_and_count_literal() {
+    assertEquals(
+        project(
+            agg(
+                relation("test"),
+                ImmutableList.of(
+                    alias("COUNT(*)", aggregate("COUNT", AllFields.of())),
+                    alias("COUNT(1)", aggregate("COUNT", intLiteral(1)))),
+                emptyList(),
+                emptyList(),
+                emptyList()),
+            alias("COUNT(*)", aggregate("COUNT", AllFields.of())),
+            alias("COUNT(1)", aggregate("COUNT", intLiteral(1)))),
+        buildAST("SELECT COUNT(*), COUNT(1) FROM test"));
+  }
+
+  @Test
   public void can_build_group_by_field_name() {
     assertEquals(
         project(


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Support `COUNT(*)` and `COUNT(1)` in the new SQL engine.

1. Convert `*` to unresolved `AllFields` and then resolved literal `"*"`. This is because `COUNT(*)` has same semantic as `COUNT(any literal)`. So there is no need to add a new expression class (`SELECT *` has its own logic and don't need resolved AllFields expression neither)
2. Follow our old approach in legacy code by generating Value Count aggregation DSL on metadata field `_index` for `COUNT(*)` and `COUNT(1)`.

Example:

```
POST _opendistro/_sql/_explain
{
  "query": """
    SELECT
      COUNT(*), COUNT(FlightNum), COUNT(1)
    FROM kibana_sample_data_flights
  """
}
{
  "root": {
    "name": "ProjectOperator",
    "description": {
      "fields": "[COUNT(*), COUNT(FlightNum), COUNT(1)]"
    },
    "children": [
      {
        "name": "ElasticsearchIndexScan",
        "description": {
          "request": """ElasticsearchQueryRequest(indexName=kibana_sample_data_flights, sourceBuilder={"from":0,"size":0,"timeout":"1m","aggregations":{"COUNT(1)":{"value_count":{"field":"_index"}},"COUNT(*)":{"value_count":{"field":"_index"}},"COUNT(FlightNum)":{"value_count":{"field":"FlightNum"}}}}, searchDone=false)"""
        },
        "children": []
      }
    ]
  }
}
```

*Documentation*: https://github.com/dai-chen/sql/blob/support-count-star-and-literal/docs/user/dql/aggregations.rst#count-aggregations

*Testing*:

1. Add new UT and comparison IT.
2. Ignore one failed IT `PrettyFormatResponseIT.aggregationFunctionInSelectCaseCheck()`. Please see the reason on `@Ignore` message.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
