### PR TITLE
Add Error Message for Explain and Run

### DIFF
--- a/workbench/public/components/Main/main.tsx
+++ b/workbench/public/components/Main/main.tsx
@@ -338,8 +338,6 @@ export class Main extends React.Component<MainProps, MainState> {
         const results: ResponseDetail<string>[] = response.map((response) =>
           this.processQueryResponse(response as IHttpResponse<ResponseData>)
         );
-        console.log('responsePromise is', responsePromise);
-        console.log('results is', results);
         const resultTable: ResponseDetail<QueryResult>[] = getQueryResultsForTable(results);
         this.setState(
           {

--- a/workbench/public/components/Main/main.tsx
+++ b/workbench/public/components/Main/main.tsx
@@ -34,6 +34,7 @@ import { CoreStart } from 'kibana/public';
 interface ResponseData {
   ok: boolean;
   resp: any;
+  body: any;
 }
 
 export interface ResponseDetail<T> {
@@ -94,6 +95,12 @@ interface MainState {
 
 const SUCCESS_MESSAGE = 'Success';
 
+const errorQueryResponse = (queryResultResponseDetail: any) => {
+  let errorMessage = queryResultResponseDetail.errorMessage + ', this query is not runnable. \n \n' +
+    queryResultResponseDetail.data;
+  return errorMessage;
+}
+
 // It gets column names and row values to display in a Table from the json API response
 export function getQueryResultsForTable(
   queryResults: ResponseDetail<string>[]
@@ -103,7 +110,7 @@ export function getQueryResultsForTable(
       if (!queryResultResponseDetail.fulfilled) {
         return {
           fulfilled: queryResultResponseDetail.fulfilled,
-          errorMessage: queryResultResponseDetail.errorMessage + ', this query is not runnable.',
+          errorMessage: errorQueryResponse(queryResultResponseDetail),
         };
       } else {
         let databaseRecords: { [key: string]: any }[] = [];
@@ -254,7 +261,7 @@ export class Main extends React.Component<MainProps, MainState> {
       return {
         fulfilled: false,
         errorMessage: response.data.resp,
-        data: '',
+        data: response.data.body,
       };
     }
 
@@ -331,6 +338,8 @@ export class Main extends React.Component<MainProps, MainState> {
         const results: ResponseDetail<string>[] = response.map((response) =>
           this.processQueryResponse(response as IHttpResponse<ResponseData>)
         );
+        console.log('responsePromise is', responsePromise);
+        console.log('results is', results);
         const resultTable: ResponseDetail<QueryResult>[] = getQueryResultsForTable(results);
         this.setState(
           {

--- a/workbench/public/components/Main/main.tsx
+++ b/workbench/public/components/Main/main.tsx
@@ -103,7 +103,7 @@ export function getQueryResultsForTable(
       if (!queryResultResponseDetail.fulfilled) {
         return {
           fulfilled: queryResultResponseDetail.fulfilled,
-          errorMessage: queryResultResponseDetail.errorMessage,
+          errorMessage: queryResultResponseDetail.errorMessage + ', this query is not runnable.',
         };
       } else {
         let databaseRecords: { [key: string]: any }[] = [];
@@ -332,7 +332,7 @@ export class Main extends React.Component<MainProps, MainState> {
           this.processQueryResponse(response as IHttpResponse<ResponseData>)
         );
         const resultTable: ResponseDetail<QueryResult>[] = getQueryResultsForTable(results);
-
+        console.log('resutlTable is', resultTable);
         this.setState(
           {
             queries: queries,

--- a/workbench/public/components/Main/main.tsx
+++ b/workbench/public/components/Main/main.tsx
@@ -332,7 +332,6 @@ export class Main extends React.Component<MainProps, MainState> {
           this.processQueryResponse(response as IHttpResponse<ResponseData>)
         );
         const resultTable: ResponseDetail<QueryResult>[] = getQueryResultsForTable(results);
-        console.log('resutlTable is', resultTable);
         this.setState(
           {
             queries: queries,

--- a/workbench/public/components/Main/main.tsx
+++ b/workbench/public/components/Main/main.tsx
@@ -249,6 +249,15 @@ export class Main extends React.Component<MainProps, MainState> {
     };
   }
 
+  formatQueryErrorBody(data: any) {
+    let prettyErrorMessage = "";
+    prettyErrorMessage += 'reason: ' + data.errorReason + '\n';
+    prettyErrorMessage += 'details: ' + data.errorDetails + '\n';
+    prettyErrorMessage += 'type: ' + data.errorType + '\n';
+    prettyErrorMessage += 'status: ' + data.status;
+    return prettyErrorMessage;
+  }
+
   processQueryResponse(response: IHttpResponse<ResponseData>): ResponseDetail<string> {
     if (!response) {
       return {
@@ -261,7 +270,7 @@ export class Main extends React.Component<MainProps, MainState> {
       return {
         fulfilled: false,
         errorMessage: response.data.resp,
-        data: response.data.body,
+        data: this.formatQueryErrorBody(response.data),
       };
     }
 

--- a/workbench/public/components/PPLPage/PPLPage.tsx
+++ b/workbench/public/components/PPLPage/PPLPage.tsx
@@ -69,6 +69,23 @@ export class PPLPage extends React.Component<PPLPageProps, PPLPageState> {
     const closeModal = () => this.setIsModalVisible(false);
     const showModal = () => this.setIsModalVisible(true);
 
+    const pplTranslationsNotEmpty = () => {
+      if (this.props.pplTranslations.length > 0) {
+        return this.props.pplTranslations[0].fulfilled;
+      }
+      return false;
+    }
+
+    const showExplainErrorMessage = () => {
+      return this.props.pplTranslations.map((queryTranslation: any) => JSON.stringify(
+        queryTranslation.errorMessage + ": This query is not explainable", null, 2
+      ));
+    }
+
+    const explainContent = pplTranslationsNotEmpty()
+    ? this.props.pplTranslations.map((queryTranslation: any) => JSON.stringify(queryTranslation.data, null, 2)).join("\n")
+    : showExplainErrorMessage();
+
     let modal;
 
     if (this.state.isModalVisible) {
@@ -85,7 +102,7 @@ export class PPLPage extends React.Component<PPLPageProps, PPLPageState> {
                 fontSize="m"
                 isCopyable
               >
-                {this.props.pplTranslations.map((queryTranslation: any) => JSON.stringify(queryTranslation.data, null, 2)).join("\n")}
+                {explainContent}
               </EuiCodeBlock>
             </EuiModalBody>
 

--- a/workbench/public/components/PPLPage/PPLPage.tsx
+++ b/workbench/public/components/PPLPage/PPLPage.tsx
@@ -78,7 +78,7 @@ export class PPLPage extends React.Component<PPLPageProps, PPLPageState> {
 
     const showExplainErrorMessage = () => {
       return this.props.pplTranslations.map((queryTranslation: any) => JSON.stringify(
-        queryTranslation.errorMessage + ": This query is not explainable", null, 2
+        queryTranslation.errorMessage + ": This query is not explainable.", null, 2
       ));
     }
 

--- a/workbench/public/components/SQLPage/SQLPage.tsx
+++ b/workbench/public/components/SQLPage/SQLPage.tsx
@@ -48,7 +48,7 @@ interface SQLPageProps {
 interface SQLPageState {
   sqlQuery: string,
   translation: string,
-  isModalVisible: boolean
+  isModalVisible: boolean,
 }
 
 export class SQLPage extends React.Component<SQLPageProps, SQLPageState> {
@@ -57,7 +57,7 @@ export class SQLPage extends React.Component<SQLPageProps, SQLPageState> {
     this.state = {
       sqlQuery: this.props.sqlQuery,
       translation: "",
-      isModalVisible: false
+      isModalVisible: false,
     };
   }
 
@@ -71,6 +71,23 @@ export class SQLPage extends React.Component<SQLPageProps, SQLPageState> {
 
     const closeModal = () => this.setIsModalVisible(false);
     const showModal = () => this.setIsModalVisible(true);
+
+    const sqlTranslationsNotEmpty = () => {
+      if (this.props.sqlTranslations.length > 0) {
+        return this.props.sqlTranslations[0].fulfilled;
+      }
+      return false;
+    }
+
+    const showExplainErrorMessage = () => {
+      return this.props.sqlTranslations.map((queryTranslation: any) => JSON.stringify(
+        queryTranslation.errorMessage + ": This query is not explainable", null, 2
+      ));
+    }
+
+    const explainContent = sqlTranslationsNotEmpty()
+    ? this.props.sqlTranslations.map((queryTranslation: any) => JSON.stringify(queryTranslation.data, null, 2)).join("\n")
+    : showExplainErrorMessage();
 
     let modal;
 
@@ -88,7 +105,7 @@ export class SQLPage extends React.Component<SQLPageProps, SQLPageState> {
                 fontSize="m"
                 isCopyable
               >
-                {this.props.sqlTranslations.map((queryTranslation: any) => JSON.stringify(queryTranslation.data, null, 2)).join("\n")}
+                {explainContent}
               </EuiCodeBlock>
             </EuiModalBody>
 
@@ -148,7 +165,10 @@ export class SQLPage extends React.Component<SQLPageProps, SQLPageState> {
               this.props.onTranslate(this.props.sqlQuery)
             }
           >
-            <EuiButton className="sql-editor-button" onClick={showModal}>
+            <EuiButton
+              className="sql-editor-button"
+              onClick={showModal}
+            >
               Explain
             </EuiButton>
             {modal}

--- a/workbench/public/components/SQLPage/SQLPage.tsx
+++ b/workbench/public/components/SQLPage/SQLPage.tsx
@@ -81,7 +81,7 @@ export class SQLPage extends React.Component<SQLPageProps, SQLPageState> {
 
     const showExplainErrorMessage = () => {
       return this.props.sqlTranslations.map((queryTranslation: any) => JSON.stringify(
-        queryTranslation.errorMessage + ": This query is not explainable", null, 2
+        queryTranslation.errorMessage + ": This query is not explainable.", null, 2
       ));
     }
 

--- a/workbench/public/components/SQLPage/SQLPage.tsx
+++ b/workbench/public/components/SQLPage/SQLPage.tsx
@@ -48,7 +48,7 @@ interface SQLPageProps {
 interface SQLPageState {
   sqlQuery: string,
   translation: string,
-  isModalVisible: boolean,
+  isModalVisible: boolean
 }
 
 export class SQLPage extends React.Component<SQLPageProps, SQLPageState> {
@@ -57,7 +57,7 @@ export class SQLPage extends React.Component<SQLPageProps, SQLPageState> {
     this.state = {
       sqlQuery: this.props.sqlQuery,
       translation: "",
-      isModalVisible: false,
+      isModalVisible: false
     };
   }
 

--- a/workbench/server/services/QueryService.ts
+++ b/workbench/server/services/QueryService.ts
@@ -41,11 +41,15 @@ export default class QueryService {
       };
     } catch (err) {
       console.log(err);
+      const errorObj = JSON.parse(err.body);
       return {
         data: {
           ok: false,
           resp: err.message,
-          body: err.body,
+          errorReason: errorObj.error.reason,
+          errorDetails: errorObj.error.details,
+          errorType: errorObj.error.type,
+          status: errorObj.status
         },
       };
     }

--- a/workbench/server/services/QueryService.ts
+++ b/workbench/server/services/QueryService.ts
@@ -45,6 +45,7 @@ export default class QueryService {
         data: {
           ok: false,
           resp: err.message,
+          body: err.body,
         },
       };
     }

--- a/workbench/server/services/TranslateService.ts
+++ b/workbench/server/services/TranslateService.ts
@@ -41,7 +41,6 @@ export default class TranslateService {
       };
       return ret;
     } catch (err) {
-      console.log(err);
       return {
         data: {
           ok: false,

--- a/workbench/server/services/TranslateService.ts
+++ b/workbench/server/services/TranslateService.ts
@@ -41,6 +41,7 @@ export default class TranslateService {
       };
       return ret;
     } catch (err) {
+      console.log(err);
       return {
         data: {
           ok: false,


### PR DESCRIPTION
*Issue #, if available:*
#863 
*Description of changes:*
* Added a generic error message in `Explain` for invalid queries. The error message consists of `<API Response>: this query is not explainable.`
* Added `this query is not runnable` to error messages for `Run` on invalid queries. 

Invalid `Explain` on SQL: 
![Screen Shot 2020-12-01 at 12 25 09 PM](https://user-images.githubusercontent.com/53581635/100802046-b73dc600-33dd-11eb-8ce3-472a6cb96313.png)

Invalid `Explain` on PPL: 
![Screen Shot 2020-12-01 at 12 38 00 PM](https://user-images.githubusercontent.com/53581635/100802065-bad14d00-33dd-11eb-84b0-7495dfcb8482.png)

Invalid `Run` on SQL: 
![Screen Shot 2020-12-01 at 1 14 26 PM](https://user-images.githubusercontent.com/53581635/100802092-c3298800-33dd-11eb-97cd-8810c9d0895d.png)

Invalid `Run` on PPL: 
![Screen Shot 2020-12-01 at 1 14 41 PM](https://user-images.githubusercontent.com/53581635/100802140-d2a8d100-33dd-11eb-9355-159e6bda5e87.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
