### PR TITLE
Fetch error message in root cause for new default formatter

### DIFF
--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/error/ErrorMessage.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/error/ErrorMessage.java
@@ -28,17 +28,16 @@ public class ErrorMessage {
 
   protected Throwable exception;
 
-  @Getter
-  private int status;
+  private final int status;
 
   @Getter
-  private String type;
+  private final String type;
 
   @Getter
-  private String reason;
+  private final String reason;
 
   @Getter
-  private String details;
+  private final String details;
 
   /**
    * Error Message Constructor.

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/error/ErrorMessage.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/error/ErrorMessage.java
@@ -17,6 +17,7 @@
 
 package com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.error;
 
+import lombok.Getter;
 import org.elasticsearch.rest.RestStatus;
 import org.json.JSONObject;
 
@@ -25,17 +26,24 @@ import org.json.JSONObject;
  */
 public class ErrorMessage {
 
-  protected Exception exception;
+  protected Throwable exception;
 
+  @Getter
   private int status;
+
+  @Getter
   private String type;
+
+  @Getter
   private String reason;
+
+  @Getter
   private String details;
 
   /**
    * Error Message Constructor.
    */
-  public ErrorMessage(Exception exception, int status) {
+  public ErrorMessage(Throwable exception, int status) {
     this.exception = exception;
     this.status = status;
 

--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/error/ErrorMessageFactory.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/response/error/ErrorMessageFactory.java
@@ -31,7 +31,7 @@ public class ErrorMessageFactory {
    * @param status exception status code
    * @return error message
    */
-  public static ErrorMessage createErrorMessage(Exception e, int status) {
+  public static ErrorMessage createErrorMessage(Throwable e, int status) {
     Throwable cause = unwrapCause(e);
     if (cause instanceof ElasticsearchException) {
       ElasticsearchException exception = (ElasticsearchException) cause;

--- a/protocol/src/main/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/JdbcResponseFormatter.java
+++ b/protocol/src/main/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/JdbcResponseFormatter.java
@@ -58,13 +58,13 @@ public class JdbcResponseFormatter extends JsonResponseFormatter<QueryResult> {
 
   @Override
   public String format(Throwable t) {
-    ErrorMessage message = ErrorMessageFactory.createErrorMessage(t, getStatus(t));
-
+    int status = getStatus(t);
+    ErrorMessage message = ErrorMessageFactory.createErrorMessage(t, status);
     Error error = new Error(
         message.getType(),
         message.getReason(),
         message.getDetails());
-    return jsonify(new JdbcErrorResponse(error, message.getStatus()));
+    return jsonify(new JdbcErrorResponse(error, status));
   }
 
   private Column fetchColumn(Schema.Column col) {

--- a/protocol/src/main/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/JdbcResponseFormatter.java
+++ b/protocol/src/main/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/JdbcResponseFormatter.java
@@ -18,6 +18,8 @@ package com.amazon.opendistroforelasticsearch.sql.protocol.response.format;
 
 import com.amazon.opendistroforelasticsearch.sql.common.antlr.SyntaxCheckException;
 import com.amazon.opendistroforelasticsearch.sql.data.type.ExprType;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.error.ErrorMessage;
+import com.amazon.opendistroforelasticsearch.sql.elasticsearch.response.error.ErrorMessageFactory;
 import com.amazon.opendistroforelasticsearch.sql.exception.QueryEngineException;
 import com.amazon.opendistroforelasticsearch.sql.executor.ExecutionEngine.Schema;
 import com.amazon.opendistroforelasticsearch.sql.protocol.response.QueryResult;
@@ -56,11 +58,13 @@ public class JdbcResponseFormatter extends JsonResponseFormatter<QueryResult> {
 
   @Override
   public String format(Throwable t) {
+    ErrorMessage message = ErrorMessageFactory.createErrorMessage(t, getStatus(t));
+
     Error error = new Error(
-        t.getClass().getSimpleName(),
-        t.getMessage(),
-        t.getMessage());
-    return jsonify(new JdbcErrorResponse(error, getStatus(t)));
+        message.getType(),
+        message.getReason(),
+        message.getDetails());
+    return jsonify(new JdbcErrorResponse(error, message.getStatus()));
   }
 
   private Column fetchColumn(Schema.Column col) {

--- a/protocol/src/test/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/JdbcResponseFormatterTest.java
+++ b/protocol/src/test/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/JdbcResponseFormatterTest.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonParser;
 import java.util.Arrays;
+import org.elasticsearch.ElasticsearchException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -151,6 +152,25 @@ class JdbcResponseFormatterTest {
             + "},"
             + "\"status\":503}",
         formatter.format(new IllegalStateException("Execution error"))
+    );
+  }
+
+  @Test
+  void format_server_error_response_due_to_elasticsearch() {
+    assertJsonEquals(
+        "{\"error\":"
+            + "{\""
+            + "type\":\"ElasticsearchException\","
+            + "\"reason\":\"Error occurred in Elasticsearch engine: all shards failed\","
+            + "\"details\":\"ElasticsearchException[all shards failed]; "
+            + "nested: IllegalStateException[Execution error];; "
+            + "java.lang.IllegalStateException: Execution error\\n"
+            + "For more details, please send request for Json format to see the raw response "
+            + "from elasticsearch engine.\""
+            + "},"
+            + "\"status\":503}",
+        formatter.format(new ElasticsearchException("all shards failed",
+            new IllegalStateException("Execution error")))
     );
   }
 

--- a/protocol/src/test/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/JdbcResponseFormatterTest.java
+++ b/protocol/src/test/java/com/amazon/opendistroforelasticsearch/sql/protocol/response/format/JdbcResponseFormatterTest.java
@@ -118,7 +118,7 @@ class JdbcResponseFormatterTest {
         "{\"error\":"
             + "{\""
             + "type\":\"SyntaxCheckException\","
-            + "\"reason\":\"Invalid query syntax\","
+            + "\"reason\":\"Invalid Query\","
             + "\"details\":\"Invalid query syntax\""
             + "},"
             + "\"status\":400}",
@@ -132,7 +132,7 @@ class JdbcResponseFormatterTest {
         "{\"error\":"
             + "{\""
             + "type\":\"SemanticCheckException\","
-            + "\"reason\":\"Invalid query semantics\","
+            + "\"reason\":\"Invalid Query\","
             + "\"details\":\"Invalid query semantics\""
             + "},"
             + "\"status\":400}",
@@ -146,7 +146,7 @@ class JdbcResponseFormatterTest {
         "{\"error\":"
             + "{\""
             + "type\":\"IllegalStateException\","
-            + "\"reason\":\"Execution error\","
+            + "\"reason\":\"There was internal problem at backend\","
             + "\"details\":\"Execution error\""
             + "},"
             + "\"status\":503}",


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/1002

*Description of changes:* Reuse existing `ErrorMessage` and `ErrorMessageFactory` to extract root cause info from Elasticsearch search. After changed, the error response is exactly same as that of old engine and PPL.

*Testing*: UT and manual verification as below

Without the fix:

```
PUT _settings
{
  "index.max_result_window": 100
}

POST _opendistro/_sql/
{
  "query": """
    SELECT * FROM accounts
  """
}
{
  "error": {
    "type": "SearchPhaseExecutionException",
    "reason": "all shards failed",
    "details": "all shards failed"
  },
  "status": 400
}
```

After the fix:

```
{
  "error": {
    "type": "SearchPhaseExecutionException",
    "reason": "Error occurred in Elasticsearch engine: all shards failed",
    "details": "Shard[0]: java.lang.IllegalArgumentException: Result window is too large, from + size must be less than or equal to: [100] but was [200]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level setting.\n\nFor more details, please send request for Json format to see the raw response from elasticsearch engine."
  },
  "status": 400
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
