### PR TITLE
update odbc workflow

### DIFF
--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -83,8 +83,8 @@ jobs:
       run:
         working-directory: sql-odbc
     steps:
+    - uses: actions/core@v1.2.6
     - uses: actions/checkout@v1
-      - actions/core@v1.2.6
     - name: add-msbuild-to-path
       uses: microsoft/setup-msbuild@v1.0.0
     - name: configure-and-build-driver
@@ -127,8 +127,8 @@ jobs:
       run:
         working-directory: sql-odbc
     steps:
+    - uses: actions/core@v1.2.6
     - uses: actions/checkout@v1
-        - actions/core@v1.2.6
     - name: add-msbuild-to-path
       uses: microsoft/setup-msbuild@v1.0.0
     - name: configure-and-build-driver

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -83,7 +83,7 @@ jobs:
       run:
         working-directory: sql-odbc
     steps:
-    - uses: actions/core@v1.2.6
+    - uses: @actions/core@v1.2.6
     - uses: actions/checkout@v1
     - name: add-msbuild-to-path
       uses: microsoft/setup-msbuild@v1.0.0
@@ -127,7 +127,7 @@ jobs:
       run:
         working-directory: sql-odbc
     steps:
-    - uses: actions/core@v1.2.6
+    - uses: @actions/core@v1.2.6
     - uses: actions/checkout@v1
     - name: add-msbuild-to-path
       uses: microsoft/setup-msbuild@v1.0.0

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -83,9 +83,10 @@ jobs:
       run:
         working-directory: sql-odbc
     steps:
-    - uses: actions/checkout@v1.2.6
+    - uses: actions/checkout@v1
+      - actions/core@v1.2.6
     - name: add-msbuild-to-path
-      uses: microsoft/setup-msbuild@v1.2.6
+      uses: microsoft/setup-msbuild@v1.0.0
     - name: configure-and-build-driver
       run: |
         .\build_win_release32.ps1
@@ -126,9 +127,10 @@ jobs:
       run:
         working-directory: sql-odbc
     steps:
-    - uses: actions/checkout@v1.2.6
+    - uses: actions/checkout@v1
+        - actions/core@v1.2.6
     - name: add-msbuild-to-path
-      uses: microsoft/setup-msbuild@v1.2.6
+      uses: microsoft/setup-msbuild@v1.0.0
     - name: configure-and-build-driver
       run: |
         .\build_win_release64.ps1

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -83,10 +83,9 @@ jobs:
       run:
         working-directory: sql-odbc
     steps:
-    - uses: @actions/core@v1.2.6
     - uses: actions/checkout@v1
     - name: add-msbuild-to-path
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: configure-and-build-driver
       run: |
         .\build_win_release32.ps1
@@ -127,10 +126,9 @@ jobs:
       run:
         working-directory: sql-odbc
     steps:
-    - uses: @actions/core@v1.2.6
     - uses: actions/checkout@v1
     - name: add-msbuild-to-path
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: configure-and-build-driver
       run: |
         .\build_win_release64.ps1

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -83,9 +83,9 @@ jobs:
       run:
         working-directory: sql-odbc
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v1.2.6
     - name: add-msbuild-to-path
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.2.6
     - name: configure-and-build-driver
       run: |
         .\build_win_release32.ps1
@@ -126,9 +126,9 @@ jobs:
       run:
         working-directory: sql-odbc
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v1.2.6
     - name: add-msbuild-to-path
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.2.6
     - name: configure-and-build-driver
       run: |
         .\build_win_release64.ps1

--- a/.github/workflows/sql-odbc-release-workflow.yml
+++ b/.github/workflows/sql-odbc-release-workflow.yml
@@ -90,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: add-msbuild-to-path
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -136,7 +136,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: add-msbuild-to-path
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
*Issue #, if available:*
 #827

*Description of changes:*
- Updating MSBuild version as old version has an add-path command which is deprecated in current GitHub actions.
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
