### PR TITLE
Fixed interval type null/missing check failure

### DIFF
--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/IntervalClause.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/IntervalClause.java
@@ -24,6 +24,8 @@ import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.L
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.STRING;
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.FunctionDSL.define;
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.FunctionDSL.impl;
+import static com.amazon.opendistroforelasticsearch.sql.expression.function.FunctionDSL.nullMissingHandling;
+
 
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprIntervalValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
@@ -54,8 +56,8 @@ public class IntervalClause {
 
   private FunctionResolver interval() {
     return define(BuiltinFunctionName.INTERVAL.getName(),
-        impl(IntervalClause::interval, INTERVAL, INTEGER, STRING),
-        impl(IntervalClause::interval, INTERVAL, LONG, STRING));
+        impl(nullMissingHandling(IntervalClause::interval), INTERVAL, INTEGER, STRING),
+        impl(nullMissingHandling(IntervalClause::interval), INTERVAL, LONG, STRING));
   }
 
   private ExprValue interval(ExprValue value, ExprValue unit) {

--- a/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/IntervalClause.java
+++ b/core/src/main/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/IntervalClause.java
@@ -26,7 +26,6 @@ import static com.amazon.opendistroforelasticsearch.sql.expression.function.Func
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.FunctionDSL.impl;
 import static com.amazon.opendistroforelasticsearch.sql.expression.function.FunctionDSL.nullMissingHandling;
 
-
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprIntervalValue;
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.exception.ExpressionEvaluationException;

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/IntervalClauseTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/IntervalClauseTest.java
@@ -16,9 +16,15 @@
 package com.amazon.opendistroforelasticsearch.sql.expression.datetime;
 
 import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.intervalValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.missingValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.model.ExprValueUtils.nullValue;
+import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTEGER;
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTERVAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
 
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.exception.ExpressionEvaluationException;
@@ -29,6 +35,7 @@ import com.amazon.opendistroforelasticsearch.sql.expression.FunctionExpression;
 import com.amazon.opendistroforelasticsearch.sql.expression.env.Environment;
 import java.time.Duration;
 import java.time.Period;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -38,6 +45,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class IntervalClauseTest extends ExpressionTestBase {
   @Mock
   Environment<Expression, ExprValue> env;
+
+  @Mock
+  Expression nullRef;
+
+  @Mock
+  Expression missingRef;
 
   @Test
   public void microsecond() {
@@ -113,5 +126,23 @@ public class IntervalClauseTest extends ExpressionTestBase {
   public void to_string() {
     FunctionExpression expr = dsl.interval(DSL.literal(1), DSL.literal("day"));
     assertEquals("interval(1, \"day\")", expr.toString());
+  }
+
+  @Test
+  public void null_value() {
+    when(nullRef.type()).thenReturn(INTEGER);
+    when(nullRef.valueOf(env)).thenReturn(nullValue());
+    FunctionExpression expr = dsl.interval(nullRef, DSL.literal("day"));
+    assertEquals(INTERVAL, expr.type());
+    assertEquals(nullValue(), expr.valueOf(env));
+  }
+
+  @Test
+  public void missing_value() {
+    when(missingRef.type()).thenReturn(INTEGER);
+    when(missingRef.valueOf(env)).thenReturn(missingValue());
+    FunctionExpression expr = dsl.interval(missingRef, DSL.literal("day"));
+    assertEquals(INTERVAL, expr.type());
+    assertEquals(missingValue(), expr.valueOf(env));
   }
 }

--- a/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/IntervalClauseTest.java
+++ b/core/src/test/java/com/amazon/opendistroforelasticsearch/sql/expression/datetime/IntervalClauseTest.java
@@ -22,9 +22,7 @@ import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.I
 import static com.amazon.opendistroforelasticsearch.sql.data.type.ExprCoreType.INTERVAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
-
 
 import com.amazon.opendistroforelasticsearch.sql.data.model.ExprValue;
 import com.amazon.opendistroforelasticsearch.sql.exception.ExpressionEvaluationException;
@@ -35,7 +33,6 @@ import com.amazon.opendistroforelasticsearch.sql.expression.FunctionExpression;
 import com.amazon.opendistroforelasticsearch.sql.expression.env.Environment;
 import java.time.Duration;
 import java.time.Period;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/NullLiteralIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/NullLiteralIT.java
@@ -56,6 +56,14 @@ public class NullLiteralIT extends SQLIntegTestCase {
         rows(null, null));
   }
 
+  @Test
+  public void testNullLiteralInInterval() {
+    verifyDataRows(
+        query("SELECT INTERVAL NULL DAY, INTERVAL 60 * 60 * 24 * (NULL - FLOOR(NULL)) SECOND"),
+        rows(null, null)
+    );
+  }
+
   private JSONObject query(String sql) {
     return new JSONObject(executeQuery(sql, "jdbc"));
   }

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilder.java
@@ -22,6 +22,7 @@ import com.amazon.opendistroforelasticsearch.sql.ast.Node;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.AggregateFunction;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Alias;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Function;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.Interval;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Literal;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.Aggregation;
@@ -136,7 +137,8 @@ public class AstAggregationBuilder extends OpenDistroSQLParserBaseVisitor<Unreso
 
   private boolean isNonLiteralFunction(UnresolvedExpression expr) {
     // The base case for recursion
-    if (expr instanceof Literal) {
+    // Interval is included since it is a special case of literal
+    if (expr instanceof Literal || expr instanceof Interval) {
       return false;
     }
     if (expr instanceof Function) {

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilder.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilder.java
@@ -21,9 +21,7 @@ import static java.util.Collections.emptyList;
 import com.amazon.opendistroforelasticsearch.sql.ast.Node;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.AggregateFunction;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.Alias;
-import com.amazon.opendistroforelasticsearch.sql.ast.expression.Function;
-import com.amazon.opendistroforelasticsearch.sql.ast.expression.Interval;
-import com.amazon.opendistroforelasticsearch.sql.ast.expression.Literal;
+import com.amazon.opendistroforelasticsearch.sql.ast.expression.QualifiedName;
 import com.amazon.opendistroforelasticsearch.sql.ast.expression.UnresolvedExpression;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.Aggregation;
 import com.amazon.opendistroforelasticsearch.sql.ast.tree.UnresolvedPlan;
@@ -126,8 +124,7 @@ public class AstAggregationBuilder extends OpenDistroSQLParserBaseVisitor<Unreso
    */
   private Optional<UnresolvedExpression> findNonAggregatedItemInSelect() {
     return querySpec.getSelectItems().stream()
-                                     .filter(this::isNonAggregatedExpression)
-                                     .filter(this::isNonLiteralFunction)
+                                     .filter(this::isNonAggregateOrLiteralExpression)
                                      .findFirst();
   }
 
@@ -135,28 +132,18 @@ public class AstAggregationBuilder extends OpenDistroSQLParserBaseVisitor<Unreso
     return querySpec.getAggregators().isEmpty();
   }
 
-  private boolean isNonLiteralFunction(UnresolvedExpression expr) {
-    // The base case for recursion
-    // Interval is included since it is a special case of literal
-    if (expr instanceof Literal || expr instanceof Interval) {
-      return false;
-    }
-    if (expr instanceof Function) {
-      List<? extends Node> children = expr.getChild();
-      return children.stream().anyMatch(child ->
-              isNonLiteralFunction((UnresolvedExpression) child));
-    }
-    return true;
-  }
-
-  private boolean isNonAggregatedExpression(UnresolvedExpression expr) {
+  private boolean isNonAggregateOrLiteralExpression(UnresolvedExpression expr) {
     if (expr instanceof AggregateFunction) {
       return false;
     }
 
+    if (expr instanceof QualifiedName) {
+      return true;
+    }
+
     List<? extends Node> children = expr.getChild();
-    return children.stream()
-                   .allMatch(child -> isNonAggregatedExpression((UnresolvedExpression) child));
+    return children.stream().anyMatch(child ->
+        isNonAggregateOrLiteralExpression((UnresolvedExpression) child));
   }
 
 }

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilderTest.java
@@ -133,6 +133,13 @@ class AstAggregationBuilderTest {
                     hasGroupByItems(),
                     hasAggregators(
                             alias("AVG(age)", aggregate("AVG", qualifiedName("age"))))));
+
+    assertThat(
+        buildAggregation("SELECT INTERVAL 1 DAY FROM test HAVING AVG(age) > 30"),
+        allOf(
+            hasGroupByItems(),
+            hasAggregators(
+                alias("AVG(age)", aggregate("AVG", qualifiedName("age"))))));
   }
 
   @Test

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilderTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/parser/AstAggregationBuilderTest.java
@@ -140,6 +140,20 @@ class AstAggregationBuilderTest {
             hasGroupByItems(),
             hasAggregators(
                 alias("AVG(age)", aggregate("AVG", qualifiedName("age"))))));
+
+    assertThat(
+        buildAggregation("SELECT CAST(1 AS LONG) FROM test HAVING AVG(age) > 30"),
+        allOf(
+            hasGroupByItems(),
+            hasAggregators(
+                alias("AVG(age)", aggregate("AVG", qualifiedName("age"))))));
+
+    assertThat(
+        buildAggregation("SELECT CASE WHEN true THEN 1 ELSE 2 END FROM test HAVING AVG(age) > 30"),
+        allOf(
+            hasGroupByItems(),
+            hasAggregators(
+                alias("AVG(age)", aggregate("AVG", qualifiedName("age"))))));
   }
 
   @Test


### PR DESCRIPTION
*Issue #, if available:*
#991 

*Description of changes:*
- Interval type failed semantic check in aggregations with implicit group by, so added interval type as literal type to be non-aggregation select items to pass the check
- Handled null and missing value check for interval type
- Added corresponding tests. Note: didn't add comparison test because missing `INTERVAL` in JDBC types


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
