### PR TITLE
Adding additional logging to ExprMissingValue exception

### DIFF
--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/expression/domain/BindingTuple.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/expression/domain/BindingTuple.java
@@ -46,7 +46,7 @@ public class BindingTuple {
      * @return binding value.
      */
     public ExprValue resolve(String bindingName) {
-        return bindingMap.getOrDefault(bindingName, new ExprMissingValue());
+        return bindingMap.getOrDefault(bindingName, new ExprMissingValue(bindingName, bindingMap.keySet()));
     }
 
     @Override

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/expression/model/ExprMissingValue.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/expression/model/ExprMissingValue.java
@@ -15,10 +15,25 @@
 
 package com.amazon.opendistroforelasticsearch.sql.legacy.expression.model;
 
+import java.util.Set;
+
 /**
  * The definition of the missing value.
  */
 public class ExprMissingValue implements ExprValue {
+    private final String missingValue;
+    private final Set<String> availableValues;
+
+    public ExprMissingValue(String missingValue, Set<String> availableValues) {
+        this.missingValue = missingValue;
+        this.availableValues = availableValues;
+    }
+
+    @Override
+    public Object value() {
+        throw new IllegalStateException("invalid value operation on " + kind() + " (" + this.missingValue + "), available: " + this.availableValues.toString());
+    }
+
     @Override
     public ExprValueKind kind() {
         return ExprValueKind.MISSING_VALUE;


### PR DESCRIPTION
*Issue #, if available:*

In a simple GROUP BY queries I'm getting the following exception and need more info about the problem:
```
{
  "error": {
    "reason": "There was internal problem at backend",
    "details": "invalid value operation on MISSING_VALUE",
    "type": "IllegalStateException"
  },
  "status": 500
}
```

FAILS
```
POST _opendistro/_sql
{
  "query": "select ABC.Status, count(*) from my_index group by ABC.Status"
}
```

WORKS with ?format=json
```
POST _opendistro/_sql?format=json
{
  "query": "select ABC.Status, count(*) from my_index group by ABC.Status"
}

```

*Description of changes:*
Adding additional details to the error message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
