### PR TITLE
Throw exception when access unknow field type

### DIFF
--- a/docs/experiment/ppl/index.rst
+++ b/docs/experiment/ppl/index.rst
@@ -77,3 +77,7 @@ The query start with search command and then flowing a set of command delimited 
   - `Identifiers <general/identifiers.rst>`_
 
   - `Data Types <general/datatypes.rst>`_
+
+* **Limitations**
+
+  - `Limitations <limitations/limitations.rst>`_

--- a/docs/experiment/ppl/limitations/limitations.rst
+++ b/docs/experiment/ppl/limitations/limitations.rst
@@ -1,0 +1,21 @@
+
+===========
+Limitations
+===========
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Introduction
+============
+
+In this doc, the restrictions and limitations of PPL is covered as follows.
+
+Limitations on Fields
+=====================
+
+We are not supporting use `alias field type <https://www.elastic.co/guide/en/elasticsearch/reference/current/alias.html>`_ as identifier. It will throw exception ``can't resolve Symbol``.

--- a/docs/user/limitations/limitations.rst
+++ b/docs/user/limitations/limitations.rst
@@ -20,6 +20,12 @@ Limitations on Identifiers
 
 Using Elasticsearch cluster name as catalog name to qualify an index name, such as ``my_cluster.my_index``, is not supported for now.
 
+Limitations on Fields
+=====================
+
+We are not supporting use `alias field type <https://www.elastic.co/guide/en/elasticsearch/reference/current/alias.html>`_ as identifier. It will throw exception ``can't resolve Symbol``.
+
+
 Limitations on Aggregations
 ===========================
 

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/system/ElasticsearchDescribeIndexRequest.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/request/system/ElasticsearchDescribeIndexRequest.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -113,7 +114,10 @@ public class ElasticsearchDescribeIndexRequest implements ElasticsearchSystemReq
     Map<String, ExprType> fieldTypes = new HashMap<>();
     Map<String, IndexMapping> indexMappings = client.getIndexMappings(indexName);
     for (IndexMapping indexMapping : indexMappings.values()) {
-      fieldTypes.putAll(indexMapping.getAllFieldTypes(this::transformESTypeToExprType));
+      fieldTypes
+          .putAll(indexMapping.getAllFieldTypes(this::transformESTypeToExprType).entrySet().stream()
+              .filter(entry -> !ExprCoreType.UNKNOWN.equals(entry.getValue()))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
     return fieldTypes;
   }


### PR DESCRIPTION
*Issue #, if available:* #941

*Description of changes:*
1. Remove the unknow type field from symbol table.
2. update the limitation doc to callout alias field type can't be used as identifier.
a. SQL, https://github.com/penghuo/sql/blob/issue-941/docs/user/limitations/limitations.rst
b. PPL, https://github.com/penghuo/sql/blob/issue-941/docs/experiment/ppl/limitations/limitations.rst


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
