### PR TITLE
[PPL] Support index name with date suffix

### DIFF
--- a/docs/experiment/ppl/general/identifiers.rst
+++ b/docs/experiment/ppl/general/identifiers.rst
@@ -30,6 +30,8 @@ For Elasticsearch, the following identifiers are supported extensionally:
 3. Identifiers with ``-`` in the middle: this is mostly the case for index name with date information.
 4. Identifiers with star ``*`` present: this is mostly an index pattern for wildcard match.
 
+Index name with date suffix separated by dash or dots, such as ``cwl-2020.01.11`` or ``logs-7.0-2020.01.11``, is common for those created by Logstash or FileBeat ingestion. So, this kind of identifier used as index name is also supported without the need of being quoted for user convenience.
+
 Examples
 --------
 

--- a/docs/experiment/ppl/general/identifiers.rst
+++ b/docs/experiment/ppl/general/identifiers.rst
@@ -30,7 +30,7 @@ For Elasticsearch, the following identifiers are supported extensionally:
 3. Identifiers with ``-`` in the middle: this is mostly the case for index name with date information.
 4. Identifiers with star ``*`` present: this is mostly an index pattern for wildcard match.
 
-Index name with date suffix separated by dash or dots, such as ``cwl-2020.01.11`` or ``logs-7.0-2020.01.11``, is common for those created by Logstash or FileBeat ingestion. So, this kind of identifier used as index name is also supported without the need of being quoted for user convenience.
+Index name with date suffix separated by dash or dots, such as ``cwl-2020.01.11`` or ``logs-7.0-2020.01.11``, is common for those created by Logstash or FileBeat ingestion. So, this kind of identifier used as index name is also supported without the need of being quoted for user convenience. In this case, wildcard within date pattern is also allowed to search for data across indices of different date range. For example, you can use ``logs-2020.1*`` to search in indices for October, November and December 2020.
 
 Examples
 --------

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/SearchCommandIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/SearchCommandIT.java
@@ -53,10 +53,10 @@ public class SearchCommandIT extends PPLIntegTestCase {
   @Test
   public void testSearchCommandWithSpecialIndexName() throws IOException {
     executeRequest(new Request("PUT", "/logs-2021.01.11"));
-    executeQuery("search source=logs-2021.01.11");
+    verifyDataRows(executeQuery("search source=logs-2021.01.11"));
 
     executeRequest(new Request("PUT", "/logs-7.10.0-2021.01.11"));
-    executeQuery("search source=logs-7.10.0-2021.01.11");
+    verifyDataRows(executeQuery("search source=logs-7.10.0-2021.01.11"));
   }
 
   @Test

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/SearchCommandIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/SearchCommandIT.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.ppl;
 
+import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,15 @@ public class SearchCommandIT extends PPLIntegTestCase {
     assertEquals(
         executeQueryToString(String.format("search source=%s", TEST_INDEX_BANK)),
         executeQueryToString(String.format("source=%s", TEST_INDEX_BANK)));
+  }
+
+  @Test
+  public void testSearchCommandWithSpecialIndexName() throws IOException {
+    executeRequest(new Request("PUT", "/logs-2021.01.11"));
+    executeQuery("search source=logs-2021.01.11");
+
+    executeRequest(new Request("PUT", "/logs-7.10.0-2021.01.11"));
+    executeQuery("search source=logs-7.10.0-2021.01.11");
   }
 
   @Test

--- a/ppl/src/main/antlr/OpenDistroPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenDistroPPLLexer.g4
@@ -242,7 +242,7 @@ INTEGER_LITERAL:                    DEC_DIGIT+;
 DECIMAL_LITERAL:                    (DEC_DIGIT+)? '.' DEC_DIGIT+;
 
 fragment ID_LITERAL:                [@*A-Z]+?[*A-Z_\-0-9]*;
-ID_DOT:                             ID_LITERAL ([\-.][0-9]+)*;
+ID_DOT:                             ID_LITERAL ([\-.][*0-9]+)*;
 DQUOTA_STRING:                      '"' ( '\\'. | '""' | ~('"'| '\\') )* '"';
 SQUOTA_STRING:                      '\'' ('\\'. | '\'\'' | ~('\'' | '\\'))* '\'';
 BQUOTA_STRING:                      '`' ( '\\'. | '``' | ~('`'|'\\'))* '`';

--- a/ppl/src/main/antlr/OpenDistroPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenDistroPPLLexer.g4
@@ -242,6 +242,7 @@ INTEGER_LITERAL:                    DEC_DIGIT+;
 DECIMAL_LITERAL:                    (DEC_DIGIT+)? '.' DEC_DIGIT+;
 
 fragment ID_LITERAL:                [@*A-Z]+?[*A-Z_\-0-9]*;
+ID_DOT:                             ID_LITERAL ([\-.][0-9]+)*;
 DQUOTA_STRING:                      '"' ( '\\'. | '""' | ~('"'| '\\') )* '"';
 SQUOTA_STRING:                      '\'' ('\\'. | '\'\'' | ~('\'' | '\\'))* '\'';
 BQUOTA_STRING:                      '`' ( '\\'. | '``' | ~('`'|'\\'))* '`';

--- a/ppl/src/main/antlr/OpenDistroPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenDistroPPLLexer.g4
@@ -241,8 +241,9 @@ ID:                                 ID_LITERAL;
 INTEGER_LITERAL:                    DEC_DIGIT+;
 DECIMAL_LITERAL:                    (DEC_DIGIT+)? '.' DEC_DIGIT+;
 
+fragment DATE_SUFFIX:               ([\-.][*0-9]+)*;
 fragment ID_LITERAL:                [@*A-Z]+?[*A-Z_\-0-9]*;
-ID_DOT:                             ID_LITERAL ([\-.][*0-9]+)*;
+ID_DATE_SUFFIX:                     ID_LITERAL DATE_SUFFIX;
 DQUOTA_STRING:                      '"' ( '\\'. | '""' | ~('"'| '\\') )* '"';
 SQUOTA_STRING:                      '\'' ('\\'. | '\'\'' | ~('\'' | '\\'))* '\'';
 BQUOTA_STRING:                      '`' ( '\\'. | '``' | ~('`'|'\\'))* '`';

--- a/ppl/src/main/antlr/OpenDistroPPLParser.g4
+++ b/ppl/src/main/antlr/OpenDistroPPLParser.g4
@@ -178,7 +178,7 @@ booleanExpression
 /** tables */
 tableSource
     : qualifiedName
-    | ID_DOT
+    | ID_DATE_SUFFIX
     ;
 
 /** fields */
@@ -312,11 +312,11 @@ valueList
     ;
 
 qualifiedName
-    : ident (DOT ident)*                                            #identsAsQualifiedName
+    : ident /* (DOT ident)* */                                           #identsAsQualifiedName
     ;
 
 wcQualifiedName
-    : wildcard (DOT wildcard)*                                      #identsAsWildcardQualifiedName
+    : wildcard /*(DOT wildcard)* */                                      #identsAsWildcardQualifiedName
     ;
 
 ident

--- a/ppl/src/main/antlr/OpenDistroPPLParser.g4
+++ b/ppl/src/main/antlr/OpenDistroPPLParser.g4
@@ -312,11 +312,11 @@ valueList
     ;
 
 qualifiedName
-    : ident /* (DOT ident)* */                                           #identsAsQualifiedName
+    : ident                                          #identsAsQualifiedName
     ;
 
 wcQualifiedName
-    : wildcard /*(DOT wildcard)* */                                      #identsAsWildcardQualifiedName
+    : wildcard                                       #identsAsWildcardQualifiedName
     ;
 
 ident

--- a/ppl/src/main/antlr/OpenDistroPPLParser.g4
+++ b/ppl/src/main/antlr/OpenDistroPPLParser.g4
@@ -178,6 +178,7 @@ booleanExpression
 /** tables */
 tableSource
     : qualifiedName
+    | ID_DOT
     ;
 
 /** fields */

--- a/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilder.java
+++ b/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilder.java
@@ -267,7 +267,7 @@ public class AstBuilder extends OpenDistroPPLParserBaseVisitor<UnresolvedPlan> {
    */
   @Override
   public UnresolvedPlan visitFromClause(FromClauseContext ctx) {
-    return new Relation(visitExpression(ctx.tableSource().qualifiedName()));
+    return new Relation(visitExpression(ctx.tableSource()));
   }
 
   /**

--- a/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -227,8 +227,7 @@ public class AstExpressionBuilder extends OpenDistroPPLParserBaseVisitor<Unresol
 
   @Override
   public UnresolvedExpression visitTableSource(TableSourceContext ctx) {
-    return new QualifiedName(Collections.singletonList(
-        StringUtils.unquoteIdentifier(ctx.getText())));
+    return visitIdentifier(ctx);
   }
 
   /**
@@ -236,25 +235,13 @@ public class AstExpressionBuilder extends OpenDistroPPLParserBaseVisitor<Unresol
    */
   @Override
   public UnresolvedExpression visitIdentsAsQualifiedName(IdentsAsQualifiedNameContext ctx) {
-    return new QualifiedName(
-        ctx.ident()
-            .stream()
-            .map(ParserRuleContext::getText)
-            .map(StringUtils::unquoteText)
-            .collect(Collectors.toList())
-    );
+    return visitIdentifier(ctx.ident());
   }
 
   @Override
   public UnresolvedExpression visitIdentsAsWildcardQualifiedName(
       IdentsAsWildcardQualifiedNameContext ctx) {
-    return new QualifiedName(
-        ctx.wildcard()
-            .stream()
-            .map(ParserRuleContext::getText)
-            .map(StringUtils::unquoteText)
-            .collect(Collectors.toList())
-    );
+    return visitIdentifier(ctx.wildcard());
   }
 
   @Override
@@ -281,6 +268,11 @@ public class AstExpressionBuilder extends OpenDistroPPLParserBaseVisitor<Unresol
   @Override
   public UnresolvedExpression visitBooleanLiteral(BooleanLiteralContext ctx) {
     return new Literal(Boolean.valueOf(ctx.getText()), DataType.BOOLEAN);
+  }
+
+  private UnresolvedExpression visitIdentifier(ParserRuleContext ctx) {
+    return new QualifiedName(Collections.singletonList(
+        StringUtils.unquoteIdentifier(ctx.getText())));
   }
 
 }

--- a/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -18,8 +18,10 @@ package com.amazon.opendistroforelasticsearch.sql.ppl.parser;
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.BuiltinFunctionName.IS_NOT_NULL;
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.BuiltinFunctionName.IS_NULL;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.BinaryArithmeticContext;
+import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.BooleanFunctionCallContext;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.BooleanLiteralContext;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.CompareExprContext;
+import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.CountAllFunctionCallContext;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.DecimalLiteralContext;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.EvalClauseContext;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.EvalFunctionCallContext;
@@ -38,6 +40,7 @@ import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDis
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.SortFieldContext;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.StatsFunctionCallContext;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.StringLiteralContext;
+import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.TableSourceContext;
 import static com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser.WcFieldExpressionContext;
 
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.AggregateFunction;
@@ -59,7 +62,6 @@ import com.amazon.opendistroforelasticsearch.sql.ast.expression.QualifiedName;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Xor;
 import com.amazon.opendistroforelasticsearch.sql.common.utils.StringUtils;
-import com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParser;
 import com.amazon.opendistroforelasticsearch.sql.ppl.antlr.parser.OpenDistroPPLParserBaseVisitor;
 import com.amazon.opendistroforelasticsearch.sql.ppl.utils.ArgumentFactory;
 import com.google.common.collect.ImmutableMap;
@@ -183,8 +185,7 @@ public class AstExpressionBuilder extends OpenDistroPPLParserBaseVisitor<Unresol
   }
 
   @Override
-  public UnresolvedExpression visitCountAllFunctionCall(
-      OpenDistroPPLParser.CountAllFunctionCallContext ctx) {
+  public UnresolvedExpression visitCountAllFunctionCall(CountAllFunctionCallContext ctx) {
     return new AggregateFunction("count", AllFields.of());
   }
 
@@ -198,8 +199,7 @@ public class AstExpressionBuilder extends OpenDistroPPLParserBaseVisitor<Unresol
    * Eval function.
    */
   @Override
-  public UnresolvedExpression visitBooleanFunctionCall(
-      OpenDistroPPLParser.BooleanFunctionCallContext ctx) {
+  public UnresolvedExpression visitBooleanFunctionCall(BooleanFunctionCallContext ctx) {
     final String functionName = ctx.conditionFunctionBase().getText();
 
     return new Function(
@@ -223,6 +223,12 @@ public class AstExpressionBuilder extends OpenDistroPPLParserBaseVisitor<Unresol
             .stream()
             .map(this::visitFunctionArg)
             .collect(Collectors.toList()));
+  }
+
+  @Override
+  public UnresolvedExpression visitTableSource(TableSourceContext ctx) {
+    return new QualifiedName(Collections.singletonList(
+        StringUtils.unquoteIdentifier(ctx.getText())));
   }
 
   /**

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilderTest.java
@@ -381,6 +381,7 @@ public class AstBuilderTest {
   @Test
   public void testIdentifierAsIndexNameWithDotInTheMiddle() {
     assertEqual("source=log.2020.10.10", relation("log.2020.10.10"));
+    assertEqual("source=log-7.10-2020.10.10", relation("log-7.10-2020.10.10"));
   }
 
   @Test

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilderTest.java
@@ -379,9 +379,8 @@ public class AstBuilderTest {
   }
 
   @Test
-  public void identifierAsIndexNameWithDotInTheMiddleThrowException() {
-    exceptionRule.expect(SyntaxCheckException.class);
-    plan("source=log.2020.10.10");
+  public void testIdentifierAsIndexNameWithDotInTheMiddle() {
+    assertEqual("source=log.2020.10.10", relation("log.2020.10.10"));
   }
 
   @Test

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstBuilderTest.java
@@ -50,7 +50,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.amazon.opendistroforelasticsearch.sql.ast.Node;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.RareTopN.CommandType;
-import com.amazon.opendistroforelasticsearch.sql.common.antlr.SyntaxCheckException;
 import com.amazon.opendistroforelasticsearch.sql.ppl.antlr.PPLSyntaxParser;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -394,6 +393,13 @@ public class AstBuilderTest {
   public void testIdentifierAsIndexNameContainStar() {
     assertEqual("source=log-2020-10-*",
         relation("log-2020-10-*"));
+  }
+
+  @Test
+  public void testIdentifierAsIndexNameContainStarAndDots() {
+    assertEqual("source=log-2020.10.*", relation("log-2020.10.*"));
+    assertEqual("source=log-2020.*.01", relation("log-2020.*.01"));
+    assertEqual("source=log-2020.*.*", relation("log-2020.*.*"));
   }
 
   @Test

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilderTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/parser/AstExpressionBuilderTest.java
@@ -376,6 +376,7 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
         ));
   }
 
+  @Ignore("Nested field is not supported in backend yet")
   @Test
   public void testNestedFieldName() {
     assertEqual("source=t | fields field0.field1.field2",
@@ -390,6 +391,19 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
 
   @Test
   public void testFieldNameWithSpecialChars() {
+    assertEqual("source=t | fields `field-0`",
+        projectWithArg(
+            relation("t"),
+            defaultFieldsArgs(),
+            field(
+                qualifiedName("field-0")
+            )
+        ));
+  }
+
+  @Ignore("Nested field is not supported in backend yet")
+  @Test
+  public void testNestedFieldNameWithSpecialChars() {
     assertEqual("source=t | fields `field-0`.`field#1`.`field*2`",
         projectWithArg(
             relation("t"),
@@ -486,9 +500,9 @@ public class AstExpressionBuilderTest extends AstBuilderTest {
   @Test
   public void canBuildKeywordsAsIdentInQualifiedName() {
     assertEqual(
-        "source=test.timestamp | fields timestamp",
+        "source=test | fields timestamp",
         projectWithArg(
-            relation("test.timestamp"),
+            relation("test"),
             defaultFieldsArgs(),
             field("timestamp")
         )

--- a/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/com/amazon/opendistroforelasticsearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -151,8 +151,8 @@ public class PPLQueryDataAnonymizerTest {
 
   @Test
   public void testQualifiedName() {
-    assertEquals("source=t | fields + field0.field1",
-        anonymize("source=t | fields field0.field1")
+    assertEquals("source=t | fields + field0",
+        anonymize("source=t | fields field0")
     );
   }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/980

*Description of changes:*

1. Support index name with date suffix separated by dash or dot: Add an alternative for index name rule to avoid change on qualified name and thus impact on other identifiers, such as alias and field name.
2. Disable nested field rule in grammar: because it is not supported in core engine.

With the first change, the following index names are supported now. Please find more details in user manual doc below.

1. Date suffix: `filebeat-2020.01.11`
2. Multi date suffix separated by dash: `filebeat-7.10-2020.01.11`
3. Wildcard: `filebeat-2020.*` or `filebeat-2020.*.11`

*Documentation*: Add a new paragraph for this support for index name only. https://github.com/dai-chen/sql/blob/support-index-name-with-dots-in-ppl/docs/experiment/ppl/general/identifiers.rst#description

*Testing*: All old UT/IT passed. Add new UT/IT to verify different index names.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
