### PR TITLE
Keep development doc sync with latest code

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -32,7 +32,7 @@ Here are the official instructions on how to set ``JAVA_HOME`` for different pla
 Elasticsearch & Kibana
 ----------------------
 
-For convenience, we recommend installing Elasticsearch and Kibana on your local machine. You can download the open source ZIP for each and extract them to a folder.
+For convenience, we recommend installing `Elasticsearch <https://www.elastic.co/downloads/past-releases#elasticsearch-oss>`_ and `Kibana <https://www.elastic.co/downloads/past-releases#kibana-oss>`_ on your local machine. You can download the open source ZIP for each and extract them to a folder.
 
 If you just want to have a quick look, you can also get an Elasticsearch running with plugin installed by ``./gradlew :plugin:run``.
 
@@ -217,7 +217,7 @@ Most of the time you just need to run ./gradlew build which will make sure you p
      - Run all checks according to Checkstyle configuration.
    * - ./gradlew test
      - Run all unit tests.
-   * - ./gradlew :integ-test:integTestRunner
+   * - ./gradlew :integ-test:integTest
      - Run all integration test (this takes time).
    * - ./gradlew build
      - Build plugin by run all tasks above (this takes time).


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes: Update the [Developer Guide](https://github.com/penghuo/sql/blob/fix-develop-readme/docs/developing.rst)
1. Add the Elasticsearch OSS and Kibana OSS download link. Currently, it to official Elasticsearch website because ODFE Kibana doesn't have MAC version.
2. Fix the integ-test command.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
