### PR TITLE
Update utils.ts

### DIFF
--- a/workbench/public/utils/utils.ts
+++ b/workbench/public/utils/utils.ts
@@ -84,7 +84,7 @@ export function scrollToNode(nodeId: string): void {
 
 // Download functions
 export function onDownloadFile(data: any, fileFormat: string, fileName: string) {
-  const encodedUri = encodeURI(data);
+  const encodedUri = encodeURIComponent(data);
   const content = 'data:text/'+fileFormat+';charset=utf-8,' + encodedUri;
   const link = document.createElement("a");
   link.setAttribute('href', content);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed encode function for saving to file.
encodeURI doesn't work very well in current versions of Chrome. This function won't escape symbols like "#".
So, all requested data that should be saved in a file will be truncated by the first # symbol in Chrome browser, in Safari this feature works fine.