### PR TITLE
Added metrics for SQL query requests in new engine

### DIFF
--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/MetricsIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/MetricsIT.java
@@ -17,7 +17,6 @@
 package com.amazon.opendistroforelasticsearch.sql.sql;
 
 import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
-import static org.hamcrest.Matchers.equalTo;
 
 import com.amazon.opendistroforelasticsearch.sql.legacy.SQLIntegTestCase;
 import com.amazon.opendistroforelasticsearch.sql.legacy.metrics.MetricName;
@@ -45,16 +44,10 @@ public class MetricsIT extends SQLIntegTestCase {
   @Test
   public void requestCount() throws IOException, InterruptedException {
     int beforeQueries = requestTotal();
-    multiSuccessfulQueries(3);
+    executeQuery(String.format(Locale.ROOT, "select age from %s", TEST_INDEX_BANK));
     TimeUnit.SECONDS.sleep(2L);
 
-    assertThat(requestTotal(), equalTo(beforeQueries + 3));
-  }
-
-  private void multiSuccessfulQueries(int num) throws IOException {
-    for (int i = 0; i < num; ++i) {
-      executeQuery(String.format(Locale.ROOT, "select age from %s", TEST_INDEX_BANK));
-    }
+    assertEquals(beforeQueries + 1, requestTotal());
   }
 
   private Request makeStatRequest() {

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/MetricsIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/MetricsIT.java
@@ -1,0 +1,85 @@
+/*
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.sql;
+
+import static com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants.TEST_INDEX_BANK;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.amazon.opendistroforelasticsearch.sql.legacy.SQLIntegTestCase;
+import com.amazon.opendistroforelasticsearch.sql.legacy.metrics.MetricName;
+import com.amazon.opendistroforelasticsearch.sql.util.TestUtils;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MetricsIT extends SQLIntegTestCase {
+
+  @Override
+  protected void init() throws Exception {
+    loadIndex(Index.BANK);
+    TestUtils.enableNewQueryEngine(client());
+  }
+
+  @Test
+  public void requestCount() throws IOException, InterruptedException {
+    int beforeQueries = requestTotal();
+    multiSuccessfulQueries(3);
+    TimeUnit.SECONDS.sleep(2L);
+
+    assertThat(requestTotal(), equalTo(beforeQueries + 3));
+  }
+
+  private void multiSuccessfulQueries(int num) throws IOException {
+    for (int i = 0; i < num; ++i) {
+      executeQuery(String.format(Locale.ROOT, "select age from %s", TEST_INDEX_BANK));
+    }
+  }
+
+  private Request makeStatRequest() {
+    return new Request(
+        "GET", "/_opendistro/_sql/stats"
+    );
+  }
+
+  private int requestTotal() throws IOException {
+    JSONObject jsonObject = new JSONObject(executeStatRequest(makeStatRequest()));
+    return jsonObject.getInt(MetricName.REQ_TOTAL.getName());
+  }
+
+  private String executeStatRequest(final Request request) throws IOException {
+    Response response = client().performRequest(request);
+    Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+    InputStream is = response.getEntity().getContent();
+    StringBuilder sb = new StringBuilder();
+    try (BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        sb.append(line);
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -198,16 +198,7 @@ public class RestSQLQueryAction extends BaseRestHandler {
   }
 
   private static void logAndPublishMetrics(Exception e) {
-    if (isServerError(e)) {
-      LOG.error(LogUtils.getRequestId() + " Server side error during query execution", e);
-      Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_SYS).increment();
-    } else {
-      LOG.error(LogUtils.getRequestId() + " Client side error during query execution", e);
-      Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_CUS).increment();
-    }
-  }
-
-  private static boolean isServerError(Exception e) {
-    return e instanceof QueryEngineException;
+    LOG.error(LogUtils.getRequestId() + " Server side error during query execution", e);
+    Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_SYS).increment();
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently the strategy of the rest query action **can inform the metrics and increment the request total before deciding which engine the query should go into**. But after the query comes to the new engine, **the metrics publish is missing if any error turns up during executing or explaining in new engine** (while the old engine can still publish the metrics if meets with errors).

This pull request is to add metrics publish when new engine meets request failure. If the exception `QueryEngineException` type of its extension type, the stats for failed request count in server (`FAILED_REQ_COUNT_SYS`) increments. Else the stats for failed request count in client (`FAILED_REQ_COUNT_CUS`) increments. 

Besides here also adds the metrics integration tests of success request cases for SQL query requests in new engine.

The failure cases are not tested in integration test because time amount to finish the metrics update might vary. Here attaches the manual sanity test of related stats in metrics, the sleep time was set to 30s, the stats were obtained from local ES log:


- Execute a query supported in new engine and does not meet any errors
```
[2020-12-10T15:43:31,936][INFO ][c.a.o.s.l.p.RestSqlAction] [147dda5ddf8a.ant.amazon.com] 
Before executing SQL query:
Request total: 0,
Failed client request count: 0,
Failed server request count 0
[2020-12-10T15:43:32,004][INFO ][c.a.o.s.l.p.RestSqlAction] [147dda5ddf8a.ant.amazon.com] [9d2e3afa-4663-492d-acee-8dcc1a7d28d7] Incoming request /_opendistro/_sql?pretty=true: ( SELECT DATE('string_literal') )
[2020-12-10T15:43:32,626][INFO ][c.a.o.s.l.p.RestSqlAction] [147dda5ddf8a.ant.amazon.com] [9d2e3afa-4663-492d-acee-8dcc1a7d28d7] Request SQLQueryRequest(jsonContent={"query":"SELECT DATE('2020-12-10')"}, query=SELECT DATE('2020-12-10'), path=/_opendistro/_sql, format=jdbc) is handled by new SQL query engine
[2020-12-10T15:43:42,681][INFO ][c.a.o.s.l.p.RestSQLQueryAction] [147dda5ddf8a.ant.amazon.com] 
After executing SQL query:
Request total: 1,
Failed client request count: 0,
Failed server request count 0
```


- Execute a query supported in new engine but meet some errors in core engine computing:
```
[2020-12-10T15:43:48,180][INFO ][c.a.o.s.l.p.RestSqlAction] [147dda5ddf8a.ant.amazon.com] 
Before executing SQL query:
Request total: 1,
Failed client request count: 0,
Failed server request count 0
[2020-12-10T15:43:48,181][INFO ][c.a.o.s.l.p.RestSqlAction] [147dda5ddf8a.ant.amazon.com] [0f2e4929-353c-4a92-b722-8e995e315cd9] Incoming request /_opendistro/_sql?pretty=true: ( SELECT DATE('string_literal') )
[2020-12-10T15:43:48,202][INFO ][c.a.o.s.l.p.RestSqlAction] [147dda5ddf8a.ant.amazon.com] [0f2e4929-353c-4a92-b722-8e995e315cd9] Request SQLQueryRequest(jsonContent={"query":"SELECT DATE('0')"}, query=SELECT DATE('0'), path=/_opendistro/_sql, format=jdbc) is handled by new SQL query engine
[2020-12-10T15:43:48,203][ERROR][c.a.o.s.l.p.RestSQLQueryAction] [147dda5ddf8a.ant.amazon.com] Error happened during query handling
com.amazon.opendistroforelasticsearch.sql.exception.SemanticCheckException: date:0 in unsupported format, please use yyyy-MM-dd
	at com.amazon.opendistroforelasticsearch.sql.data.model.ExprDateValue.<init>(ExprDateValue.java:49) ~[core-1.12.0.0.jar:?]
	at com.amazon.opendistroforelasticsearch.sql.expression.datetime.DateTimeFunction.exprDate(DateTimeFunction.java:459) ~[core-1.12.0.0.jar:?]
	at com.amazon.opendistroforelasticsearch.sql.expression.function.FunctionDSL.lambda$nullMissingHandling$5e7b55fb$1(FunctionDSL.java:245) ~[core-1.12.0.0.jar:?]

...

[2020-12-10T15:43:58,217][INFO ][c.a.o.s.l.p.RestSQLQueryAction] [147dda5ddf8a.ant.amazon.com] 
After executing SQL query:
Request total: 2,
Failed client request count: 0,
Failed server request count 1
```


- Stats API behavior:
```
// before executing
GET /_opendistro/_sql/stats

{"ppl_request_total":0,"failed_request_count_cb":0,"default_cursor_request_count":0,"default_cursor_request_total":0,"ppl_failed_request_count_syserr":0,"failed_request_count_cuserr":0,"circuit_breaker":0,"request_total":0,"ppl_failed_request_count_cuserr":0,"ppl_request_count":0,"request_count":0,"failed_request_count_syserr":0}

// executed a good query
POST _opendistro/_sql
{
  "query": "SELECT DATE('2020-12-10')"
}

GET /_opendistro/_sql/stats

{"ppl_request_total":0,"failed_request_count_cb":0,"default_cursor_request_count":0,"default_cursor_request_total":0,"ppl_failed_request_count_syserr":0,"failed_request_count_cuserr":0,"circuit_breaker":0,"request_total":1,"ppl_failed_request_count_cuserr":0,"ppl_request_count":0,"request_count":0,"failed_request_count_syserr":0}

// executed a bad query and threw `SemanticCheckException`
POST /_opendistro/_sql
{
  "query": "SELECT DATE('0')"
}

After around 30 sec...

GET /_opendistro/_sql/stats

{"ppl_request_total":0,"failed_request_count_cb":0,"default_cursor_request_count":0,"default_cursor_request_total":0,"ppl_failed_request_count_syserr":0,"failed_request_count_cuserr":0,"circuit_breaker":0,"request_total":2,"ppl_failed_request_count_cuserr":0,"ppl_request_count":0,"request_count":2,"failed_request_count_syserr":1}

```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
