### PR TITLE
Rename sql-cli wheel to use dashes instead of underscore

### DIFF
--- a/.github/workflows/sql-cli-release-workflow.yml
+++ b/.github/workflows/sql-cli-release-workflow.yml
@@ -42,9 +42,11 @@ jobs:
           python setup.py sdist bdist_wheel
           artifact=`ls ./dist/*.tar.gz`
           wheel_artifact=`ls ./dist/*.whl`
+          renamed_wheel_artifact=`echo $wheel_artifact | sed 's/_/-/g'`
+          mv "$wheel_artifact" "$renamed_wheel_artifact"
 
           aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-clients/opendistro-sql-cli/
-          aws s3 cp $wheel_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-clients/opendistro-sql-cli/
+          aws s3 cp $renamed_wheel_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-clients/opendistro-sql-cli/
 
         # aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/downloads/*"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
change `odfe_sql_cli-1.12.0.0-py3-none-any.whl` to `odfe-sql-cli-1.12.0.0-py3-none-any.whl` when uploading to s3 for infra team's script

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
