### PR TITLE
Fix ODBC build failures

### DIFF
--- a/sql-odbc/scripts/build_aws-sdk-cpp.ps1
+++ b/sql-odbc/scripts/build_aws-sdk-cpp.ps1
@@ -7,9 +7,11 @@ $INSTALL_DIR = $args[4]
 Write-Host $args
 
 # Clone the AWS SDK CPP repo
-# $SDK_VER = "1.7.29"
+ $SDK_VER = "1.7.29"
 # -b "$SDK_VER" `
 git clone `
+    --branch `
+    $SDK_VER `
     --single-branch `
     "https://github.com/aws/aws-sdk-cpp.git" `
     $SRC_DIR

--- a/sql-odbc/scripts/build_aws-sdk-cpp.ps1
+++ b/sql-odbc/scripts/build_aws-sdk-cpp.ps1
@@ -7,7 +7,7 @@ $INSTALL_DIR = $args[4]
 Write-Host $args
 
 # Clone the AWS SDK CPP repo
- $SDK_VER = "1.7.29"
+ $SDK_VER = "1.8.186"
 # -b "$SDK_VER" `
 git clone `
     --branch `


### PR DESCRIPTION
*Issue #, if available:*
#1091 

*Description of changes:*
Changed aws sdk cpp version to the last success version `1.8.186`. This PR is a temporary solution to fix the build errors, but we probably need to dive deeper to adapt our future versions to the new releases of aws sdk.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.