### PR TITLE
Bump jackson-databind version to 2.10.5.1

### DIFF
--- a/elasticsearch/build.gradle
+++ b/elasticsearch/build.gradle
@@ -12,8 +12,8 @@ dependencies {
     compile project(':core')
     compile group: 'org.elasticsearch', name: 'elasticsearch', version: "${es_version}"
     compile "io.github.resilience4j:resilience4j-retry:1.5.0"
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.4'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.4'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5' 
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
     compile group: 'org.json', name: 'json', version:'20180813'
     compileOnly group: 'org.elasticsearch.client', name: 'elasticsearch-rest-high-level-client', version: "${es_version}"
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 configurations.all {
     exclude group: "commons-logging", module: "commons-logging"
+    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:29.0-jre'

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -25,10 +25,10 @@ repositories {
 
 configurations.all {
     exclude group: "commons-logging", module: "commons-logging"
-    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:29.0-jre'
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.10.5'
 }
 
 dependencies {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -31,6 +31,7 @@ thirdPartyAudit.enabled = false
 configurations.all {
     // conflict with spring-jcl
     exclude group: "commons-logging", module: "commons-logging"
+    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:29.0-jre'

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -31,7 +31,7 @@ thirdPartyAudit.enabled = false
 configurations.all {
     // conflict with spring-jcl
     exclude group: "commons-logging", module: "commons-logging"
-    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.10.5'
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:29.0-jre'

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -11,8 +11,8 @@ repositories {
 dependencies {
     // https://github.com/google/guava/wiki/CVE-2018-10237
     compile group: 'com.google.guava', name: 'guava', version: '29.0-jre'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.4'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.4'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5' 
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
     implementation 'com.google.code.gson:gson:2.8.6'
     compile project(':core')
     compile project(':elasticsearch')

--- a/sql-jdbc/build.gradle
+++ b/sql-jdbc/build.gradle
@@ -52,7 +52,7 @@ repositories {
 
 dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.6'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.7'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5'
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.452'
 
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.3.1')


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
* Bump jackson-databind version to 2.10.5.1 to address CVE for sql
* Bump jackson-core version to 2.10.5
* Force integ-test to use jackson-core version 2.10.5
* Exclude jackson-core from :plugin 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
