### PR TITLE
Fix issue: sort order keyword is case sensitive

### DIFF
--- a/integ-test/src/test/resources/correctness/bugfixes/852.txt
+++ b/integ-test/src/test/resources/correctness/bugfixes/852.txt
@@ -1,0 +1,6 @@
+SELECT AvgTicketPrice FROM kibana_sample_data_flights ORDER BY AvgTicketPrice DESC
+SELECT AvgTicketPrice FROM kibana_sample_data_flights ORDER BY AvgTicketPrice desc
+SELECT AvgTicketPrice FROM kibana_sample_data_flights ORDER BY AvgTicketPrice DeSc
+SELECT AvgTicketPrice FROM kibana_sample_data_flights ORDER BY AvgTicketPrice ASC
+SELECT AvgTicketPrice FROM kibana_sample_data_flights ORDER BY AvgTicketPrice asc
+SELECT AvgTicketPrice FROM kibana_sample_data_flights ORDER BY AvgTicketPrice AsC

--- a/integ-test/src/test/resources/correctness/queries/orderby.txt
+++ b/integ-test/src/test/resources/correctness/queries/orderby.txt
@@ -1,6 +1,8 @@
 SELECT FlightNum FROM kibana_sample_data_flights ORDER BY FlightNum
 SELECT FlightNum FROM kibana_sample_data_flights ORDER BY FlightNum ASC
 SELECT FlightNum FROM kibana_sample_data_flights ORDER BY FlightNum DESC
+SELECT FlightNum FROM kibana_sample_data_flights ORDER BY FlightNum asc
+SELECT FlightNum FROM kibana_sample_data_flights ORDER BY FlightNum desc
 SELECT FlightNum, AvgTicketPrice FROM kibana_sample_data_flights ORDER BY FlightNum, AvgTicketPrice
 SELECT FlightNum, AvgTicketPrice FROM kibana_sample_data_flights ORDER BY FlightNum DESC, AvgTicketPrice
 SELECT FlightNum, AvgTicketPrice FROM kibana_sample_data_flights ORDER BY FlightNum, AvgTicketPrice DESC

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/context/QuerySpecification.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/context/QuerySpecification.java
@@ -219,7 +219,7 @@ public class QuerySpecification {
       if (ctx == null) {
         return null;
       }
-      return SortOrder.valueOf(ctx.getText());
+      return SortOrder.valueOf(ctx.getText().toUpperCase());
     }
 
     private NullOrder visitNullOrderClause(TerminalNode first, TerminalNode last) {

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
@@ -416,6 +416,29 @@ class AstBuilderTest {
   }
 
   @Test
+  public void can_build_order_by_sort_order_keyword_insensitive() {
+    assertEquals(
+        project(
+            sort(
+                relation("test"),
+                field("age",
+                    argument("asc", booleanLiteral(true)))),
+            alias("age", qualifiedName("age"))),
+        buildAST("SELECT age FROM test ORDER BY age ASC")
+    );
+
+    assertEquals(
+        project(
+            sort(
+                relation("test"),
+                field("age",
+                    argument("asc", booleanLiteral(true)))),
+            alias("age", qualifiedName("age"))),
+        buildAST("SELECT age FROM test ORDER BY age asc")
+    );
+  }
+
+  @Test
   public void can_build_from_subquery() {
     assertEquals(
         project(


### PR DESCRIPTION
*Issue #, if available:*
#852 

*Description of changes:*
- Replaced the sort order keyword to upper case when collecting the query information in `QuerySpecification`
- Added tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
