### PR TITLE
Support double value in string format for GeoPoint

### DIFF
--- a/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactoryTest.java
+++ b/elasticsearch/src/test/java/com/amazon/opendistroforelasticsearch/sql/elasticsearch/data/value/ElasticsearchExprValueFactoryTest.java
@@ -284,7 +284,40 @@ class ElasticsearchExprValueFactoryTest {
     assertEquals(new ElasticsearchExprGeoPointValue(42.60355556, -97.25263889),
         tupleValue("{\"geoV\":{\"lat\":42.60355556,\"lon\":-97.25263889}}").get("geoV"));
     assertEquals(new ElasticsearchExprGeoPointValue(42.60355556, -97.25263889),
+        tupleValue("{\"geoV\":{\"lat\":\"42.60355556\",\"lon\":\"-97.25263889\"}}").get("geoV"));
+    assertEquals(new ElasticsearchExprGeoPointValue(42.60355556, -97.25263889),
         constructFromObject("geoV", "42.60355556,-97.25263889"));
+  }
+
+  @Test
+  public void constructGeoPointFromUnsupportedFormatShouldThrowException() {
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class,
+            () -> tupleValue("{\"geoV\":[42.60355556,-97.25263889]}").get("geoV"));
+    assertEquals("geo point must in format of {\"lat\": number, \"lon\": number}",
+        exception.getMessage());
+
+    exception =
+        assertThrows(IllegalStateException.class,
+            () -> tupleValue("{\"geoV\":{\"lon\":-97.25263889}}").get("geoV"));
+    assertEquals("geo point must in format of {\"lat\": number, \"lon\": number}",
+        exception.getMessage());
+
+    exception =
+        assertThrows(IllegalStateException.class,
+            () -> tupleValue("{\"geoV\":{\"lat\":-97.25263889}}").get("geoV"));
+    assertEquals("geo point must in format of {\"lat\": number, \"lon\": number}",
+        exception.getMessage());
+
+    exception =
+        assertThrows(IllegalStateException.class,
+            () -> tupleValue("{\"geoV\":{\"lat\":true,\"lon\":-97.25263889}}").get("geoV"));
+    assertEquals("latitude must be number value, but got value: true", exception.getMessage());
+
+    exception =
+        assertThrows(IllegalStateException.class,
+            () -> tupleValue("{\"geoV\":{\"lat\":42.60355556,\"lon\":false}}").get("geoV"));
+    assertEquals("longitude must be number value, but got value: false", exception.getMessage());
   }
 
   @Test
@@ -298,7 +331,7 @@ class ElasticsearchExprValueFactoryTest {
    * https://www.elastic.co/guide/en/elasticsearch/reference/current/array.html.
    */
   @Test
-  public void constructFromElasticsearcyArrayReturnFirstElement() {
+  public void constructFromElasticsearchArrayReturnFirstElement() {
     assertEquals(integerValue(1), tupleValue("{\"intV\":[1, 2, 3]}").get("intV"));
     assertEquals(new ExprTupleValue(
         new LinkedHashMap<String, ExprValue>() {


### PR DESCRIPTION
Signed-off-by: Peng Huo <penghuo@gmail.com>

*Issue #, if available:* #1064

*Description of changes:*
1. Support the double value in string format for GeoPoint.
Note: we are not supporting all the GeoPoint listed in [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html). We only support two type of geopoint now.
```
PUT my-index-000001/_doc/1
{
  "text": "Geo-point as an object",
  "location": { 
    "lat": 41.12,
    "lon": -71.34
  }
}
PUT my-index-000001/_doc/2
{
  "text": "Geo-point as an object",
  "location": { 
    "lat": "41.12",
    "lon": "-71.34"
  }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.