### PR TITLE
Update Workflows for Workbench

### DIFF
--- a/.github/workflows/sql-workbench-release-workflow.yml
+++ b/.github/workflows/sql-workbench-release-workflow.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+env: 
+  PLUGIN_NAME: opendistroQueryWorkbenchKibana
+  OD_VERSION: 1.12.0.0
+
 jobs:
 
   build:
@@ -34,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.22.0'
+          node-version: '10.22.1'
 
       - name: Move Workbench to Plugins Dir
         run: |
@@ -52,6 +56,7 @@ jobs:
         run: |
           cd kibana/plugins/workbench
           yarn build
+          mv ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
           artifact=`ls ./build/*.zip`
 
           aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/kibana-plugins/opendistro-query-workbench/

--- a/.github/workflows/sql-workbench-test-and-build-workflow.yml
+++ b/.github/workflows/sql-workbench-test-and-build-workflow.yml
@@ -2,6 +2,10 @@ name: SQL Workbench Test and Build
 
 on: [pull_request, push]
 
+env: 
+  PLUGIN_NAME: opendistroQueryWorkbenchKibana
+  OD_VERSION: 1.12.0.0
+
 jobs:
 
   build:
@@ -20,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.22.0'
+          node-version: '10.22.1'
       - name: Move Workbench to Plugins Dir
         run: |
           mkdir kibana/plugins
@@ -39,6 +43,7 @@ jobs:
         run: |
           cd kibana/plugins/workbench
           yarn build
+          mv ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OD_VERSION }}.zip
       - name: Upload Artifact
         uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated node version and workflow for `test-and-build` and `release` actions for Query Workbench to allow all actions to pass after Workbench migration to v7.10

Related: #840 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
