### PR TITLE
Extend the PPL identifier defintion

### DIFF
--- a/docs/experiment/ppl/general/identifiers.rst
+++ b/docs/experiment/ppl/general/identifiers.rst
@@ -23,6 +23,13 @@ Description
 
 A regular identifier is a string of characters that must start with ASCII letter (lower or upper case). The subsequent character can be a combination of letter, digit, underscore (``_``). It cannot be a reversed key word. And whitespace and other special characters are not allowed.
 
+For Elasticsearch, the following identifiers are supported extensionally:
+
+1. Identifiers prefixed by dot ``.``: this is called hidden index in Elasticsearch, for example ``.kibana``.
+2. Identifiers prefixed by at sign ``@``: this is common for meta fields generated in Logstash ingestion.
+3. Identifiers with ``-`` in the middle: this is mostly the case for index name with date information.
+4. Identifiers with star ``*`` present: this is mostly an index pattern for wildcard match.
+
 Examples
 --------
 
@@ -46,12 +53,7 @@ Delimited Identifiers
 Description
 -----------
 
-A delimited identifier is an identifier enclosed in back ticks `````. In this case, the identifier enclosed is not necessarily a regular identifier. In other words, it can contain any special character not allowed by regular identifier. For Elasticsearch, the following identifiers are supported extensionally:
-
-1. Identifiers prefixed by dot ``.``: this is called hidden index in Elasticsearch, for example ``.kibana``.
-2. Identifiers prefixed by at sign ``@``: this is common for meta fields generated in Logstash ingestion.
-3. Identifiers with ``-`` in the middle: this is mostly the case for index name with date information.
-4. Identifiers with star ``*`` present: this is mostly an index pattern for wildcard match.
+A delimited identifier is an identifier enclosed in back ticks `````. In this case, the identifier enclosed is not necessarily a regular identifier. In other words, it can contain any special character not allowed by regular identifier.
 
 Use Cases
 ---------
@@ -67,7 +69,7 @@ Examples
 
 Here are examples for quoting an index name by back ticks::
 
-    od> source=`acc*` | fields `account_number`;
+    od> source=`accounts` | fields `account_number`;
     fetched rows / total rows = 4/4
     +------------------+
     | account_number   |

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StatsCommandIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StatsCommandIT.java
@@ -90,7 +90,7 @@ public class StatsCommandIT extends PPLIntegTestCase {
     JSONObject response =
         executeQuery(String.format("source=%s | stats avg(abs(age) * 2.0)",
             TEST_INDEX_ACCOUNT));
-    verifySchema(response, schema("avg(abs(age)*2.0)", null, "double"));
+    verifySchema(response, schema("avg(abs(age) * 2.0)", null, "double"));
     verifyDataRows(response, rows(60.342));
   }
 

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StatsCommandIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/StatsCommandIT.java
@@ -79,7 +79,8 @@ public class StatsCommandIT extends PPLIntegTestCase {
   @Test
   public void testStatsNested() throws IOException {
     JSONObject response =
-        executeQuery(String.format("source=%s | stats avg(abs(age)*2) as AGE", TEST_INDEX_ACCOUNT));
+        executeQuery(String.format("source=%s | stats avg(abs(age) * 2) as AGE",
+            TEST_INDEX_ACCOUNT));
     verifySchema(response, schema("AGE", null, "double"));
     verifyDataRows(response, rows(60.342));
   }
@@ -87,7 +88,7 @@ public class StatsCommandIT extends PPLIntegTestCase {
   @Test
   public void testStatsNestedDoubleValue() throws IOException {
     JSONObject response =
-        executeQuery(String.format("source=%s | stats avg(abs(age)*2.0)",
+        executeQuery(String.format("source=%s | stats avg(abs(age) * 2.0)",
             TEST_INDEX_ACCOUNT));
     verifySchema(response, schema("avg(abs(age)*2.0)", null, "double"));
     verifyDataRows(response, rows(60.342));

--- a/ppl/src/main/antlr/OpenDistroPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenDistroPPLLexer.g4
@@ -230,13 +230,11 @@ CONCAT_WS:                          'CONCAT_WS';
 LENGTH:                             'LENGTH';
 STRCMP:                             'STRCMP';
 
-// LITERALS AND VALUES
-//STRING_LITERAL:                     DQUOTA_STRING | SQUOTA_STRING | BQUOTA_STRING;
 ID:                                 ID_LITERAL;
 INTEGER_LITERAL:                    DEC_DIGIT+;
 DECIMAL_LITERAL:                    (DEC_DIGIT+)? '.' DEC_DIGIT+;
 
-fragment ID_LITERAL:                [A-Z_]+[A-Z_$0-9@\-]*;
+fragment ID_LITERAL:                [@*A-Z]+?[*A-Z_\-0-9]*;
 DQUOTA_STRING:                      '"' ( '\\'. | '""' | ~('"'| '\\') )* '"';
 SQUOTA_STRING:                      '\'' ('\\'. | '\'\'' | ~('\'' | '\\'))* '\'';
 BQUOTA_STRING:                      '`' ( '\\'. | '``' | ~('`'|'\\'))* '`';


### PR DESCRIPTION
*Issue #, if available:* #882 

*Description of changes:*
1. Update the doc to support Elasticsearch extension as identifier. https://github.com/penghuo/sql/blob/issue-882/docs/experiment/ppl/general/identifiers.rst


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
