### PR TITLE
Improve logging in new SQL engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Here is a documentation list with features only available in this improved SQL q
     * Improvement on Subqueries in FROM clause
 * [Window functions](./docs/user/dql/window.rst): ranking window function support
 
+To avoid impact on your side, normally you won't see any difference in query response. If you want to check if and why your query falls back to be handled by old SQL engine, please explain your query and check Elasticsearch log for "Request is falling back to old SQL engine due to ...".
+
 
 ## Setup
 

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -106,6 +106,10 @@ public class RestSQLQueryAction extends BaseRestHandler {
                 sqlService.analyze(
                     sqlService.parse(request.getQuery())));
     } catch (SyntaxCheckException e) {
+      // When explain, print info log for what unsupported syntax is causing fallback to old engine
+      if (request.isExplainRequest()) {
+        LOG.info("Request is falling back to old SQL engine due to: " + e.getMessage());
+      }
       return NOT_SUPPORTED_YET;
     }
 

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSqlAction.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSqlAction.java
@@ -156,8 +156,7 @@ public class RestSqlAction extends BaseRestHandler {
                                                                     format.getFormatName());
                 RestChannelConsumer result = newSqlQueryHandler.prepareRequest(newSqlRequest, client);
                 if (result != RestSQLQueryAction.NOT_SUPPORTED_YET) {
-                    LOG.info("[{}] Request {} is handled by new SQL query engine",
-                        LogUtils.getRequestId(), newSqlRequest);
+                    LOG.info("[{}] Request is handled by new SQL query engine", LogUtils.getRequestId());
                     return result;
                 }
                 LOG.debug("[{}] Request {} is not supported and falling back to old SQL engine",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/817

*Description of changes:*

1. Avoid dump request object which contains original query: Because we've logged sanitized query with request ID, actually there is no need to dump it again.
2. Add log for fall back reason: To make our development easier, added info log for fall back reason when explain queries. And also update README for user who wants to figure out this too.

*Examples*:

1. Logging for request handled by new SQL engine:

```
POST _opendistro/_sql
{
  "query": " SELECT age FROM accounts "
}
[aa74566f-ad79-4c3c-a221-5e1f6c6b88ed] Incoming request /_opendistro/_sql?pretty=true: ( SELECT identifier FROM table )
[aa74566f-ad79-4c3c-a221-5e1f6c6b88ed] Request is handled by new SQL query engine
```

2. Logging for explaining fallback due to unsupported syntax exception (ex. `LIMIT`) thrown by ANTLR parser:

```
POST _opendistro/_sql/_explain
{
  "query": " SELECT age FROM accounts LIMIT 1"
}
... Request is falling back to old SQL engine due to: Failed to parse query due to offending symbol [LIMIT] at: '
      SELECT age FROM accounts LIMIT' <--- HERE... More details: Expecting tokens in {<EOF>, ';'}
```

3. Logging for explaining fallback due to semantic exception (exception thrown manually from Analyzer):

```
POST _opendistro/_sql/_explain
{
  "query": " SELECT projects FROM employees "
}
... Request is falling back to old SQL engine due to: Identifier [projects] of type [ARRAY] is not supported yet
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
