### PR TITLE
Revert java version in jdbc release workflow

### DIFF
--- a/.github/workflows/sql-jdbc-release-workflow.yml
+++ b/.github/workflows/sql-jdbc-release-workflow.yml
@@ -9,7 +9,7 @@ jobs:
   Release-SQL-JDBC:
     strategy:
       matrix:
-        java: [14]
+        java: [10]
 
     name: Build and Release JDBC Plugin
     runs-on: ubuntu-latest


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- revert java version to 10 in jdbc release workflow from #838, as `java.xml.bind` is removed in java 11, using java 14 won't work

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
