### PR TITLE
Fix symbol error and Fix SSLError when connect es.

### DIFF
--- a/sql-cli/README.md
+++ b/sql-cli/README.md
@@ -60,7 +60,7 @@ To install the SQL CLI:
 1. To launch the CLI, run:
 
     ```
-    odfesql https://localhost:9200 --username admin —password admin
+    odfesql https://localhost:9200 --username admin --password admin
     ```
     By default, the `odfesql` command connects to [http://localhost:9200](http://localhost:9200/).
 
@@ -90,7 +90,7 @@ For a list of all available configurations, see [clirc](https://github.com/opend
 2. Index the sample data.
 
     ```
-    curl -H "Content-Type: application/x-ndjson" -POST https://localhost:9200/data/_bulk -u admin:admin --insecure —data-binary "@accounts.json"
+    curl -H "Content-Type: application/x-ndjson" -POST https://localhost:9200/data/_bulk -u admin:admin --insecure --data-binary "@accounts.json"
     ```
 
 

--- a/sql-cli/src/odfe_sql_cli/esconnection.py
+++ b/sql-cli/src/odfe_sql_cli/esconnection.py
@@ -80,7 +80,8 @@ class ESConnection:
         ssl_context.verify_mode = ssl.CERT_NONE
 
         open_distro_client = Elasticsearch(
-            [self.endpoint], http_auth=self.http_auth, verify_certs=False, ssl_context=ssl_context
+            [self.endpoint], http_auth=self.http_auth, verify_certs=False, ssl_context=ssl_context,
+            connection_class=RequestsHttpConnection
         )
 
         return open_distro_client

--- a/sql-cli/tests/test_esconnection.py
+++ b/sql-cli/tests/test_esconnection.py
@@ -130,7 +130,8 @@ class TestExecutor:
             od_test_executor.get_open_distro_client()
 
             mock_es.assert_called_with(
-                [OPEN_DISTRO_ENDPOINT], http_auth=AUTH, verify_certs=False, ssl_context=od_test_executor.ssl_context
+                [OPEN_DISTRO_ENDPOINT], http_auth=AUTH, verify_certs=False, ssl_context=od_test_executor.ssl_context,
+                connection_class=RequestsHttpConnection
             )
 
     def test_get_aes_client(self):


### PR DESCRIPTION
1. Replace "—" with "--".
2. Add "connection_class=RequestsHttpConnection" when create es client.
3. Add "connection_class=RequestsHttpConnection" when test  creating es client.