### PR TITLE
Config the default locale for gradle as en_US

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@
 #
 
 version=1.12.0
+org.gradle.jvmargs=-Duser.language=en -Duser.country=US


### PR DESCRIPTION
*Issue #, if available:* #824 

*Description of changes:*
Test in Linux with setting "LANG=ja_JP.UTF-8". The gradle will honer the configured setting en_US now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
