### PR TITLE
The empty array values should be treated as null value when parsing json content

### DIFF
--- a/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/utils/ElasticsearchJsonContent.java
+++ b/elasticsearch/src/main/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/utils/ElasticsearchJsonContent.java
@@ -90,7 +90,7 @@ public class ElasticsearchJsonContent implements Content {
 
   @Override
   public boolean isNull() {
-    return value == null || value.isNull();
+    return value == null || value.isNull() || (value.isArray() && value.isEmpty());
   }
 
   @Override

--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactoryTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactoryTest.java
@@ -106,6 +106,11 @@ class ElasticsearchExprValueFactoryTest {
   }
 
   @Test
+  public void constructNullArrayValue() {
+    assertEquals(nullValue(), tupleValue("{\"intV\":[]}").get("intV"));
+  }
+
+  @Test
   public void constructByte() {
     assertEquals(byteValue((byte) 1), tupleValue("{\"byteV\":1}").get("byteV"));
     assertEquals(byteValue((byte) 1), constructFromObject("byteV", 1));


### PR DESCRIPTION
*Issue #, if available:* #1043

*Description of changes:*
The empty array values should be treated as null value when parsing json content

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
