### PR TITLE
For ODFE 1.12 change position for sql workbench plugin

### DIFF
--- a/workbench/public/plugin.ts
+++ b/workbench/public/plugin.ts
@@ -23,8 +23,13 @@ export class WorkbenchPlugin implements Plugin<WorkbenchPluginSetup, WorkbenchPl
     core.application.register({
       id: 'opendistro-query-workbench',
       title: PLUGIN_NAME,
-      category: DEFAULT_APP_CATEGORIES.kibana,
-      order: 8010,
+      category: {
+        id: 'odfe',
+        label: 'Open Distro for Elasticsearch',
+        euiIconType: 'logoKibana',
+        order: 2000,
+      },
+      order: 1000,
       async mount(params: AppMountParameters) {
         // Load application bundle
         const { renderApp } = await import('./application');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change position of SQL workbench plugin in side bar. 
The order is designed by UX designer and in step of 1000(https://github.com/elastic/kibana/blob/master/docs/development/core/public/kibana-plugin-core-public.appcategory.md). 
The sql workbench is the first in the row. So I put 1000 for the order number. 
![image (4)](https://user-images.githubusercontent.com/53279298/100165385-03818700-2e6f-11eb-9061-2e95ece2f5d1.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
