### PR TITLE
Bump jackson-dataformat-cbor Version

### DIFF
--- a/elasticsearch/build.gradle
+++ b/elasticsearch/build.gradle
@@ -13,7 +13,8 @@ dependencies {
     compile group: 'org.elasticsearch', name: 'elasticsearch', version: "${es_version}"
     compile "io.github.resilience4j:resilience4j-retry:1.5.0"
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5' 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.4'
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.11.4'
     compile group: 'org.json', name: 'json', version:'20180813'
     compileOnly group: 'org.elasticsearch.client', name: 'elasticsearch-rest-high-level-client', version: "${es_version}"
 

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -29,6 +29,7 @@ configurations.all {
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:29.0-jre'
     resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.10.5'
+    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4'
 }
 
 dependencies {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -35,7 +35,6 @@ configurations.all {
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:29.0-jre'
-    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.10.5'
     resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4'
 }
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -35,6 +35,8 @@ configurations.all {
     // enforce 1.1.3, https://www.whitesourcesoftware.com/vulnerability-database/WS-2019-0379
     resolutionStrategy.force 'commons-codec:commons-codec:1.13'
     resolutionStrategy.force 'com.google.guava:guava:29.0-jre'
+    resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.10.5'
+    resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4'
 }
 
 dependencies {

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -12,7 +12,8 @@ dependencies {
     // https://github.com/google/guava/wiki/CVE-2018-10237
     compile group: 'com.google.guava', name: 'guava', version: '29.0-jre'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5' 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.4'
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.11.4'
     implementation 'com.google.code.gson:gson:2.8.6'
     compile project(':core')
     compile project(':elasticsearch')


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Bump jackson-dataformat-cbor version to `2.11.4` to address high-severity CVEs. Also bumped jackson-databind version where needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.