### PR TITLE
Revert Error Messages for Run/Explain

### DIFF
--- a/workbench/public/components/Main/main.tsx
+++ b/workbench/public/components/Main/main.tsx
@@ -249,15 +249,6 @@ export class Main extends React.Component<MainProps, MainState> {
     };
   }
 
-  formatQueryErrorBody(data: any) {
-    let prettyErrorMessage = "";
-    prettyErrorMessage += 'reason: ' + data.errorReason + '\n';
-    prettyErrorMessage += 'details: ' + data.errorDetails + '\n';
-    prettyErrorMessage += 'type: ' + data.errorType + '\n';
-    prettyErrorMessage += 'status: ' + data.status;
-    return prettyErrorMessage;
-  }
-
   processQueryResponse(response: IHttpResponse<ResponseData>): ResponseDetail<string> {
     if (!response) {
       return {
@@ -270,7 +261,7 @@ export class Main extends React.Component<MainProps, MainState> {
       return {
         fulfilled: false,
         errorMessage: response.data.resp,
-        data: this.formatQueryErrorBody(response.data),
+        data: response.data.body,
       };
     }
 

--- a/workbench/public/components/PPLPage/PPLPage.tsx
+++ b/workbench/public/components/PPLPage/PPLPage.tsx
@@ -76,15 +76,9 @@ export class PPLPage extends React.Component<PPLPageProps, PPLPageState> {
       return false;
     }
 
-    const showExplainErrorMessage = () => {
-      return this.props.pplTranslations.map((queryTranslation: any) => JSON.stringify(
-        queryTranslation.errorMessage + ": This query is not explainable.", null, 2
-      ));
-    }
-
     const explainContent = pplTranslationsNotEmpty()
     ? this.props.pplTranslations.map((queryTranslation: any) => JSON.stringify(queryTranslation.data, null, 2)).join("\n")
-    : showExplainErrorMessage();
+    : 'This query is not explainable.';
 
     let modal;
 

--- a/workbench/public/components/SQLPage/SQLPage.tsx
+++ b/workbench/public/components/SQLPage/SQLPage.tsx
@@ -79,15 +79,9 @@ export class SQLPage extends React.Component<SQLPageProps, SQLPageState> {
       return false;
     }
 
-    const showExplainErrorMessage = () => {
-      return this.props.sqlTranslations.map((queryTranslation: any) => JSON.stringify(
-        queryTranslation.errorMessage + ": This query is not explainable.", null, 2
-      ));
-    }
-
     const explainContent = sqlTranslationsNotEmpty()
     ? this.props.sqlTranslations.map((queryTranslation: any) => JSON.stringify(queryTranslation.data, null, 2)).join("\n")
-    : showExplainErrorMessage();
+    : 'This query is not explainable.';
 
     let modal;
 

--- a/workbench/server/services/QueryService.ts
+++ b/workbench/server/services/QueryService.ts
@@ -41,15 +41,11 @@ export default class QueryService {
       };
     } catch (err) {
       console.log(err);
-      const errorObj = JSON.parse(err.body);
       return {
         data: {
           ok: false,
           resp: err.message,
-          errorReason: errorObj.error.reason,
-          errorDetails: errorObj.error.details,
-          errorType: errorObj.error.type,
-          status: errorObj.status
+          body: err.body
         },
       };
     }


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
After discussion with @anirudha , revert `Run` error message to JSON format to avoid necessity for any front-end changes upon modification of back-end response. Also simplified `Explain` error to simply `This query is not explainable`, as the backend response is not helpful to the user at all (`unable to parse/serialize body`). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
