### PR TITLE
Add like, isnull, isnotnull function in PPL

### DIFF
--- a/docs/category.json
+++ b/docs/category.json
@@ -17,7 +17,8 @@
     "experiment/ppl/general/identifiers.rst",
     "experiment/ppl/functions/math.rst",
     "experiment/ppl/functions/datetime.rst",
-    "experiment/ppl/functions/string.rst"
+    "experiment/ppl/functions/string.rst",
+    "experiment/ppl/functions/condition.rst"
   ],
   "sql_cli": [
     "user/dql/expressions.rst",

--- a/docs/category.json
+++ b/docs/category.json
@@ -14,7 +14,10 @@
     "experiment/ppl/cmd/sort.rst",
     "experiment/ppl/cmd/stats.rst",
     "experiment/ppl/cmd/where.rst",
-    "experiment/ppl/general/identifiers.rst"
+    "experiment/ppl/general/identifiers.rst",
+    "experiment/ppl/functions/math.rst",
+    "experiment/ppl/functions/datetime.rst",
+    "experiment/ppl/functions/string.rst"
   ],
   "sql_cli": [
     "user/dql/expressions.rst",

--- a/docs/experiment/ppl/functions/condition.rst
+++ b/docs/experiment/ppl/functions/condition.rst
@@ -52,3 +52,18 @@ Example::
     | 18               | null       |
     +------------------+------------+
 
+EXISTS
+------
+
+`Because Elasticsearch doesn't differentiate null and missing <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html>`_. so we can't provide function like ismissing/isnotmissing to test field exist or not. But you can still use isnull/isnotnull for such purpose.
+
+Example, the account 13 doesn't have email field::
+
+    od> source=accounts | where isnull(email) | fields account_number, email
+    fetched rows / total rows = 1/1
+    +------------------+---------+
+    | account_number   | email   |
+    |------------------+---------|
+    | 13               | null    |
+    +------------------+---------+
+

--- a/docs/experiment/ppl/functions/condition.rst
+++ b/docs/experiment/ppl/functions/condition.rst
@@ -1,0 +1,54 @@
+===================
+Condition Functions
+===================
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 1
+
+ISNULL
+------
+
+Description
+>>>>>>>>>>>
+
+Usage: isnull(field) return true if field is null.
+
+Argument type: all the supported data type.
+
+Return type: BOOLEAN
+
+Example::
+
+    od> source=accounts | where isnull(employer) | fields account_number, employer
+    fetched rows / total rows = 1/1
+    +------------------+------------+
+    | account_number   | employer   |
+    |------------------+------------|
+    | 18               | null       |
+    +------------------+------------+
+
+ISNOTNULL
+---------
+
+Description
+>>>>>>>>>>>
+
+Usage: isnotnull(field) return true if field is not null.
+
+Argument type: all the supported data type.
+
+Return type: BOOLEAN
+
+Example::
+
+    od> source=accounts | where not isnotnull(employer) | fields account_number, employer
+    fetched rows / total rows = 1/1
+    +------------------+------------+
+    | account_number   | employer   |
+    |------------------+------------|
+    | 18               | null       |
+    +------------------+------------+
+

--- a/docs/experiment/ppl/functions/datetime.rst
+++ b/docs/experiment/ppl/functions/datetime.rst
@@ -6,7 +6,7 @@ Date and Time Functions
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 ADDDATE
 -------

--- a/docs/experiment/ppl/functions/datetime.rst
+++ b/docs/experiment/ppl/functions/datetime.rst
@@ -1,0 +1,758 @@
+=======================
+Date and Time Functions
+=======================
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 2
+
+ADDDATE
+-------
+
+Description
+>>>>>>>>>>>
+
+Usage: adddate(date, INTERVAL expr unit)/ adddate(date, expr) adds the time interval of second argument to date; adddate(date, days) adds the second argument as integer number of days to date.
+
+Argument type: DATE/DATETIME/TIMESTAMP/STRING, INTERVAL/LONG
+
+Return type map:
+
+(DATE/DATETIME/TIMESTAMP/STRING, INTERVAL) -> DATETIME
+
+(DATE, LONG) -> DATE
+
+(DATETIME/TIMESTAMP/STRING, LONG) -> DATETIME
+
+Synonyms: `DATE_ADD`_
+
+Example::
+
+    od> source=people | eval `ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR)` = ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR), `ADDDATE(DATE('2020-08-26'), 1)` = ADDDATE(DATE('2020-08-26'), 1), `ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)` = ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR)`, `ADDDATE(DATE('2020-08-26'), 1)`, `ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)`
+    fetched rows / total rows = 1/1
+    +------------------------------------------------+----------------------------------+------------------------------------------------+
+    | ADDDATE(DATE('2020-08-26'), INTERVAL 1 HOUR)   | ADDDATE(DATE('2020-08-26'), 1)   | ADDDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
+    |------------------------------------------------+----------------------------------+------------------------------------------------|
+    | 2020-08-26 01:00:00                            | 2020-08-27                       | 2020-08-27 01:01:01                            |
+    +------------------------------------------------+----------------------------------+------------------------------------------------+
+
+
+DATE
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: date(expr) constructs a date type with the input string expr as a date. If the argument is of date/datetime/timestamp, it extracts the date value part from the expression.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: DATE
+
+Example::
+
+    >od source=people | eval `DATE('2020-08-26')` = DATE('2020-08-26'), `DATE(TIMESTAMP('2020-08-26 13:49:00'))` = DATE(TIMESTAMP('2020-08-26 13:49:00')) | fields `DATE('2020-08-26')`, `DATE(TIMESTAMP('2020-08-26 13:49:00'))`
+    fetched rows / total rows = 1/1
+    +----------------------+------------------------------------------+
+    | DATE('2020-08-26')   | DATE(TIMESTAMP('2020-08-26 13:49:00'))   |
+    |----------------------+------------------------------------------|
+    | DATE '2020-08-26'    | DATE '2020-08-26'                        |
+    +----------------------+------------------------------------------+
+
+
+DATE_ADD
+--------
+
+Description
+>>>>>>>>>>>
+
+Usage: date_add(date, INTERVAL expr unit)/ date_add(date, expr) adds the time interval expr to date
+
+Argument type: DATE/DATETIME/TIMESTAMP/STRING, INTERVAL/LONG
+
+Return type map:
+
+DATE/DATETIME/TIMESTAMP/STRING, INTERVAL -> DATETIME
+
+DATE, LONG -> DATE
+
+DATETIME/TIMESTAMP/STRING, LONG -> DATETIME
+
+Synonyms: `ADDDATE`_
+
+Example::
+
+    od> source=people | eval `DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR)` = DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR), `DATE_ADD(DATE('2020-08-26'), 1)` = DATE_ADD(DATE('2020-08-26'), 1), `DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1)` = DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR)`, `DATE_ADD(DATE('2020-08-26'), 1)`, `DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1)`
+    fetched rows / total rows = 1/1
+    +-------------------------------------------------+-----------------------------------+-------------------------------------------------+
+    | DATE_ADD(DATE('2020-08-26'), INTERVAL 1 HOUR)   | DATE_ADD(DATE('2020-08-26'), 1)   | DATE_ADD(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
+    |-------------------------------------------------+-----------------------------------+-------------------------------------------------|
+    | 2020-08-26 01:00:00                             | 2020-08-27                        | 2020-08-27 01:01:01                             |
+    +-------------------------------------------------+-----------------------------------+-------------------------------------------------+
+
+
+DATE_FORMAT
+-----------
+
+Description
+>>>>>>>>>>>
+
+Usage: date_format(date, format) formats the date argument using the specifiers in the format argument.
+
+.. list-table:: The following table describes the available specifier arguments.
+   :widths: 20 80
+   :header-rows: 1
+
+   * - Specifier
+     - Description
+   * - %a
+     - Abbreviated weekday name (Sun..Sat)
+   * - %b
+     - Abbreviated month name (Jan..Dec)
+   * - %c
+     - Month, numeric (0..12)
+   * - %D
+     - Day of the month with English suffix (0th, 1st, 2nd, 3rd, …)
+   * - %d
+     - Day of the month, numeric (00..31)
+   * - %e
+     - Day of the month, numeric (0..31)
+   * - %f
+     - Microseconds (000000..999999)
+   * - %H
+     - Hour (00..23)
+   * - %h
+     - Hour (01..12)
+   * - %I
+     - Hour (01..12)
+   * - %i
+     - Minutes, numeric (00..59)
+   * - %j
+     - Day of year (001..366)
+   * - %k
+     - Hour (0..23)
+   * - %l
+     - Hour (1..12)
+   * - %M
+     - Month name (January..December)
+   * - %m
+     - Month, numeric (00..12)
+   * - %p
+     - AM or PM
+   * - %r
+     - Time, 12-hour (hh:mm:ss followed by AM or PM)
+   * - %S
+     - Seconds (00..59)
+   * - %s
+     - Seconds (00..59)
+   * - %T
+     - Time, 24-hour (hh:mm:ss)
+   * - %U
+     - Week (00..53), where Sunday is the first day of the week; WEEK() mode 0
+   * - %u
+     - Week (00..53), where Monday is the first day of the week; WEEK() mode 1
+   * - %V
+     - Week (01..53), where Sunday is the first day of the week; WEEK() mode 2; used with %X
+   * - %v
+     - Week (01..53), where Monday is the first day of the week; WEEK() mode 3; used with %x
+   * - %W
+     - Weekday name (Sunday..Saturday)
+   * - %w
+     - Day of the week (0=Sunday..6=Saturday)
+   * - %X
+     - Year for the week where Sunday is the first day of the week, numeric, four digits; used with %V
+   * - %x
+     - Year for the week, where Monday is the first day of the week, numeric, four digits; used with %v
+   * - %Y
+     - Year, numeric, four digits
+   * - %y
+     - Year, numeric (two digits)
+   * - %%
+     - A literal % character
+   * - %x
+     - x, for any “x” not listed above
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP, STRING
+
+Return type: STRING
+
+Example::
+
+    >od source=people | eval `DATE_FORMAT('1998-01-31 13:14:15.012345', '%T.%f')` = DATE_FORMAT('1998-01-31 13:14:15.012345', '%T.%f'), `DATE_FORMAT(TIMESTAMP('1998-01-31 13:14:15.012345'), '%Y-%b-%D %r')` = DATE_FORMAT(TIMESTAMP('1998-01-31 13:14:15.012345'), '%Y-%b-%D %r') | fields `DATE_FORMAT('1998-01-31 13:14:15.012345', '%T.%f')`, `DATE_FORMAT(TIMESTAMP('1998-01-31 13:14:15.012345'), '%Y-%b-%D %r')`
+    fetched rows / total rows = 1/1
+    +-----------------------------------------------+----------------------------------------------------------------+
+    | DATE('1998-01-31 13:14:15.012345', '%T.%f')   | DATE(TIMESTAMP('1998-01-31 13:14:15.012345'), '%Y-%b-%D %r')   |
+    |-----------------------------------------------+----------------------------------------------------------------|
+    | '13:14:15.012345'                             | '1998-Jan-31st 01:14:15 PM'                                    |
+    +-----------------------------------------------+----------------------------------------------------------------+
+
+
+DATE_SUB
+--------
+
+Description
+>>>>>>>>>>>
+
+Usage: date_sub(date, INTERVAL expr unit)/ date_sub(date, expr) subtracts the time interval expr from date
+
+Argument type: DATE/DATETIME/TIMESTAMP/STRING, INTERVAL/LONG
+
+Return type map:
+
+DATE/DATETIME/TIMESTAMP/STRING, INTERVAL -> DATETIME
+
+DATE, LONG -> DATE
+
+DATETIME/TIMESTAMP/STRING, LONG -> DATETIME
+
+Synonyms: `SUBDATE`_
+
+Example::
+
+    od> source=people | eval `DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY)` = DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY), `DATE_SUB(DATE('2020-08-26'), 1)` = DATE_SUB(DATE('2020-08-26'), 1), `DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1)` = DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY)`, `DATE_SUB(DATE('2020-08-26'), 1)`, `DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1)`
+    fetched rows / total rows = 1/1
+    +-------------------------------------------------+-----------------------------------+-------------------------------------------------+
+    | DATE_SUB(DATE('2008-01-02'), INTERVAL 31 DAY)   | DATE_SUB(DATE('2020-08-26'), 1)   | DATE_SUB(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
+    |-------------------------------------------------+-----------------------------------+-------------------------------------------------|
+    | 2007-12-02                                      | 2020-08-25                        | 2020-08-25 01:01:01                             |
+    +-------------------------------------------------+-----------------------------------+-------------------------------------------------+
+
+
+DAY
+---
+
+Description
+>>>>>>>>>>>
+
+Usage: day(date) extracts the day of the month for date, in the range 1 to 31. The dates with value 0 such as '0000-00-00' or '2008-00-00' are invalid.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Synonyms: DAYOFMONTH
+
+Example::
+
+    od> source=people | eval `DAY(DATE('2020-08-26'))` = DAY(DATE('2020-08-26')) | fields `DAY(DATE('2020-08-26'))`
+    fetched rows / total rows = 1/1
+    +---------------------------+
+    | DAY(DATE('2020-08-26'))   |
+    |---------------------------|
+    | 26                        |
+    +---------------------------+
+
+
+DAYNAME
+-------
+
+Description
+>>>>>>>>>>>
+
+Usage: dayname(date) returns the name of the weekday for date, including Monday, Tuesday, Wednesday, Thursday, Friday, Saturday and Sunday.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: STRING
+
+Example::
+
+    od> source=people | eval `DAYNAME(DATE('2020-08-26'))` = DAYNAME(DATE('2020-08-26')) | fields `DAYNAME(DATE('2020-08-26'))`
+    fetched rows / total rows = 1/1
+    +-------------------------------+
+    | DAYNAME(DATE('2020-08-26'))   |
+    |-------------------------------|
+    | Wednesday                     |
+    +-------------------------------+
+
+
+DAYOFMONTH
+----------
+
+Description
+>>>>>>>>>>>
+
+Usage: dayofmonth(date) extracts the day of the month for date, in the range 1 to 31. The dates with value 0 such as '0000-00-00' or '2008-00-00' are invalid.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Synonyms: DAY
+
+Example::
+
+    od> source=people | eval `DAYOFMONTH(DATE('2020-08-26'))` = DAYOFMONTH(DATE('2020-08-26')) | fields `DAYOFMONTH(DATE('2020-08-26'))`
+    fetched rows / total rows = 1/1
+    +----------------------------------+
+    | DAYOFMONTH(DATE('2020-08-26'))   |
+    |----------------------------------|
+    | 26                               |
+    +----------------------------------+
+
+
+DAYOFWEEK
+---------
+
+Description
+>>>>>>>>>>>
+
+Usage: dayofweek(date) returns the weekday index for date (1 = Sunday, 2 = Monday, …, 7 = Saturday).
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `DAYOFWEEK(DATE('2020-08-26'))` = DAYOFWEEK(DATE('2020-08-26')) | fields `DAYOFWEEK(DATE('2020-08-26'))`
+    fetched rows / total rows = 1/1
+    +---------------------------------+
+    | DAYOFWEEK(DATE('2020-08-26'))   |
+    |---------------------------------|
+    | 4                               |
+    +---------------------------------+
+
+
+
+DAYOFYEAR
+---------
+
+Description
+>>>>>>>>>>>
+
+Usage:  dayofyear(date) returns the day of the year for date, in the range 1 to 366.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `DAYOFYEAR(DATE('2020-08-26'))` = DAYOFYEAR(DATE('2020-08-26')) | fields `DAYOFYEAR(DATE('2020-08-26'))`
+    fetched rows / total rows = 1/1
+    +---------------------------------+
+    | DAYOFYEAR(DATE('2020-08-26'))   |
+    |---------------------------------|
+    | 239                             |
+    +---------------------------------+
+
+
+FROM_DAYS
+---------
+
+Description
+>>>>>>>>>>>
+
+Usage: from_days(N) returns the date value given the day number N.
+
+Argument type: INTEGER/LONG
+
+Return type: DATE
+
+Example::
+
+    od> source=people | eval `FROM_DAYS(733687)` = FROM_DAYS(733687) | fields `FROM_DAYS(733687)`
+    fetched rows / total rows = 1/1
+    +---------------------+
+    | FROM_DAYS(733687)   |
+    |---------------------|
+    | 2008-10-07          |
+    +---------------------+
+
+
+HOUR
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: hour(time) extracts the hour value for time. Different from the time of day value, the time value has a large range and can be greater than 23, so the return value of hour(time) can be also greater than 23.
+
+Argument type: STRING/TIME/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `HOUR(TIME('01:02:03'))` = HOUR(TIME('01:02:03')) | fields `HOUR(TIME('01:02:03'))`
+    fetched rows / total rows = 1/1
+    +--------------------------+
+    | HOUR(TIME('01:02:03'))   |
+    |--------------------------|
+    | 1                        |
+    +--------------------------+
+
+
+MAKETIME
+--------
+
+Description
+>>>>>>>>>>>
+
+Specifications:
+
+1. MAKETIME(INTEGER, INTEGER, INTEGER) -> DATE
+
+
+MICROSECOND
+-----------
+
+Description
+>>>>>>>>>>>
+
+Usage: microsecond(expr) returns the microseconds from the time or datetime expression expr as a number in the range from 0 to 999999.
+
+Argument type: STRING/TIME/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `MICROSECOND(TIME('01:02:03.123456'))` = MICROSECOND(TIME('01:02:03.123456')) | fields `MICROSECOND(TIME('01:02:03.123456'))`
+    fetched rows / total rows = 1/1
+    +----------------------------------------+
+    | MICROSECOND(TIME('01:02:03.123456'))   |
+    |----------------------------------------|
+    | 123456                                 |
+    +----------------------------------------+
+
+
+MINUTE
+------
+
+Description
+>>>>>>>>>>>
+
+Usage: minute(time) returns the minute for time, in the range 0 to 59.
+
+Argument type: STRING/TIME/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `MINUTE(TIME('01:02:03'))` =  MINUTE(TIME('01:02:03')) | fields `MINUTE(TIME('01:02:03'))`
+    fetched rows / total rows = 1/1
+    +----------------------------+
+    | MINUTE(TIME('01:02:03'))   |
+    |----------------------------|
+    | 2                          |
+    +----------------------------+
+
+
+MONTH
+-----
+
+Description
+>>>>>>>>>>>
+
+Usage: month(date) returns the month for date, in the range 1 to 12 for January to December. The dates with value 0 such as '0000-00-00' or '2008-00-00' are invalid.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `MONTH(DATE('2020-08-26'))` =  MONTH(DATE('2020-08-26')) | fields `MONTH(DATE('2020-08-26'))`
+    fetched rows / total rows = 1/1
+    +-----------------------------+
+    | MONTH(DATE('2020-08-26'))   |
+    |-----------------------------|
+    | 8                           |
+    +-----------------------------+
+
+
+MONTHNAME
+---------
+
+Description
+>>>>>>>>>>>
+
+Usage: monthname(date) returns the full name of the month for date.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: STRING
+
+Example::
+
+    od> source=people | eval `MONTHNAME(DATE('2020-08-26'))` = MONTHNAME(DATE('2020-08-26')) | fields `MONTHNAME(DATE('2020-08-26'))`
+    fetched rows / total rows = 1/1
+    +---------------------------------+
+    | MONTHNAME(DATE('2020-08-26'))   |
+    |---------------------------------|
+    | August                          |
+    +---------------------------------+
+
+
+NOW
+---
+
+Description
+>>>>>>>>>>>
+
+Specifications:
+
+1. NOW() -> DATE
+
+
+QUARTER
+-------
+
+Description
+>>>>>>>>>>>
+
+Usage: quarter(date) returns the quarter of the year for date, in the range 1 to 4.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `QUARTER(DATE('2020-08-26'))` = QUARTER(DATE('2020-08-26')) | fields `QUARTER(DATE('2020-08-26'))`
+    fetched rows / total rows = 1/1
+    +-------------------------------+
+    | QUARTER(DATE('2020-08-26'))   |
+    |-------------------------------|
+    | 3                             |
+    +-------------------------------+
+
+
+SECOND
+------
+
+Description
+>>>>>>>>>>>
+
+Usage: second(time) returns the second for time, in the range 0 to 59.
+
+Argument type: STRING/TIME/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `SECOND(TIME('01:02:03'))` = SECOND(TIME('01:02:03')) | fields `SECOND(TIME('01:02:03'))`
+    fetched rows / total rows = 1/1
+    +----------------------------+
+    | SECOND(TIME('01:02:03'))   |
+    |----------------------------|
+    | 3                          |
+    +----------------------------+
+
+
+SUBDATE
+-------
+
+Description
+>>>>>>>>>>>
+
+Usage: subdate(date, INTERVAL expr unit)/ subdate(date, expr) subtracts the time interval expr from date
+
+Argument type: DATE/DATETIME/TIMESTAMP/STRING, INTERVAL/LONG
+
+Return type map:
+
+DATE/DATETIME/TIMESTAMP/STRING, INTERVAL -> DATETIME
+
+DATE, LONG -> DATE
+
+DATETIME/TIMESTAMP/STRING, LONG -> DATETIME
+
+Synonyms: `DATE_SUB`_
+
+Example::
+
+    od> source=people | eval `SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY)` = SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY), `SUBDATE(DATE('2020-08-26'), 1)` = SUBDATE(DATE('2020-08-26'), 1), `SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)` = SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1) | fields `SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY)`, `SUBDATE(DATE('2020-08-26'), 1)`, `SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)`
+    fetched rows / total rows = 1/1
+    +------------------------------------------------+----------------------------------+------------------------------------------------+
+    | SUBDATE(DATE('2008-01-02'), INTERVAL 31 DAY)   | SUBDATE(DATE('2020-08-26'), 1)   | SUBDATE(TIMESTAMP('2020-08-26 01:01:01'), 1)   |
+    |------------------------------------------------+----------------------------------+------------------------------------------------|
+    | 2007-12-02                                     | 2020-08-25                       | 2020-08-25 01:01:01                            |
+    +------------------------------------------------+----------------------------------+------------------------------------------------+
+
+
+TIME
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: time(expr) constructs a time type with the input string expr as a time. If the argument is of date/datetime/time/timestamp, it extracts the time value part from the expression.
+
+Argument type: STRING/DATE/DATETIME/TIME/TIMESTAMP
+
+Return type: TIME
+
+Example::
+
+    >od source=people | eval `TIME('13:49:00')` = TIME('13:49:00'), `TIME(TIMESTAMP('2020-08-26 13:49:00'))` = TIME(TIMESTAMP('2020-08-26 13:49:00')) | fields `TIME('13:49:00')`, `TIME(TIMESTAMP('2020-08-26 13:49:00'))`
+    fetched rows / total rows = 1/1
+    +--------------------+------------------------------------------+
+    | TIME('13:49:00')   | TIME(TIMESTAMP('2020-08-26 13:49:00'))   |
+    |--------------------+------------------------------------------|
+    | TIME '13:49:00'    | TIME '13:49:00'                          |
+    +--------------------+------------------------------------------+
+
+
+TIME_TO_SEC
+-----------
+
+Description
+>>>>>>>>>>>
+
+Usage: time_to_sec(time) returns the time argument, converted to seconds.
+
+Argument type: STRING/TIME/DATETIME/TIMESTAMP
+
+Return type: LONG
+
+Example::
+
+    od> source=people | eval `TIME_TO_SEC(TIME('22:23:00'))` = TIME_TO_SEC(TIME('22:23:00')) | fields `TIME_TO_SEC(TIME('22:23:00'))`
+    fetched rows / total rows = 1/1
+    +---------------------------------+
+    | TIME_TO_SEC(TIME('22:23:00'))   |
+    |---------------------------------|
+    | 80580                           |
+    +---------------------------------+
+
+
+TIMESTAMP
+---------
+
+Description
+>>>>>>>>>>>
+
+Usage: timestamp(expr) construct a timestamp type with the input string expr as an timestamp. If the argument is of date/datetime/timestamp type, cast expr to timestamp type with default timezone UTC.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: TIMESTAMP
+
+Example::
+
+    >od source=people | eval `TIMESTAMP('2020-08-26 13:49:00')` = TIMESTAMP('2020-08-26 13:49:00') | fields `TIMESTAMP('2020-08-26 13:49:00')`
+    fetched rows / total rows = 1/1
+    +------------------------------------+
+    | TIMESTAMP('2020-08-26 13:49:00')   |
+    |------------------------------------|
+    | TIMESTAMP '2020-08-26 13:49:00     |
+    +------------------------------------+
+
+
+TO_DAYS
+-------
+
+Description
+>>>>>>>>>>>
+
+Usage: to_days(date) returns the day number (the number of days since year 0) of the given date. Returns NULL if date is invalid.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: LONG
+
+Example::
+
+    od> source=people | eval `TO_DAYS(DATE('2008-10-07'))` = TO_DAYS(DATE('2008-10-07')) | fields `TO_DAYS(DATE('2008-10-07'))`
+    fetched rows / total rows = 1/1
+    +-------------------------------+
+    | TO_DAYS(DATE('2008-10-07'))   |
+    |-------------------------------|
+    | 733687                        |
+    +-------------------------------+
+
+
+WEEK
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: week(date[, mode]) returns the week number for date. If the mode argument is omitted, the default mode 0 is used.
+
+.. list-table:: The following table describes how the mode argument works.
+   :widths: 25 50 25 75
+   :header-rows: 1
+
+   * - Mode
+     - First day of week
+     - Range
+     - Week 1 is the first week …
+   * - 0
+     - Sunday
+     - 0-53
+     - with a Sunday in this year
+   * - 1
+     - Monday
+     - 0-53
+     - with 4 or more days this year
+   * - 2
+     - Sunday
+     - 1-53
+     - with a Sunday in this year
+   * - 3
+     - Monday
+     - 1-53
+     - with 4 or more days this year
+   * - 4
+     - Sunday
+     - 0-53
+     - with 4 or more days this year
+   * - 5
+     - Monday
+     - 0-53
+     - with a Monday in this year
+   * - 6
+     - Sunday
+     - 1-53
+     - with 4 or more days this year
+   * - 7
+     - Monday
+     - 1-53
+     - with a Monday in this year
+
+Argument type: DATE/DATETIME/TIMESTAMP/STRING
+
+Return type: INTEGER
+
+Example::
+
+    >od source=people | eval `WEEK(DATE('2008-02-20'))` = WEEK(DATE('2008-02-20')), `WEEK(DATE('2008-02-20'), 1)` = WEEK(DATE('2008-02-20'), 1) | fields `WEEK(DATE('2008-02-20'))`, `WEEK(DATE('2008-02-20'), 1)`
+    fetched rows / total rows = 1/1
+    +----------------------------+-------------------------------+
+    | WEEK(DATE('2008-02-20'))   | WEEK(DATE('2008-02-20'), 1)   |
+    |----------------------------|-------------------------------|
+    | 7                          | 8                             |
+    +----------------------------+-------------------------------+
+
+
+YEAR
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: year(date) returns the year for date, in the range 1000 to 9999, or 0 for the “zero” date.
+
+Argument type: STRING/DATE/DATETIME/TIMESTAMP
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `YEAR(DATE('2020-08-26'))` = YEAR(DATE('2020-08-26')) | fields `YEAR(DATE('2020-08-26'))`
+    fetched rows / total rows = 1/1
+    +----------------------------+
+    | YEAR(DATE('2020-08-26'))   |
+    |----------------------------|
+    | 2020                       |
+    +----------------------------+
+
+

--- a/docs/experiment/ppl/functions/math.rst
+++ b/docs/experiment/ppl/functions/math.rst
@@ -1,0 +1,664 @@
+======================
+Mathematical Functions
+======================
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+ABS
+---
+
+Description
+>>>>>>>>>>>
+
+Usage: abs(x) calculate the abs x.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: INTEGER/LONG/FLOAT/DOUBLE
+
+Example::
+
+    od> source=people | eval `ABS(-1)` = ABS(-1) | fields `ABS(-1)`
+    fetched rows / total rows = 1/1
+    +-----------+
+    | ABS(-1)   |
+    |-----------|
+    | 1         |
+    +-----------+
+
+
+ACOS
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: acos(x) calculate the arc cosine of x. Returns NULL if x is not in the range -1 to 1.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `ACOS(0)` = ACOS(0) | fields `ACOS(0)`
+    fetched rows / total rows = 1/1
+    +--------------------+
+    | ACOS(0)            |
+    |--------------------|
+    | 1.5707963267948966 |
+    +--------------------+
+
+
+ASIN
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: asin(x) calculate the arc sine of x. Returns NULL if x is not in the range -1 to 1.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `ASIN(0)` = ASIN(0) | fields `ASIN(0)`
+    fetched rows / total rows = 1/1
+    +-----------+
+    | ASIN(0)   |
+    |-----------|
+    | 0.0       |
+    +-----------+
+
+
+ATAN
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: atan(x) calculates the arc tangent of x. atan(y, x) calculates the arc tangent of y / x, except that the signs of both arguments are used to determine the quadrant of the result.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `ATAN(2)` = ATAN(2), `ATAN(2, 3)` = ATAN(2, 3) | fields `ATAN(2)`, `ATAN(2, 3)`
+    fetched rows / total rows = 1/1
+    +--------------------+--------------------+
+    | ATAN(2)            | ATAN(2, 3)         |
+    |--------------------+--------------------|
+    | 1.1071487177940904 | 0.5880026035475675 |
+    +--------------------+--------------------+
+
+
+ATAN2
+-----
+
+Description
+>>>>>>>>>>>
+
+Usage: atan2(y, x) calculates the arc tangent of y / x, except that the signs of both arguments are used to determine the quadrant of the result.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `ATAN2(2, 3)` = ATAN2(2, 3) | fields `ATAN2(2, 3)`
+    fetched rows / total rows = 1/1
+    +--------------------+
+    | ATAN2(2, 3)        |
+    |--------------------|
+    | 0.5880026035475675 |
+    +--------------------+
+
+
+CEIL
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: ceil(x) return the smallest integer value this is greater or equal to x.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `CEIL(2.75)` = CEIL(2.75) | fields `CEIL(2.75)`
+    fetched rows / total rows = 1/1
+    +--------------+
+    | CEIL(2.75)   |
+    |--------------|
+    | 3            |
+    +--------------+
+
+
+CONV
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: CONV(x, a, b) converts the number x from a base to b base.
+
+Argument type: x: STRING, a: INTEGER, b: INTEGER
+
+Return type: STRING
+
+Example::
+
+    od> source=people | eval `CONV('12', 10, 16)` = CONV('12', 10, 16), `CONV('2C', 16, 10)` = CONV('2C', 16, 10), `CONV(12, 10, 2)` = CONV(12, 10, 2), `CONV(1111, 2, 10)` = CONV(1111, 2, 10) | fields `CONV('12', 10, 16)`, `CONV('2C', 16, 10)`, `CONV(12, 10, 2)`, `CONV(1111, 2, 10)`
+    fetched rows / total rows = 1/1
+    +----------------------+----------------------+-------------------+---------------------+
+    | CONV('12', 10, 16)   | CONV('2C', 16, 10)   | CONV(12, 10, 2)   | CONV(1111, 2, 10)   |
+    |----------------------+----------------------+-------------------+---------------------|
+    | c                    | 44                   | 1100              | 15                  |
+    +----------------------+----------------------+-------------------+---------------------+
+
+COS
+---
+
+Description
+>>>>>>>>>>>
+
+Usage: cos(x) calculate the cosine of x, where x is given in radians.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `COS(0)` = COS(0) | fields `COS(0)`
+    fetched rows / total rows = 1/1
+    +----------+
+    | COS(0)   |
+    |----------|
+    | 1.0      |
+    +----------+
+
+
+COT
+---
+
+Description
+>>>>>>>>>>>
+
+Usage: cot(x) calculate the cotangent of x. Returns out-of-range error if x equals to 0.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `COT(1)` = COT(1) | fields `COT(1)`
+    fetched rows / total rows = 1/1
+    +--------------------+
+    | COT(1)             |
+    |--------------------|
+    | 0.6420926159343306 |
+    +--------------------+
+
+
+CRC32
+-----
+
+Description
+>>>>>>>>>>>
+
+Usage: Calculates a cyclic redundancy check value and returns a 32-bit unsigned value.
+
+Argument type: STRING
+
+Return type: LONG
+
+Example::
+
+    od> source=people | eval `CRC32('MySQL')` = CRC32('MySQL') | fields `CRC32('MySQL')`
+    fetched rows / total rows = 1/1
+    +------------------+
+    | CRC32('MySQL')   |
+    |------------------|
+    | 3259397556       |
+    +------------------+
+
+
+DEGREES
+-------
+
+Description
+>>>>>>>>>>>
+
+Usage: degrees(x) converts x from radians to degrees.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `DEGREES(1.57)` = DEGREES(1.57) | fields `DEGREES(1.57)`
+    fetched rows / total rows  = 1/1
+    +-------------------+
+    | DEGREES(1.57)     |
+    |-------------------|
+    | 89.95437383553924 |
+    +-------------------+
+
+E
+-
+
+Description
+>>>>>>>>>>>
+
+Usage: E() returns the Euler's number
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `E()` = E() | fields `E()`
+    fetched rows / total rows = 1/1
+    +-------------------+
+    | E()               |
+    |-------------------|
+    | 2.718281828459045 |
+    +-------------------+
+
+
+EXP
+---
+
+Description
+>>>>>>>>>>>
+
+Usage: exp(x) return e raised to the power of x.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `EXP(2)` = EXP(2) | fields `EXP(2)`
+    fetched rows / total rows = 1/1
+    +------------------+
+    | EXP(2)           |
+    |------------------|
+    | 7.38905609893065 |
+    +------------------+
+
+
+FLOOR
+-----
+
+Description
+>>>>>>>>>>>
+
+Usage: floor(x) return the largest integer value this is smaller or equal to x.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `FLOOR(2.75)` = FLOOR(2.75) | fields `FLOOR(2.75)`
+    fetched rows / total rows = 1/1
+    +---------------+
+    | FLOOR(2.75)   |
+    |---------------|
+    | 2             |
+    +---------------+
+
+
+LN
+--
+
+Description
+>>>>>>>>>>>
+
+Usage: ln(x) return the the natural logarithm of x.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `LN(2)` = LN(2) | fields `LN(2)`
+    fetched rows / total rows = 1/1
+    +--------------------+
+    | LN(2)              |
+    |--------------------|
+    | 0.6931471805599453 |
+    +--------------------+
+
+
+LOG
+---
+
+Description
+>>>>>>>>>>>
+
+Specifications:
+
+Usage: log(x) returns the natural logarithm of x that is the base e logarithm of the x. log(B, x) is equivalent to log(x)/log(B).
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `LOG(2)` = LOG(2), `LOG(2, 8)` = LOG(2, 8) | fields `LOG(2)`, `LOG(2, 8)`
+    fetched rows / total rows = 1/1
+    +--------------------+-------------+
+    | LOG(2)             | LOG(2, 8)   |
+    |--------------------+-------------|
+    | 0.6931471805599453 | 3.0         |
+    +--------------------+-------------+
+
+
+LOG2
+----
+
+Description
+>>>>>>>>>>>
+
+Specifications:
+
+Usage: log2(x) is equivalent to log(x)/log(2).
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `LOG2(8)` = LOG2(8) | fields `LOG2(8)`
+    fetched rows / total rows = 1/1
+    +-----------+
+    | LOG2(8)   |
+    |-----------|
+    | 3.0       |
+    +-----------+
+
+
+LOG10
+-----
+
+Description
+>>>>>>>>>>>
+
+Specifications:
+
+Usage: log10(x) is equivalent to log(x)/log(10).
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `LOG10(100)` = LOG10(100) | fields `LOG10(100)`
+    fetched rows / total rows = 1/1
+    +--------------+
+    | LOG10(100)   |
+    |--------------|
+    | 2.0          |
+    +--------------+
+
+
+MOD
+---
+
+Description
+>>>>>>>>>>>
+
+Usage: MOD(n, m) calculates the remainder of the number n divided by m.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: Wider type between types of n and m if m is nonzero value. If m equals to 0, then returns NULL.
+
+Example::
+
+    od> source=people | eval `MOD(3, 2)` = MOD(3, 2), `MOD(3.1, 2)` = MOD(3.1, 2) | fields `MOD(3, 2)`, `MOD(3.1, 2)`
+    fetched rows / total rows = 1/1
+    +-------------+---------------+
+    | MOD(3, 2)   | MOD(3.1, 2)   |
+    |-------------+---------------|
+    | 1           | 1.1           |
+    +-------------+---------------+
+
+
+PI
+--
+
+Description
+>>>>>>>>>>>
+
+Usage: PI() returns the constant pi
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `PI()` = PI() | fields `PI()`
+    fetched rows / total rows = 1/1
+    +-------------------+
+    | PI()              |
+    |-------------------|
+    | 3.141592653589793 |
+    +-------------------+
+
+
+POW
+---
+
+Description
+>>>>>>>>>>>
+
+Usage: POW(x, y) calculates the value of x raised to the power of y. Bad inputs return NULL result.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Synonyms: `POWER`_
+
+Example::
+
+    od> source=people | eval `POW(3, 2)` = POW(3, 2), `POW(-3, 2)` = POW(-3, 2), `POW(3, -2)` = POW(3, -2) | fields `POW(3, 2)`, `POW(-3, 2)`, `POW(3, -2)`
+    fetched rows / total rows = 1/1
+    +-------------+--------------+--------------------+
+    | POW(3, 2)   | POW(-3, 2)   | POW(3, -2)         |
+    |-------------+--------------+--------------------|
+    | 9.0         | 9.0          | 0.1111111111111111 |
+    +-------------+--------------+--------------------+
+
+
+POWER
+-----
+
+Description
+>>>>>>>>>>>
+
+Usage: POWER(x, y) calculates the value of x raised to the power of y. Bad inputs return NULL result.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Synonyms: `POW`_
+
+Example::
+
+    od> source=people | eval `POWER(3, 2)` = POWER(3, 2), `POWER(-3, 2)` = POWER(-3, 2), `POWER(3, -2)` = POWER(3, -2) | fields `POWER(3, 2)`, `POWER(-3, 2)`, `POWER(3, -2)`
+    fetched rows / total rows = 1/1
+    +---------------+----------------+--------------------+
+    | POWER(3, 2)   | POWER(-3, 2)   | POWER(3, -2)       |
+    |---------------+----------------+--------------------|
+    | 9.0           | 9.0            | 0.1111111111111111 |
+    +---------------+----------------+--------------------+
+
+
+RADIANS
+-------
+
+Description
+>>>>>>>>>>>
+
+Usage: radians(x) converts x from degrees to radians.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `RADIANS(90)` = RADIANS(90) | fields `RADIANS(90)`
+    fetched rows / total rows  = 1/1
+    +--------------------+
+    | RADIANS(90)        |
+    |--------------------|
+    | 1.5707963267948966 |
+    +--------------------+
+
+
+RAND
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: RAND()/RAND(N) returns a random floating-point value in the range 0 <= value < 1.0. If integer N is specified, the seed is initialized prior to execution. One implication of this behavior is with identical argument N, rand(N) returns the same value each time, and thus produces a repeatable sequence of column values.
+
+Argument type: INTEGER
+
+Return type: FLOAT
+
+Example::
+
+    od> source=people | eval `RAND(3)` = RAND(3) | fields `RAND(3)`
+    fetched rows / total rows = 1/1
+    +------------+
+    | RAND(3)    |
+    |------------|
+    | 0.73105735 |
+    +------------+
+
+
+ROUND
+-----
+
+Description
+>>>>>>>>>>>
+
+Usage: ROUND(x, d) rounds the argument x to d decimal places, d defaults to 0 if not specified
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type map:
+
+(INTEGER/LONG [,INTEGER]) -> LONG
+(FLOAT/DOUBLE [,INTEGER]) -> LONG
+
+Example::
+
+    od> source=people | eval `ROUND(12.34)` = ROUND(12.34), `ROUND(12.34, 1)` = ROUND(12.34, 1), `ROUND(12.34, -1)` = ROUND(12.34, -1), `ROUND(12, 1)` = ROUND(12, 1) | fields `ROUND(12.34)`, `ROUND(12.34, 1)`, `ROUND(12.34, -1)`, `ROUND(12, 1)`
+    fetched rows / total rows = 1/1
+    +----------------+-------------------+--------------------+----------------+
+    | ROUND(12.34)   | ROUND(12.34, 1)   | ROUND(12.34, -1)   | ROUND(12, 1)   |
+    |----------------+-------------------+--------------------+----------------|
+    | 12.0           | 12.3              | 10.0               | 12             |
+    +----------------+-------------------+--------------------+----------------+
+
+
+SIGN
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: Returns the sign of the argument as -1, 0, or 1, depending on whether the number is negative, zero, or positive
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `SIGN(1)` = SIGN(1), `SIGN(0)` = SIGN(0), `SIGN(-1.1)` = SIGN(-1.1) | fields `SIGN(1)`, `SIGN(0)`, `SIGN(-1.1)`
+    fetched rows / total rows = 1/1
+    +-----------+-----------+--------------+
+    | SIGN(1)   | SIGN(0)   | SIGN(-1.1)   |
+    |-----------+-----------+--------------|
+    | 1         | 0         | -1           |
+    +-----------+-----------+--------------+
+
+
+SIN
+---
+
+Description
+>>>>>>>>>>>
+
+Usage: sin(x) calculate the sine of x, where x is given in radians.
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type: DOUBLE
+
+Example::
+
+    od> source=people | eval `SIN(0)` = SIN(0) | fields `SIN(0)`
+    fetched rows / total rows = 1/1
+    +----------+
+    | SIN(0)   |
+    |----------|
+    | 0.0      |
+    +----------+
+
+
+SQRT
+----
+
+Description
+>>>>>>>>>>>
+
+Usage: Calculates the square root of a non-negative number
+
+Argument type: INTEGER/LONG/FLOAT/DOUBLE
+
+Return type map:
+
+(Non-negative) INTEGER/LONG/FLOAT/DOUBLE -> DOUBLE
+(Negative) INTEGER/LONG/FLOAT/DOUBLE -> NULL
+
+Example::
+
+    od> source=people | eval `SQRT(4)` = SQRT(4), `SQRT(4.41)` = SQRT(4.41) | fields `SQRT(4)`, `SQRT(4.41)`
+    fetched rows / total rows = 1/1
+    +-----------+--------------+
+    | SQRT(4)   | SQRT(4.41)   |
+    |-----------+--------------|
+    | 2.0       | 2.1          |
+    +-----------+--------------+
+

--- a/docs/experiment/ppl/functions/math.rst
+++ b/docs/experiment/ppl/functions/math.rst
@@ -6,7 +6,7 @@ Mathematical Functions
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 
 ABS

--- a/docs/experiment/ppl/functions/string.rst
+++ b/docs/experiment/ppl/functions/string.rst
@@ -90,6 +90,7 @@ Description
 Usage: like(string, PATTERN) return true if the string match the PATTERN.
 
 There are two wildcards often used in conjunction with the LIKE operator:
+
 * ``%`` - The percent sign represents zero, one, or multiple characters
 * ``_`` - The underscore represents a single character
 

--- a/docs/experiment/ppl/functions/string.rst
+++ b/docs/experiment/ppl/functions/string.rst
@@ -1,0 +1,231 @@
+================
+String Functions
+================
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 2
+
+CONCAT
+------
+
+Description
+>>>>>>>>>>>
+
+Usage: CONCAT(str1, str2) returns str1 and str strings concatenated together.
+
+Argument type: STRING, STRING
+
+Return type: STRING
+
+Example::
+
+    od> source=people | eval `CONCAT('hello', 'world')` = CONCAT('hello', 'world') | fields `CONCAT('hello', 'world')`
+    fetched rows / total rows = 1/1
+    +----------------------------+
+    | CONCAT('hello', 'world')   |
+    |----------------------------|
+    | helloworld                 |
+    +----------------------------+
+
+
+CONCAT_WS
+---------
+
+Description
+>>>>>>>>>>>
+
+Usage: CONCAT_WS(sep, str1, str2) returns str1 concatenated with str2 using sep as a separator between them.
+
+Argument type: STRING, STRING, STRING
+
+Return type: STRING
+
+Example::
+
+    od> source=people | eval `CONCAT_WS(',', 'hello', 'world')` = CONCAT_WS(',', 'hello', 'world') | fields `CONCAT_WS(',', 'hello', 'world')`
+    fetched rows / total rows = 1/1
+    +------------------------------------+
+    | CONCAT_WS(',', 'hello', 'world')   |
+    |------------------------------------|
+    | hello,world                        |
+    +------------------------------------+
+
+
+LENGTH
+------
+
+Description
+>>>>>>>>>>>
+
+Specifications:
+
+1. LENGTH(STRING) -> INTEGER
+
+Usage: length(str) returns length of string measured in bytes.
+
+Argument type: STRING
+
+Return type: INTEGER
+
+Example::
+
+    od> source=people | eval `LENGTH('helloworld')` = LENGTH('helloworld') | fields `LENGTH('helloworld')`
+    fetched rows / total rows = 1/1
+    +------------------------+
+    | LENGTH('helloworld')   |
+    |------------------------|
+    | 10                     |
+    +------------------------+
+
+
+LOCATE
+------
+
+Description
+>>>>>>>>>>>
+
+Specifications:
+
+1. LOCATE(STRING, STRING, INTEGER) -> INTEGER
+2. LOCATE(STRING, STRING) -> INTEGER
+
+
+LOWER
+-----
+
+Description
+>>>>>>>>>>>
+
+Usage: lower(string) converts the string to lowercase.
+
+Argument type: STRING
+
+Return type: STRING
+
+Example::
+
+    od> source=people | eval `LOWER('helloworld')` = LOWER('helloworld'), `LOWER('HELLOWORLD')` = LOWER('HELLOWORLD') | fields `LOWER('helloworld')`, `LOWER('HELLOWORLD')`
+    fetched rows / total rows = 1/1
+    +-----------------------+-----------------------+
+    | LOWER('helloworld')   | LOWER('HELLOWORLD')   |
+    |-----------------------+-----------------------|
+    | helloworld            | helloworld            |
+    +-----------------------+-----------------------+
+
+
+LTRIM
+-----
+
+Description
+>>>>>>>>>>>
+
+Usage: ltrim(str) trims leading space characters from the string.
+
+Argument type: STRING
+
+Return type: STRING
+
+Example::
+
+    od> source=people | eval `LTRIM('   hello')` = LTRIM('   hello'), `LTRIM('hello   ')` = LTRIM('hello   ') | fields `LTRIM('   hello')`, `LTRIM('hello   ')`
+    fetched rows / total rows = 1/1
+    +---------------------+---------------------+
+    | LTRIM('   hello')   | LTRIM('hello   ')   |
+    |---------------------+---------------------|
+    | hello               | hello               |
+    +---------------------+---------------------+
+
+
+RTRIM
+-----
+
+Description
+>>>>>>>>>>>
+
+Usage: rtrim(str) trims trailing space characters from the string.
+
+Argument type: STRING
+
+Return type: STRING
+
+Example::
+
+    od> source=people | eval `RTRIM('   hello')` = RTRIM('   hello'), `RTRIM('hello   ')` = RTRIM('hello   ') | fields `RTRIM('   hello')`, `RTRIM('hello   ')`
+    fetched rows / total rows = 1/1
+    +---------------------+---------------------+
+    | RTRIM('   hello')   | RTRIM('hello   ')   |
+    |---------------------+---------------------|
+    |    hello            | hello               |
+    +---------------------+---------------------+
+
+
+SUBSTRING
+---------
+
+Description
+>>>>>>>>>>>
+
+Usage: substring(str, start) or substring(str, start, length) returns substring using start and length. With no length, entire string from start is returned.
+
+Argument type: STRING, INTEGER, INTEGER
+
+Return type: STRING
+
+Synonyms: SUBSTR
+
+Example::
+
+    od> source=people | eval `SUBSTRING('helloworld', 5)` = SUBSTRING('helloworld', 5), `SUBSTRING('helloworld', 5, 3)` = SUBSTRING('helloworld', 5, 3) | fields `SUBSTRING('helloworld', 5)`, `SUBSTRING('helloworld', 5, 3)`
+    fetched rows / total rows = 1/1
+    +------------------------------+---------------------------------+
+    | SUBSTRING('helloworld', 5)   | SUBSTRING('helloworld', 5, 3)   |
+    |------------------------------+---------------------------------|
+    | oworld                       | owo                             |
+    +------------------------------+---------------------------------+
+
+
+TRIM
+----
+
+Description
+>>>>>>>>>>>
+
+Argument Type: STRING
+
+Return type: STRING
+
+Example::
+
+    od> source=people | eval `TRIM('   hello')` = TRIM('   hello'), `TRIM('hello   ')` = TRIM('hello   ') | fields `TRIM('   hello')`, `TRIM('hello   ')`
+    fetched rows / total rows = 1/1
+    +--------------------+--------------------+
+    | TRIM('   hello')   | TRIM('hello   ')   |
+    |--------------------+--------------------|
+    | hello              | hello              |
+    +--------------------+--------------------+
+
+
+UPPER
+-----
+
+Description
+>>>>>>>>>>>
+
+Usage: upper(string) converts the string to uppercase.
+
+Argument type: STRING
+
+Return type: STRING
+
+Example::
+
+    od> source=people | eval `UPPER('helloworld')` = UPPER('helloworld'), `UPPER('HELLOWORLD')` = UPPER('HELLOWORLD') | fields `UPPER('helloworld')`, `UPPER('HELLOWORLD')`
+    fetched rows / total rows = 1/1
+    +-----------------------+-----------------------+
+    | UPPER('helloworld')   | UPPER('HELLOWORLD')   |
+    |-----------------------+-----------------------|
+    | HELLOWORLD            | HELLOWORLD            |
+    +-----------------------+-----------------------+

--- a/docs/experiment/ppl/functions/string.rst
+++ b/docs/experiment/ppl/functions/string.rst
@@ -6,7 +6,7 @@ String Functions
 
 .. contents::
    :local:
-   :depth: 2
+   :depth: 1
 
 CONCAT
 ------

--- a/docs/experiment/ppl/functions/string.rst
+++ b/docs/experiment/ppl/functions/string.rst
@@ -81,17 +81,27 @@ Example::
     +------------------------+
 
 
-LOCATE
+LIKE
 ------
 
 Description
 >>>>>>>>>>>
 
-Specifications:
+Usage: like(string, PATTERN) return true if the string match the PATTERN.
 
-1. LOCATE(STRING, STRING, INTEGER) -> INTEGER
-2. LOCATE(STRING, STRING) -> INTEGER
+There are two wildcards often used in conjunction with the LIKE operator:
+* ``%`` - The percent sign represents zero, one, or multiple characters
+* ``_`` - The underscore represents a single character
 
+Example::
+
+    od> source=people | eval `LIKE('hello world', '_ello%')` = LIKE('hello world', '_ello%') | fields `LIKE('hello world', '_ello%')`
+    fetched rows / total rows = 1/1
+    +---------------------------------+
+    | LIKE('hello world', '_ello%')   |
+    |---------------------------------|
+    | True                            |
+    +---------------------------------+
 
 LOWER
 -----

--- a/docs/experiment/ppl/index.rst
+++ b/docs/experiment/ppl/index.rst
@@ -60,7 +60,11 @@ The query start with search command and then flowing a set of command delimited 
 
 * **Functions**
 
-  - `PPL Functions <../../user/dql/functions.rst>`_
+  - `Math Functions <functions/math.rst>`_
+
+  - `Date and Time Functions <functions/datetime.rst>`_
+
+  - `String Functions <functions/string.rst>`_
 
 * **Optimization**
 

--- a/docs/experiment/ppl/index.rst
+++ b/docs/experiment/ppl/index.rst
@@ -66,6 +66,8 @@ The query start with search command and then flowing a set of command delimited 
 
   - `String Functions <functions/string.rst>`_
 
+  - `Condition Functions <functions/condition.rst>`_
+
 * **Optimization**
 
   - `Optimization <../../user/optimization/optimization.rst>`_

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/OperatorIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/OperatorIT.java
@@ -249,10 +249,10 @@ public class OperatorIT extends PPLIntegTestCase {
   }
 
   @Test
-  public void testLikeOperator() throws IOException {
+  public void testLikeFunction() throws IOException {
     JSONObject result =
-        executeQuery(
-            String.format("source=%s firstname like 'Hatti_' | fields firstname", TEST_INDEX_BANK));
+        executeQuery(String.format("source=%s like(firstname, 'Hatti_') | fields firstname",
+            TEST_INDEX_BANK));
     verifyDataRows(result, rows("Hattie"));
   }
 

--- a/ppl/src/main/antlr/OpenDistroPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenDistroPPLLexer.g4
@@ -70,7 +70,6 @@ AND:                                'AND';
 XOR:                                'XOR';
 TRUE:                               'TRUE';
 FALSE:                              'FALSE';
-LIKE:                               'LIKE';
 REGEXP:                             'REGEXP';
 
 // DATETIME, INTERVAL AND UNIT KEYWORDS
@@ -229,6 +228,11 @@ CONCAT:                             'CONCAT';
 CONCAT_WS:                          'CONCAT_WS';
 LENGTH:                             'LENGTH';
 STRCMP:                             'STRCMP';
+
+// BOOL FUNCTIONS
+LIKE:                               'LIKE';
+ISNULL:                             'ISNULL';
+ISNOTNULL:                          'ISNOTNULL';
 
 // LITERALS AND VALUES
 //STRING_LITERAL:                     DQUOTA_STRING | SQUOTA_STRING | BQUOTA_STRING;

--- a/ppl/src/main/antlr/OpenDistroPPLParser.g4
+++ b/ppl/src/main/antlr/OpenDistroPPLParser.g4
@@ -149,6 +149,7 @@ logicalExpression
     | left=logicalExpression OR right=logicalExpression             #logicalOr
     | left=logicalExpression (AND)? right=logicalExpression         #logicalAnd
     | left=logicalExpression XOR right=logicalExpression            #logicalXor
+    | booleanExpression                                             #booleanExpr
     ;
 
 comparisonExpression
@@ -167,6 +168,10 @@ primaryExpression
     : evalFunctionCall
     | fieldExpression
     | literalValue
+    ;
+
+booleanExpression
+    : booleanFunctionCall
     ;
 
 /** tables */
@@ -208,10 +213,16 @@ evalFunctionCall
     : evalFunctionName LT_PRTHS functionArgs RT_PRTHS
     ;
 
+/** boolean functions */
+booleanFunctionCall
+    : conditionFunctionBase LT_PRTHS functionArgs RT_PRTHS
+    ;
+
 evalFunctionName
     : mathematicalFunctionBase
     | dateAndTimeFunctionBase
     | textFunctionBase
+    | conditionFunctionBase
     ;
 
 functionArgs
@@ -238,13 +249,19 @@ dateAndTimeFunctionBase
     | TIMESTAMP | TO_DAYS | YEAR | WEEK | DATE_FORMAT
     ;
 
+/** condition function return boolean value */
+conditionFunctionBase
+    : LIKE
+    | ISNULL | ISNOTNULL
+    ;
+
 textFunctionBase
     : SUBSTR | SUBSTRING | TRIM | LTRIM | RTRIM | LOWER | UPPER | CONCAT | CONCAT_WS | LENGTH | STRCMP
     ;
 
 /** operators */
 comparisonOperator
-    : EQUAL | NOT_EQUAL | LESS | NOT_LESS | GREATER | NOT_GREATER | LIKE | REGEXP
+    : EQUAL | NOT_EQUAL | LESS | NOT_LESS | GREATER | NOT_GREATER | REGEXP
     ;
 
 binaryOperator

--- a/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistroforelasticsearch.sql.ppl.parser;
 
+import static com.amazon.opendistroforelasticsearch.sql.expression.function.BuiltinFunctionName.IS_NOT_NULL;
+import static com.amazon.opendistroforelasticsearch.sql.expression.function.BuiltinFunctionName.IS_NULL;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.BinaryArithmeticContext;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.BooleanLiteralContext;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.CompareExprContext;
@@ -61,8 +63,10 @@ import com.amazon.opendistroforelasticsearch.sql.common.utils.StringUtils;
 import com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser;
 import com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParserBaseVisitor;
 import com.amazon.opendistroforelasticsearch.sql.ppl.utils.ArgumentFactory;
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;
 
@@ -70,6 +74,16 @@ import org.antlr.v4.runtime.ParserRuleContext;
  * Class of building AST Expression nodes.
  */
 public class AstExpressionBuilder extends OpenDistroPPLParserBaseVisitor<UnresolvedExpression> {
+
+  /**
+   * The function name mapping between fronted and core engine.
+   */
+  private static Map<String, String> FUNCTION_NAME_MAPPING =
+      new ImmutableMap.Builder<String, String>()
+          .put("isnull", IS_NULL.getName().getFunctionName())
+          .put("isnotnull", IS_NOT_NULL.getName().getFunctionName())
+          .build();
+
   /**
    * Eval clause.
    */
@@ -173,6 +187,23 @@ public class AstExpressionBuilder extends OpenDistroPPLParserBaseVisitor<Unresol
   public UnresolvedExpression visitPercentileAggFunction(PercentileAggFunctionContext ctx) {
     return new AggregateFunction(ctx.PERCENTILE().getText(), visit(ctx.aggField),
         Collections.singletonList(new Argument("rank", (Literal) visit(ctx.value))));
+  }
+
+  /**
+   * Eval function.
+   */
+  @Override
+  public UnresolvedExpression visitBooleanFunctionCall(
+      OpenDistroPPLParser.BooleanFunctionCallContext ctx) {
+    final String functionName = ctx.conditionFunctionBase().getText();
+
+    return new Function(
+        FUNCTION_NAME_MAPPING.getOrDefault(functionName, functionName),
+        ctx.functionArgs()
+            .functionArg()
+            .stream()
+            .map(this::visitFunctionArg)
+            .collect(Collectors.toList()));
   }
 
   /**

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -127,7 +127,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
     assertEqual("source=t isnull(a)",
         filter(
             relation("t"),
-            function("isnull", field("a"))
+            function("is null", field("a"))
         ));
   }
 
@@ -136,7 +136,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
     assertEqual("source=t isnotnull(a)",
         filter(
             relation("t"),
-            function("isnotnull", field("a"))
+            function("is not null", field("a"))
         ));
   }
 

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -114,10 +114,28 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
 
   @Test
   public void testLogicalLikeExpr() {
-    assertEqual("source=t a like '_a%b%c_d_'",
+    assertEqual("source=t like(a, '_a%b%c_d_')",
         filter(
             relation("t"),
-            compare("like", field("a"), stringLiteral("_a%b%c_d_"))
+            function("like", field("a"), stringLiteral("_a%b%c_d_"))
+        ));
+  }
+
+  @Test
+  public void testBooleanIsNullFunction() {
+    assertEqual("source=t isnull(a)",
+        filter(
+            relation("t"),
+            function("isnull", field("a"))
+        ));
+  }
+
+  @Test
+  public void testBooleanIsNotNullFunction() {
+    assertEqual("source=t isnotnull(a)",
+        filter(
+            relation("t"),
+            function("isnotnull", field("a"))
         ));
   }
 


### PR DESCRIPTION
*Issue #, if available:* #881, #883 

*Description of changes:*
1. Add the like function. https://github.com/penghuo/sql/blob/issue-881/docs/experiment/ppl/functions/string.rst#like
2. Add the isnull/isnotnull function. https://github.com/penghuo/sql/blob/issue-881/docs/experiment/ppl/functions/condition.rst
3. Restructured the PPL functions doc. https://github.com/penghuo/sql/blob/issue-881/docs/experiment/ppl/index.rst

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
