### PR TITLE
Enable prepared statement support in new engine

### DIFF
--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/PreparedStatementIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/PreparedStatementIT.java
@@ -1,0 +1,53 @@
+/*
+ *    Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License").
+ *    You may not use this file except in compliance with the License.
+ *    A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    or in the "license" file accompanying this file. This file is distributed
+ *    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *    express or implied. See the License for the specific language governing
+ *    permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.opendistroforelasticsearch.sql.sql;
+
+import com.amazon.opendistroforelasticsearch.sql.legacy.SQLIntegTestCase;
+import com.amazon.opendistroforelasticsearch.sql.legacy.TestsConstants;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class PreparedStatementIT extends SQLIntegTestCase {
+
+  @Override
+  protected void init() throws Exception {
+    loadIndex(Index.ACCOUNT);
+  }
+
+  @Test
+  public void testPreparedStatement() {
+    JSONObject response = new JSONObject(
+        executeQuery(String.format("{\n"
+            + "  \"query\": \"SELECT state FROM %s WHERE state = ? GROUP BY state\",\n"
+            + "  \"parameters\": [\n"
+            + "    {\n"
+            + "      \"type\": \"string\",\n"
+            + "      \"value\": \"WA\"\n"
+            + "    }\n"
+            + " ]\n"
+            + "}", TestsConstants.TEST_INDEX_ACCOUNT), "jdbc"));
+
+    assertFalse(response.getJSONArray("datarows").isEmpty());
+  }
+
+  @Override
+  protected String makeRequest(String query) {
+    // Avoid wrap with "query" again
+    return query;
+  }
+
+}

--- a/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/domain/SQLQueryRequest.java
+++ b/sql/src/main/java/com/amazon/opendistroforelasticsearch/sql/sql/domain/SQLQueryRequest.java
@@ -88,12 +88,10 @@ public class SQLQueryRequest {
   }
 
   /**
-   * Pre-check if the request can be supported by meeting the following criteria:
-   *  1.Only supported fields present in request body
-   *  2.No fetch_size or "fetch_size=0" in payload. In other word, it's not a cursor request with
-   *     either non-zero "fetch_size" or "cursor" field,
-   *    or request with extra field such as "filter".
-   *  3.Response format expected is default JDBC format.
+   * Pre-check if the request can be supported by meeting ALL the following criteria:
+   *  1.Only supported fields present in request body, ex. "filter" and "cursor" are not supported
+   *  2.No fetch_size or "fetch_size=0". In other word, it's not a cursor request
+   *  3.Response format is default or can be supported.
    *
    * @return  true if supported.
    */

--- a/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/domain/SQLQueryRequestTest.java
+++ b/sql/src/test/java/com/amazon/opendistroforelasticsearch/sql/sql/domain/SQLQueryRequestTest.java
@@ -54,11 +54,29 @@ public class SQLQueryRequestTest {
   }
 
   @Test
+  public void shouldSupportQueryWithParameters() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .jsonContent("{\"query\": \"SELECT 1\", \"parameters\":[]}")
+            .build();
+    assertTrue(request.isSupported());
+  }
+
+  @Test
   public void shouldSupportQueryWithZeroFetchSize() {
     SQLQueryRequest request =
         SQLQueryRequestBuilder.request("SELECT 1")
                               .jsonContent("{\"query\": \"SELECT 1\", \"fetch_size\": 0}")
                               .build();
+    assertTrue(request.isSupported());
+  }
+
+  @Test
+  public void shouldSupportQueryWithParametersAndZeroFetchSize() {
+    SQLQueryRequest request =
+        SQLQueryRequestBuilder.request("SELECT 1")
+            .jsonContent("{\"query\": \"SELECT 1\", \"fetch_size\": 0, \"parameters\":[]}")
+            .build();
     assertTrue(request.isSupported());
   }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/sql/issues/1076, https://github.com/opendistro-for-elasticsearch/sql/issues/1070

*Description of changes:* Currently the new SQL engine won't handle request with `parameters` field which is mostly from JDBC `PreparedStatement`. Actually parameters are parsed and substituted before hitting new engine. So this PR is just to change fallback criteria a little bit and avoid fallback on request with `parameters` field.

*Documentation*: https://github.com/opendistro-for-elasticsearch/sql/blob/develop/docs/user/interfaces/protocol.rst#example-2

*Testing*: Added new IT and UT.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.