### PR TITLE
fix for odbc build failure

### DIFF
--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -121,7 +121,7 @@ jobs:
     #    name: windows-test-results
     #    path: $CI_OUTPUT_PATH/test
   build-windows64:
-    runs-on: win19/20201116.1
+    runs-on: windows-2019/20201116.1
     defaults:
       run:
         working-directory: sql-odbc

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -121,7 +121,7 @@ jobs:
     #    name: windows-test-results
     #    path: $CI_OUTPUT_PATH/test
   build-windows64:
-    runs-on: windows-2019/20201116.1
+    runs-on: windows-2019 | win19/20201116.1
     defaults:
       run:
         working-directory: sql-odbc

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -121,11 +121,12 @@ jobs:
     #    name: windows-test-results
     #    path: $CI_OUTPUT_PATH/test
   build-windows64:
-    runs-on: windows-2019 | win19/20201116.1
+    runs-on: windows-2019
     defaults:
       run:
         working-directory: sql-odbc
     steps:
+    - uses: actions/virtual-environments@win19/20201116.1
     - uses: actions/checkout@v1
     - name: add-msbuild-to-path
       uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -121,7 +121,7 @@ jobs:
     #    name: windows-test-results
     #    path: $CI_OUTPUT_PATH/test
   build-windows64:
-    runs-on: windows-2019
+    runs-on: windows-2016
     defaults:
       run:
         working-directory: sql-odbc

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -127,7 +127,8 @@ jobs:
         working-directory: sql-odbc
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/virtual-environments@win19/20201116.1
+    - name: Get specific version CMake, v3.18.3
+      uses: lukka/get-cmake@v3.18.3
     - name: add-msbuild-to-path
       uses: microsoft/setup-msbuild@v1.0.2
     - name: configure-and-build-driver

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -126,8 +126,8 @@ jobs:
       run:
         working-directory: sql-odbc
     steps:
-    - uses: actions/virtual-environments@win19/20201116.1
     - uses: actions/checkout@v1
+    - uses: actions/virtual-environments@win19/20201116.1
     - name: add-msbuild-to-path
       uses: microsoft/setup-msbuild@v1.0.2
     - name: configure-and-build-driver

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -121,7 +121,7 @@ jobs:
     #    name: windows-test-results
     #    path: $CI_OUTPUT_PATH/test
   build-windows64:
-    runs-on: windows-latest
+    runs-on: windows-2019
     defaults:
       run:
         working-directory: sql-odbc

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -123,7 +123,7 @@ jobs:
     #    name: windows-test-results
     #    path: $CI_OUTPUT_PATH/test
   build-windows64:
-    runs-on: windows-2019
+    runs-on: windows-latest
     defaults:
       run:
         working-directory: sql-odbc

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -121,7 +121,7 @@ jobs:
     #    name: windows-test-results
     #    path: $CI_OUTPUT_PATH/test
   build-windows64:
-    runs-on: windows-2016
+    runs-on: win19/20201116.1
     defaults:
       run:
         working-directory: sql-odbc

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -84,6 +84,8 @@ jobs:
         working-directory: sql-odbc
     steps:
     - uses: actions/checkout@v1
+    - name: Get specific version CMake, v3.18.3
+      uses: lukka/get-cmake@v3.18.3
     - name: add-msbuild-to-path
       uses: microsoft/setup-msbuild@v1.0.2
     - name: configure-and-build-driver

--- a/.github/workflows/sql-odbc-release-workflow.yml
+++ b/.github/workflows/sql-odbc-release-workflow.yml
@@ -89,6 +89,8 @@ jobs:
         working-directory: sql-odbc
     steps:
       - uses: actions/checkout@v1
+      - name: Get specific version CMake, v3.18.3
+        uses: lukka/get-cmake@v3.18.3
       - name: add-msbuild-to-path
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Configure AWS Credentials
@@ -135,6 +137,8 @@ jobs:
         working-directory: sql-odbc
     steps:
       - uses: actions/checkout@v1
+      - name: Get specific version CMake, v3.18.3
+        uses: lukka/get-cmake@v3.18.3
       - name: add-msbuild-to-path
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Configure AWS Credentials


### PR DESCRIPTION
*Issue  #884*

*Description of changes:*
With the latest release of GitHub Actions Virtual Environments, CMake version was upgraded to 3.19 and because of it, the AWS SDK build failed.

- Added CMake 3.18.3.
- used [get-cmake](https://github.com/marketplace/actions/get-cmake?version=v3.18.3). It is licensed under the MIT License.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
