### PR TITLE
Fix URI Encoding in 1.12

### DIFF
--- a/workbench/public/utils/utils.ts
+++ b/workbench/public/utils/utils.ts
@@ -84,7 +84,7 @@ export function scrollToNode(nodeId: string): void {
 
 // Download functions
 export function onDownloadFile(data: any, fileFormat: string, fileName: string) {
-  const encodedUri = encodeURI(data);
+  const encodedUri = encodeURIComponent(data); 
   const content = 'data:text/'+fileFormat+';charset=utf-8,' + encodedUri;
   const link = document.createElement("a");
   link.setAttribute('href', content);

--- a/workbench/public/utils/utils.ts
+++ b/workbench/public/utils/utils.ts
@@ -84,7 +84,7 @@ export function scrollToNode(nodeId: string): void {
 
 // Download functions
 export function onDownloadFile(data: any, fileFormat: string, fileName: string) {
-  const encodedUri = encodeURIComponent(data); 
+  const encodedUri = encodeURIComponent(data);
   const content = 'data:text/'+fileFormat+';charset=utf-8,' + encodedUri;
   const link = document.createElement("a");
   link.setAttribute('href', content);


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Change encoding function for saving to file to escape symbols like `#` correctly.
Related: #896

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
