### PR TITLE
Remove request id in response listener logging

### DIFF
--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryAction.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/plugin/RestSQLQueryAction.java
@@ -18,33 +18,21 @@ package com.amazon.opendistroforelasticsearch.sql.legacy.plugin;
 
 import static com.amazon.opendistroforelasticsearch.sql.executor.ExecutionEngine.QueryResponse;
 import static com.amazon.opendistroforelasticsearch.sql.protocol.response.format.JsonResponseFormatter.Style.PRETTY;
-import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.INTERNAL_SERVER_ERROR;
 import static org.elasticsearch.rest.RestStatus.OK;
-import static org.elasticsearch.rest.RestStatus.SERVICE_UNAVAILABLE;
 
-
-import com.alibaba.druid.sql.parser.ParserException;
 import com.amazon.opendistroforelasticsearch.sql.common.antlr.SyntaxCheckException;
 import com.amazon.opendistroforelasticsearch.sql.common.response.ResponseListener;
 import com.amazon.opendistroforelasticsearch.sql.common.setting.Settings;
 import com.amazon.opendistroforelasticsearch.sql.elasticsearch.security.SecurityAccess;
-import com.amazon.opendistroforelasticsearch.sql.exception.QueryEngineException;
-import com.amazon.opendistroforelasticsearch.sql.exception.SemanticCheckException;
 import com.amazon.opendistroforelasticsearch.sql.executor.ExecutionEngine.ExplainResponse;
-import com.amazon.opendistroforelasticsearch.sql.legacy.antlr.SqlAnalysisException;
-import com.amazon.opendistroforelasticsearch.sql.legacy.exception.SQLFeatureDisabledException;
-import com.amazon.opendistroforelasticsearch.sql.legacy.exception.SqlParseException;
-import com.amazon.opendistroforelasticsearch.sql.legacy.executor.format.ErrorMessageFactory;
 import com.amazon.opendistroforelasticsearch.sql.legacy.metrics.MetricName;
 import com.amazon.opendistroforelasticsearch.sql.legacy.metrics.Metrics;
-import com.amazon.opendistroforelasticsearch.sql.legacy.rewriter.matchtoterm.VerificationException;
-import com.amazon.opendistroforelasticsearch.sql.legacy.utils.LogUtils;
 import com.amazon.opendistroforelasticsearch.sql.planner.physical.PhysicalPlan;
 import com.amazon.opendistroforelasticsearch.sql.protocol.response.QueryResult;
-import com.amazon.opendistroforelasticsearch.sql.protocol.response.format.JdbcResponseFormatter;
 import com.amazon.opendistroforelasticsearch.sql.protocol.response.format.CsvResponseFormatter;
 import com.amazon.opendistroforelasticsearch.sql.protocol.response.format.Format;
+import com.amazon.opendistroforelasticsearch.sql.protocol.response.format.JdbcResponseFormatter;
 import com.amazon.opendistroforelasticsearch.sql.protocol.response.format.JsonResponseFormatter;
 import com.amazon.opendistroforelasticsearch.sql.protocol.response.format.ResponseFormatter;
 import com.amazon.opendistroforelasticsearch.sql.sql.SQLService;
@@ -52,13 +40,11 @@ import com.amazon.opendistroforelasticsearch.sql.sql.config.SQLServiceConfig;
 import com.amazon.opendistroforelasticsearch.sql.sql.domain.SQLQueryRequest;
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
-import java.sql.SQLFeatureNotSupportedException;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestChannel;
@@ -214,7 +200,7 @@ public class RestSQLQueryAction extends BaseRestHandler {
   }
 
   private static void logAndPublishMetrics(Exception e) {
-    LOG.error(LogUtils.getRequestId() + " Server side error during query execution", e);
+    LOG.error("Server side error during query execution", e);
     Metrics.getInstance().getNumericalMetric(MetricName.FAILED_REQ_COUNT_SYS).increment();
   }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* For some reason, request ID in thread context may not be populated. In response listener, another exception thrown from work thread when logging. In this case, Kibana hung there due to the uncaught exception.

```
java.lang.IllegalStateException: Request id not present in current context
  at com.amazon.opendistroforelasticsearch.sql.legacy.utils.LogUtils.getRequestId(LogUtils.java:54) ~[?:?]
  at com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSQLQueryAction.logAndPublishMetrics(RestSQLQueryAction.java:217) ~[?:?]
  at com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSQLQueryAction.access$200(RestSQLQueryAction.java:74) ~[?:?]
  at com.amazon.opendistroforelasticsearch.sql.legacy.plugin.RestSQLQueryAction$2.onFailure(RestSQLQueryAction.java:197) ~[?:?]
  at com.amazon.opendistroforelasticsearch.sql.elasticsearch.executor.ElasticsearchExecutionEngine.lambda$execute$0(ElasticsearchExecutionEngine.java:57) ~[?:?]
  at com.amazon.opendistroforelasticsearch.sql.elasticsearch.client.ElasticsearchNodeClient.lambda$withCurrentContext$5(ElasticsearchNodeClient.java:188) ~[?:?]
  at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:660) ~[elasticsearch-7.9.1.jar:7.9.1]
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
  at java.lang.Thread.run(Thread.java:834) [?:?]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
