### PR TITLE
Removed stack trace when catches anonymizing data error

### DIFF
--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/utils/QueryDataAnonymizer.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/utils/QueryDataAnonymizer.java
@@ -47,7 +47,7 @@ public class QueryDataAnonymizer {
                     .replaceAll("false", "boolean_literal")
                     .replaceAll("[\\n][\\t]+", " ");
         } catch (Exception e) {
-            LOG.error("Caught an exception when removing sensitive data", e);
+            LOG.warn("Caught an exception when anonymizing sensitive data");
             resultQuery = query;
         }
         return resultQuery;


### PR DESCRIPTION
*Issue #, if available:*
#1004 #431 

*Description of changes:*
Removed the stack trace for query data anonymizing error since it causes confusion for users who execute metadata queries and dml queries. Now it only prints a warning in log with error message "Caught an exception when anonymizing sensitive data" as follows:

Giving query `show tables like '%'`
```
[2021-01-27T14:31:29,304][WARN ][c.a.o.s.l.u.QueryDataAnonymizer] [147dda5ddf8a.ant.amazon.com] Caught an exception when anonymizing sensitive data
[2021-01-27T14:31:29,305][INFO ][c.a.o.s.l.p.RestSqlAction] [147dda5ddf8a.ant.amazon.com] [a8a76a90-8b90-449e-b50c-44cd954ee851] Incoming request /_opendistro/_sql?pretty=true: 
  show tables like '%'
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
