### PR TITLE
SQL release for Elasticsearch 7.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
 
 buildscript {
     ext {
-        es_version = "7.9.1"
+        es_version = "7.10.0"
     }
 
     repositories {
@@ -43,7 +43,7 @@ repositories {
 }
 
 ext {
-    opendistroVersion = '1.11.0'
+    opendistroVersion = '1.12.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 

--- a/doctest/build.gradle
+++ b/doctest/build.gradle
@@ -1,12 +1,16 @@
+import org.elasticsearch.gradle.testclusters.RunTask
+
 plugins {
     id "com.wiredforcode.spawn" version "0.8.2"
     id 'base'
 }
 
+apply plugin: 'elasticsearch.testclusters'
+
 def path = project(':').projectDir
 // temporary fix, because currently we are under migration to new architecture. Need to run ./gradlew run from
 // plugin module, and will only build ppl in it.
-def plugin_path = project(':plugin').projectDir
+def plugin_path = project(':doctest').projectDir
 
 task bootstrap(type: Exec) {
     inputs.file "$projectDir/bootstrap.sh"
@@ -17,7 +21,7 @@ task bootstrap(type: Exec) {
 
 //evaluationDependsOn(':')
 task startES(type: SpawnProcessTask) {
-    command "${path}/gradlew -p ${plugin_path} run"
+    command "${path}/gradlew -p ${plugin_path} runRestTestCluster"
     ready 'started'
 }
 
@@ -37,3 +41,14 @@ doctest.finalizedBy stopES
 
 build.dependsOn doctest
 clean.dependsOn(cleanBootstrap)
+
+testClusters {
+    docTestCluster {
+        plugin ':plugin'
+        testDistribution = 'oss'
+    }
+}
+tasks.register("runRestTestCluster", RunTask) {
+    description = 'Runs elasticsearch ODFE SQL plugin'
+    useCluster testClusters.docTestCluster;
+}

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClient.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClient.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import lombok.RequiredArgsConstructor;
 import org.apache.logging.log4j.ThreadContext;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.node.NodeClient;
@@ -39,7 +38,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
 
 /** Elasticsearch connection by node client. */
-@RequiredArgsConstructor
 public class ElasticsearchNodeClient implements ElasticsearchClient {
 
   /** Default types and field filter to match all. */
@@ -55,9 +53,19 @@ public class ElasticsearchNodeClient implements ElasticsearchClient {
   private final NodeClient client;
 
   /** Index name expression resolver to get concrete index name. */
-  private final IndexNameExpressionResolver resolver = new IndexNameExpressionResolver();
+  private final IndexNameExpressionResolver resolver;
 
   private static final String SQL_WORKER_THREAD_POOL_NAME = "sql-worker";
+
+  /**
+   * Constructor of ElasticsearchNodeClient.
+   */
+  public ElasticsearchNodeClient(ClusterService clusterService,
+                                 NodeClient client) {
+    this.clusterService = clusterService;
+    this.client = client;
+    this.resolver = new IndexNameExpressionResolver(client.threadPool().getThreadContext());
+  }
 
   /**
    * Get field mappings of index by an index expression. Majority is copied from legacy

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/client/ElasticsearchNodeClientTest.java
@@ -55,6 +55,7 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -83,6 +84,9 @@ class ElasticsearchNodeClientTest {
 
   @Mock
   private SearchHit searchHit;
+
+  @Mock
+  private ThreadContext threadContext;
 
   private ExprTupleValue exprTupleValue = ExprTupleValue.fromExprValueMap(ImmutableMap.of("id",
       new ExprIntegerValue(1)));
@@ -198,6 +202,7 @@ class ElasticsearchNodeClientTest {
   void schedule() {
     ThreadPool threadPool = mock(ThreadPool.class);
     when(nodeClient.threadPool()).thenReturn(threadPool);
+    when(threadPool.getThreadContext()).thenReturn(threadContext);
 
     doAnswer(
         invocation -> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@
 #   permissions and limitations under the License.
 #
 
-version=1.11.0
+version=1.12.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -13,7 +13,7 @@
 #   permissions and limitations under the License.
 #
 
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -17,6 +17,7 @@ tasks.withType(licenseHeaders.class) {
 }
 
 validateNebulaPom.enabled = false
+loggerUsageCheck.enabled = false
 
 repositories {
     mavenCentral()
@@ -63,14 +64,15 @@ compileTestJava {
     }
 }
 
-tasks.integTest.dependsOn(':plugin:bundlePlugin', ':integ-test:integTestWithNewEngine')
-testClusters.integTest {
+testClusters.all {
     testDistribution = 'oss'
-    plugin file(tasks.getByPath(':plugin:bundlePlugin').archiveFile)
+    plugin ":plugin"
 }
 
 // Run only legacy SQL ITs with new SQL engine disabled
-integTest.runner {
+integTest {
+    dependsOn (':plugin:bundlePlugin',':integ-test:integTestWithNewEngine')
+
     systemProperty 'tests.security.manager', 'false'
     systemProperty('project.root', project.projectDir.absolutePath)
 
@@ -95,112 +97,95 @@ integTest.runner {
 // Run PPL ITs and new, legacy and comparison SQL ITs with new SQL engine enabled
 task integTestWithNewEngine(type: RestIntegTestTask) {
     dependsOn ':plugin:bundlePlugin'
-    runner {
-        systemProperty 'tests.security.manager', 'false'
-        systemProperty('project.root', project.projectDir.absolutePath)
 
-        systemProperty "https", System.getProperty("https")
-        systemProperty "user", System.getProperty("user")
-        systemProperty "password", System.getProperty("password")
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty('project.root', project.projectDir.absolutePath)
 
-        // Enable new SQL engine
-        systemProperty 'enableNewEngine', 'true'
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
 
-        // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
-        // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
-        doFirst { systemProperty 'cluster.debug', getDebug() }
+    // Enable new SQL engine
+    systemProperty 'enableNewEngine', 'true'
 
-        if (System.getProperty("test.debug") != null) {
-            jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
-        }
+    // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
+    // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
+    doFirst { systemProperty 'cluster.debug', getDebug() }
 
-        exclude 'com/amazon/opendistroforelasticsearch/sql/doctest/**/*IT.class'
-        exclude 'com/amazon/opendistroforelasticsearch/sql/correctness/**'
-
-        // Explain IT is dependent on internal implementation of old engine so it's not necessary
-        // to run these with new engine and not necessary to make this consistent with old engine.
-        exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/ExplainIT.class'
-        exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/PrettyFormatterIT.class'
-        exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/TermQueryExplainIT.class'
-
-        // Skip old semantic analyzer IT because analyzer in new engine has different behavior
-        exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/QueryAnalysisIT.class'
-
-        // Skip this IT to avoid breaking tests due to inconsistency in JDBC schema
-        exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/AggregationExpressionIT.class'
-
-        // Skip this IT because all assertions are against explain output
-        exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/OrderIT.class'
+    if (System.getProperty("test.debug") != null) {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
     }
+
+    exclude 'com/amazon/opendistroforelasticsearch/sql/doctest/**/*IT.class'
+    exclude 'com/amazon/opendistroforelasticsearch/sql/correctness/**'
+
+    // Explain IT is dependent on internal implementation of old engine so it's not necessary
+    // to run these with new engine and not necessary to make this consistent with old engine.
+    exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/ExplainIT.class'
+    exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/PrettyFormatterIT.class'
+    exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/TermQueryExplainIT.class'
+
+    // Skip old semantic analyzer IT because analyzer in new engine has different behavior
+    exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/QueryAnalysisIT.class'
+
+    // Skip this IT to avoid breaking tests due to inconsistency in JDBC schema
+    exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/AggregationExpressionIT.class'
+
+    // Skip this IT because all assertions are against explain output
+    exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/OrderIT.class'
 }
 
-testClusters.integTestWithNewEngine {
-    testDistribution = 'oss'
-    plugin file(tasks.getByPath(':plugin:bundlePlugin').archiveFile)
-}
+
 
 
 task docTest(type: RestIntegTestTask) {
     dependsOn ':plugin:bundlePlugin'
-    runner {
-        systemProperty 'tests.security.manager', 'false'
-        systemProperty('project.root', project.projectDir.absolutePath)
 
-        // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
-        // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
-        doFirst { systemProperty 'cluster.debug', getDebug()}
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty('project.root', project.projectDir.absolutePath)
 
-        if (System.getProperty("test.debug") != null) {
-            jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
-        }
+    // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
+    // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
+    doFirst { systemProperty 'cluster.debug', getDebug()}
 
-        include 'com/amazon/opendistroforelasticsearch/sql/doctest/**/*IT.class'
-        exclude 'com/amazon/opendistroforelasticsearch/sql/correctness/**/*IT.class'
-        exclude 'com/amazon/opendistroforelasticsearch/sql/ppl/**/*IT.class'
-        exclude 'com/amazon/opendistroforelasticsearch/sql/sql/**/*IT.class'
-        exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/**/*IT.class'
+    if (System.getProperty("test.debug") != null) {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
     }
-}
 
-testClusters.docTest {
-    testDistribution = 'oss'
-    plugin file(tasks.getByPath(':plugin:bundlePlugin').archiveFile)
+    include 'com/amazon/opendistroforelasticsearch/sql/doctest/**/*IT.class'
+    exclude 'com/amazon/opendistroforelasticsearch/sql/correctness/**/*IT.class'
+    exclude 'com/amazon/opendistroforelasticsearch/sql/ppl/**/*IT.class'
+    exclude 'com/amazon/opendistroforelasticsearch/sql/sql/**/*IT.class'
+    exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/**/*IT.class'
 }
-
 
 task comparisonTest(type: RestIntegTestTask) {
     dependsOn ':plugin:bundlePlugin'
-    runner {
-        systemProperty 'tests.security.manager', 'false'
-        systemProperty('project.root', project.projectDir.absolutePath)
 
-        // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
-        // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
-        doFirst { systemProperty 'cluster.debug', getDebug()}
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty('project.root', project.projectDir.absolutePath)
 
-        if (System.getProperty("test.debug") != null) {
-            jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
-        }
+    // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
+    // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
+    doFirst { systemProperty 'cluster.debug', getDebug()}
 
-        include 'com/amazon/opendistroforelasticsearch/sql/correctness/**/*IT.class'
-        exclude 'com/amazon/opendistroforelasticsearch/sql/doctest/**/*IT.class'
-        exclude 'com/amazon/opendistroforelasticsearch/sql/ppl/**/*IT.class'
-        exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/**/*IT.class'
-
-        // Enable logging output to console
-        testLogging.showStandardStreams true
-
-        // Pass down system properties to IT class
-        systemProperty "esHost", System.getProperty("esHost")
-        systemProperty "dbUrl", System.getProperty("dbUrl")
-        systemProperty "otherDbUrls", System.getProperty("otherDbUrls")
-        systemProperty "queries", System.getProperty("queries")
+    if (System.getProperty("test.debug") != null) {
+        jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
     }
-}
 
-testClusters.comparisonTest {
-    testDistribution = 'oss'
-    plugin file(tasks.getByPath(':plugin:bundlePlugin').archiveFile)
+    include 'com/amazon/opendistroforelasticsearch/sql/correctness/**/*IT.class'
+    exclude 'com/amazon/opendistroforelasticsearch/sql/doctest/**/*IT.class'
+    exclude 'com/amazon/opendistroforelasticsearch/sql/ppl/**/*IT.class'
+    exclude 'com/amazon/opendistroforelasticsearch/sql/legacy/**/*IT.class'
+
+    // Enable logging output to console
+    testLogging.showStandardStreams true
+
+    // Pass down system properties to IT class
+    systemProperty "esHost", System.getProperty("esHost")
+    systemProperty "dbUrl", System.getProperty("dbUrl")
+    systemProperty "otherDbUrls", System.getProperty("otherDbUrls")
+    systemProperty "queries", System.getProperty("queries")
 }
 
 task compileJdbc(type:Exec) {

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -89,7 +89,7 @@ dependencies {
 
     testCompile group: 'org.hamcrest', name: 'hamcrest-core', version:'2.2'
     // testCompile group: 'com.alibaba', name: 'fastjson', version:'1.2.56'
-    testCompile group: 'org.mockito', name: 'mockito-core', version:'2.23.4'
+    testCompile group: 'org.mockito', name: 'mockito-core', version:'3.5.0'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: "org.elasticsearch.client", name: 'transport', version: "${es_version}"
 

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/query/maker/AggMaker.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/query/maker/AggMaker.java
@@ -48,8 +48,8 @@ import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuil
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGridAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
-import org.elasticsearch.search.aggregations.bucket.histogram.ExtendedBounds;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.LongBounds;
 import org.elasticsearch.search.aggregations.bucket.nested.ReverseNestedAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.DateRangeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregationBuilder;
@@ -586,7 +586,7 @@ public class AggMaker {
                     case "extended_bounds":
                         String[] bounds = value.split(":");
                         if (bounds.length == 2) {
-                            dateHistogram.extendedBounds(new ExtendedBounds(bounds[0], bounds[1]));
+                            dateHistogram.extendedBounds(new LongBounds(bounds[0], bounds[1]));
                         }
                         break;
 

--- a/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryActionTest.java
+++ b/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryActionTest.java
@@ -21,12 +21,16 @@ import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlAct
 import static com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSqlAction.QUERY_API_ENDPOINT;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.when;
 
 import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.sql.domain.SQLQueryRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.json.JSONObject;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -38,11 +42,20 @@ public class RestSQLQueryActionTest {
   @Mock
   private ClusterService clusterService;
 
-  @Mock
   private NodeClient nodeClient;
 
   @Mock
+  private ThreadPool threadPool;
+
+  @Mock
   private Settings settings;
+
+  @Before
+  public void setup() {
+    nodeClient = new NodeClient(org.elasticsearch.common.settings.Settings.EMPTY, threadPool);
+    when(threadPool.getThreadContext())
+        .thenReturn(new ThreadContext(org.elasticsearch.common.settings.Settings.EMPTY));
+  }
 
   @Test
   public void handleQueryThatCanSupport() {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -24,7 +24,7 @@ esplugin {
 
 javadoc.enabled = false
 test.enabled = false
-integTest.enabled = false
+loggerUsageCheck.enabled = false
 dependencyLicenses.enabled = false
 thirdPartyAudit.enabled = false
 
@@ -129,5 +129,4 @@ afterEvaluate {
         archiveName "${packageName}-${version}.deb"
         dependsOn 'assemble'
     }
-
 }


### PR DESCRIPTION
## Major breaking change
1. [The runner is in RestIntegTestTask has been moved to RestTestBasePlugin](https://github.com/elastic/elasticsearch/pull/60261). The new introduced RestTestBasePlugin will apply the testClusters defined in TestClustersPlugin to all the Task inherit RestIntegTestTask. Thus, we defined the testClusters  
2. [Remove integTest task from PluginBuildPlugin](https://github.com/elastic/elasticsearch/pull/61879). 

## Description of changes
1. Define the testClusters which will be used as runner for all the test tasks.
```
testClusters.all {	
    testDistribution = 'oss'
    plugin ":plugin"
}
```
2.Originally, the docTest use testClusters.integTest to run doc test. We define the new testCluster.docTestCluster for docTest and inherent the RunTask.
```
testClusters {
    docTestCluster {
        plugin ':plugin'
        testDistribution = 'oss'
    }
}
tasks.register("runRestTestCluster", RunTask) {
    description = 'Runs elasticsearch ODFE SQL plugin'
    useCluster testClusters.docTestCluster;
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
