### PR TITLE
Add basic PPL support to CLI for the purpose of doctest

### DIFF
--- a/.github/workflows/sql-cli-test-and-build-workflow.yml
+++ b/.github/workflows/sql-cli-test-and-build-workflow.yml
@@ -32,11 +32,11 @@ jobs:
         run: |
           sudo add-apt-repository ppa:openjdk-r/ppa
           sudo apt update
-          sudo apt install openjdk-14-jdk
+          sudo apt install openjdk-13-jdk
           sudo apt install unzip
-          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.10.0-amd64.deb
+          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.9.1-amd64.deb
           sudo dpkg -i elasticsearch-oss-7.10.0-amd64.deb
-          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/opendistro_sql-1.12.0.0.zip
+          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/opendistro_sql-1.11.0.0.zip
           sudo systemctl start elasticsearch.service
 
       - name: Run Tox Testing

--- a/.github/workflows/sql-cli-test-and-build-workflow.yml
+++ b/.github/workflows/sql-cli-test-and-build-workflow.yml
@@ -34,9 +34,9 @@ jobs:
           sudo apt update
           sudo apt install openjdk-13-jdk
           sudo apt install unzip
-          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.9.1-amd64.deb
-          sudo dpkg -i elasticsearch-oss-7.9.1-amd64.deb
-          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/opendistro_sql-1.11.0.0.zip
+          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.10.0-amd64.deb
+          sudo dpkg -i elasticsearch-oss-7.10.0-amd64.deb
+          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/opendistro_sql-1.12.0.0.zip
           sudo systemctl start elasticsearch.service
 
       - name: Run Tox Testing

--- a/.github/workflows/sql-cli-test-and-build-workflow.yml
+++ b/.github/workflows/sql-cli-test-and-build-workflow.yml
@@ -35,7 +35,7 @@ jobs:
           sudo apt install openjdk-13-jdk
           sudo apt install unzip
           wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.9.1-amd64.deb
-          sudo dpkg -i elasticsearch-oss-7.10.0-amd64.deb
+          sudo dpkg -i elasticsearch-oss-7.9.1-amd64.deb
           sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/opendistro_sql-1.11.0.0.zip
           sudo systemctl start elasticsearch.service
 

--- a/.github/workflows/sql-cli-test-and-build-workflow.yml
+++ b/.github/workflows/sql-cli-test-and-build-workflow.yml
@@ -32,11 +32,11 @@ jobs:
         run: |
           sudo add-apt-repository ppa:openjdk-r/ppa
           sudo apt update
-          sudo apt install openjdk-11-jdk
+          sudo apt install openjdk-14-jdk
           sudo apt install unzip
-          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.6.1-amd64.deb
-          sudo dpkg -i elasticsearch-oss-7.6.1-amd64.deb
-          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/opendistro_sql-1.6.0.0.zip
+          wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.10.0-amd64.deb
+          sudo dpkg -i elasticsearch-oss-7.10.0-amd64.deb
+          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/opendistro_sql-1.12.0.0.zip
           sudo systemctl start elasticsearch.service
 
       - name: Run Tox Testing

--- a/.github/workflows/sql-cli-test-and-build-workflow.yml
+++ b/.github/workflows/sql-cli-test-and-build-workflow.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt install unzip
           wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.9.1-amd64.deb
           sudo dpkg -i elasticsearch-oss-7.9.1-amd64.deb
-          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/opendistro_sql-1.11.0.0.zip
+          sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch https://d3g5vo6xdbdb9a.cloudfront.net/downloads/elasticsearch-plugins/opendistro-sql/opendistro_sql-1.11.0.0.zip
           sudo systemctl start elasticsearch.service
 
       - name: Run Tox Testing

--- a/doctest/bootstrap.sh
+++ b/doctest/bootstrap.sh
@@ -22,4 +22,4 @@ fi
 $DIR/.venv/bin/pip install -U pip setuptools wheel
 $DIR/.venv/bin/pip install -r $DIR/requirements.txt
 # Temporary fix, add odfe-sql-cli dependency into requirements.txt once we have released cli to PyPI
-$DIR/.venv/bin/pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple odfe-sql-cli==0.0.1
+$DIR/.venv/bin/pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple odfe-sql-cli==0.0.2

--- a/sql-cli/README.md
+++ b/sql-cli/README.md
@@ -118,6 +118,7 @@ Run single query from command line with options
 
 ## CLI Options
 
+* `-l`: Query language option. Available options are [sql, ppl]. By default it's using sql.
 * `-p`: always use pager to display output
 * `--clirc`: provide path of config file to load
 

--- a/sql-cli/setup.py
+++ b/sql-cli/setup.py
@@ -24,7 +24,7 @@ install_requirements = [
     "cli_helpers[styles] == 1.2.1",
     "elasticsearch == 7.5.1",
     "pyfiglet == 0.8.post1",
-    "boto3 == 1.9.181",
+    "boto3 == 1.16.29",
     "requests-aws4auth == 0.9",
 ]
 

--- a/sql-cli/src/odfe_sql_cli/main.py
+++ b/sql-cli/src/odfe_sql_cli/main.py
@@ -71,8 +71,27 @@ click.disable_unicode_literals_warning = True
     default=False,
     help="Use AWS sigV4 to connect to AWS ELasticsearch domain",
 )
-def cli(endpoint, query, explain, clirc, result_format, is_vertical, username, password, always_use_pager,
-        use_aws_authentication):
+@click.option(
+    "-l",
+    "--language",
+    "query_language",
+    type=click.STRING,
+    default="sql",
+    help="SQL OR PPL",
+)
+def cli(
+    endpoint,
+    query,
+    explain,
+    clirc,
+    result_format,
+    is_vertical,
+    username,
+    password,
+    always_use_pager,
+    use_aws_authentication,
+    query_language,
+):
     """
     Provide endpoint for Elasticsearch client.
     By default, it uses http://localhost:9200 to connect.
@@ -103,7 +122,12 @@ def cli(endpoint, query, explain, clirc, result_format, is_vertical, username, p
         sys.exit(0)
 
     # use console to interact with user
-    odfesql_cli = OdfeSqlCli(clirc_file=clirc, always_use_pager=always_use_pager, use_aws_authentication=use_aws_authentication)
+    odfesql_cli = OdfeSqlCli(
+        clirc_file=clirc,
+        always_use_pager=always_use_pager,
+        use_aws_authentication=use_aws_authentication,
+        query_language=query_language,
+    )
     odfesql_cli.connect(endpoint, http_auth)
     odfesql_cli.run_cli()
 

--- a/sql-cli/src/odfe_sql_cli/odfesql_cli.py
+++ b/sql-cli/src/odfe_sql_cli/odfesql_cli.py
@@ -47,13 +47,14 @@ click.disable_unicode_literals_warning = True
 class OdfeSqlCli:
     """OdfeSqlCli instance is used to build and run the ODFE SQL CLI."""
 
-    def __init__(self, clirc_file=None, always_use_pager=False, use_aws_authentication=False):
+    def __init__(self, clirc_file=None, always_use_pager=False, use_aws_authentication=False, query_language="sql"):
         # Load conf file
         config = self.config = get_config(clirc_file)
         literal = self.literal = self._get_literals()
 
         self.prompt_app = None
         self.es_executor = None
+        self.query_language = query_language
         self.always_use_pager = always_use_pager
         self.use_aws_authentication = use_aws_authentication
         self.keywords_list = literal["keywords"]
@@ -121,6 +122,7 @@ class OdfeSqlCli:
         print("Server: Open Distro for ES %s" % self.es_executor.es_version)
         print("CLI Version: %s" % __version__)
         print("Endpoint: %s" % self.es_executor.endpoint)
+        print("Query Language: %s" % self.query_language)
 
         while True:
             try:
@@ -165,7 +167,7 @@ class OdfeSqlCli:
             click.echo(text, color=color)
 
     def connect(self, endpoint, http_auth=None):
-        self.es_executor = ESConnection(endpoint, http_auth, self.use_aws_authentication)
+        self.es_executor = ESConnection(endpoint, http_auth, self.use_aws_authentication, self.query_language)
         self.es_executor.set_connection()
 
     def _get_literals(self):

--- a/sql-cli/tests/test_odfesql_cli.py
+++ b/sql-cli/tests/test_odfesql_cli.py
@@ -26,6 +26,7 @@ from src.odfe_sql_cli.esstyle import style_factory
 AUTH = None
 QUERY_WITH_CTRL_D = "select * from %s;\r\x04\r" % TEST_INDEX_NAME
 USE_AWS_CREDENTIALS = False
+QUERY_LANGUAGE = "sql"
 
 
 @pytest.fixture()
@@ -40,7 +41,7 @@ class TestOdfeSqlCli:
         ) as mock_set_connectiuon:
             cli.connect(endpoint=ENDPOINT)
 
-            mock_ESConnection.assert_called_with(ENDPOINT, AUTH, USE_AWS_CREDENTIALS)
+            mock_ESConnection.assert_called_with(ENDPOINT, AUTH, USE_AWS_CREDENTIALS, QUERY_LANGUAGE)
             mock_set_connectiuon.assert_called()
 
     @estest


### PR DESCRIPTION
*Issue #, if available:*

Currently the doctest module dependes on sql-cli, however it's installed through a test release version on `test.pypi`, the source code of that version is not consistent with the current code base. This PR will migrate the code from [developer's branch](https://github.com/zhongnansu/sql-cli/tree/ppl-support) to the main repo.

*Description of changes:*
- Add basic ppl support for the purpose of doctest module.
- Add command option `-l` for query language, be default it uses sql, so it doesn't break the original user experience. Additionally, we add `ppl` as an option to run ppl commands. 

#### Note
This is not an official support for ppl in the cli, even though the core logic is added only for doctest. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
