### PR TITLE
Enable failed test logging and fix flaky UT

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,6 +34,11 @@ test {
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
+        showStandardStreams = false
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,11 +34,7 @@ test {
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
-        showExceptions true
         exceptionFormat "full"
-        showCauses true
-        showStackTraces true
-        showStandardStreams = false
     }
 }
 

--- a/elasticsearch/build.gradle
+++ b/elasticsearch/build.gradle
@@ -28,6 +28,11 @@ test {
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
+        showStandardStreams = false
     }
 }
 

--- a/elasticsearch/build.gradle
+++ b/elasticsearch/build.gradle
@@ -28,11 +28,7 @@ test {
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
-        showExceptions true
         exceptionFormat "full"
-        showCauses true
-        showStackTraces true
-        showStandardStreams = false
     }
 }
 

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -56,11 +56,7 @@ test {
 
     testLogging {
         events "passed", "skipped", "failed"
-        showExceptions true
         exceptionFormat "full"
-        showCauses true
-        showStackTraces true
-        showStandardStreams = false
     }
 }
 

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -53,6 +53,15 @@ test {
     // set 'project.projectDir' property to allow unit test classes to access test resources
     // in src/test/resources in current module
     systemProperty('project.root', project.projectDir.absolutePath)
+
+    testLogging {
+        events "passed", "skipped", "failed"
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
+        showStandardStreams = false
+    }
 }
 
 dependencies {

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -42,6 +42,18 @@ dependencies {
 
 }
 
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
+        showStandardStreams = false
+    }
+}
+
 jacoco {
     toolVersion = "0.8.5"
 }

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -43,14 +43,9 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
-        showExceptions true
         exceptionFormat "full"
-        showCauses true
-        showStackTraces true
-        showStandardStreams = false
     }
 }
 

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -27,6 +27,11 @@ test {
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
+        showStandardStreams = false
     }
 }
 

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -27,11 +27,7 @@ test {
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
-        showExceptions true
         exceptionFormat "full"
-        showCauses true
-        showStackTraces true
-        showStandardStreams = false
     }
 }
 

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -44,6 +44,11 @@ test {
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
+        showStandardStreams = false
     }
 }
 

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -44,11 +44,7 @@ test {
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
-        showExceptions true
         exceptionFormat "full"
-        showCauses true
-        showStackTraces true
-        showStandardStreams = false
     }
 }
 

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/context/QuerySpecification.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/context/QuerySpecification.java
@@ -40,7 +40,7 @@ import com.amazon.opendistroforelasticsearch.sql.sql.antlr.parser.OpenDistroSQLP
 import com.amazon.opendistroforelasticsearch.sql.sql.parser.AstExpressionBuilder;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -82,7 +82,7 @@ public class QuerySpecification {
    * Aggregate function calls that spreads in SELECT, HAVING clause. Since this is going to be
    * pushed to aggregation operator, de-duplicate is necessary to avoid duplication.
    */
-  private final Set<UnresolvedExpression> aggregators = new HashSet<>();
+  private final Set<UnresolvedExpression> aggregators = new LinkedHashSet<>();
 
   /**
    * Items in GROUP BY clause that may be:

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstBuilderTest.java
@@ -197,20 +197,33 @@ class AstBuilderTest {
   }
 
   @Test
-  public void can_build_count_star_and_count_literal() {
+  public void can_build_count_literal() {
     assertEquals(
         project(
             agg(
                 relation("test"),
                 ImmutableList.of(
-                    alias("COUNT(*)", aggregate("COUNT", AllFields.of())),
                     alias("COUNT(1)", aggregate("COUNT", intLiteral(1)))),
                 emptyList(),
                 emptyList(),
                 emptyList()),
-            alias("COUNT(*)", aggregate("COUNT", AllFields.of())),
             alias("COUNT(1)", aggregate("COUNT", intLiteral(1)))),
-        buildAST("SELECT COUNT(*), COUNT(1) FROM test"));
+        buildAST("SELECT COUNT(1) FROM test"));
+  }
+
+  @Test
+  public void can_build_count_star() {
+    assertEquals(
+        project(
+            agg(
+                relation("test"),
+                ImmutableList.of(
+                    alias("COUNT(*)", aggregate("COUNT", AllFields.of()))),
+                emptyList(),
+                emptyList(),
+                emptyList()),
+            alias("COUNT(*)", aggregate("COUNT", AllFields.of()))),
+        buildAST("SELECT COUNT(*) FROM test"));
   }
 
   @Test


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/909

*Description of changes:*

1. Fix UT: Suspect root cause is the use of HashSet instead of LinkedHashSet. Thus fix it and also split original UT into two in case any more flaky behavior.
2. Enable test logging for failed UT in `ppl`, `sql`, `core`, `elasticsearch`, `protocol`, `legacy` module: reference https://stackoverflow.com/questions/39350802/gradle-stack-trace-on-terminal

*Sample output:*

Here is an example of failed UT with current changes:

```
com.amazon.opendistroforelasticsearch.sql.sql.parser.AstBuilderTest > can_build_count_literal() FAILED
    org.opentest4j.AssertionFailedError: expected: <Project(projectList=[Alias(name=COUNT(1), delegated=COUNT(1), alias=null)], argExprList=[], child=[Aggregation(aggExprList=[Alias(name=COUNT(1), delegated=COUNT(1), alias=null)], sortExprList=[], groupExprList=[], argExprList=[], child=[Relation(tableName=test, alias=null)])])> but was: <Project(projectList=[Alias(name=1, delegated=1, alias=null)], argExprList=[], child=[Relation(tableName=test, alias=null)])>
        at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
        at org.junit.jupiter.api.AssertionUtils.failNotEqual(AssertionUtils.java:62)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1124)
        at com.amazon.opendistroforelasticsearch.sql.sql.parser.AstBuilderTest.can_build_count_literal(AstBuilderTest.java:201)
```

Previously without current PR changes:

```
com.amazon.opendistroforelasticsearch.sql.sql.parser.AstBuilderTest > can_build_count_literal() FAILED
    org.opentest4j.AssertionFailedError at AstBuilderTest.java:201
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
