### PR TITLE
Added compatible names of SQL plugin for ODBC to check the ES connection

### DIFF
--- a/sql-odbc/src/odfesqlodbc/es_communication.cpp
+++ b/sql-odbc/src/odfesqlodbc/es_communication.cpp
@@ -38,8 +38,7 @@ static const std::string SQL_ENDPOINT_CLOSE_CURSOR = "/_opendistro/_sql/close";
 static const std::string PLUGIN_ENDPOINT_FORMAT_JSON =
     "/_cat/plugins?format=json";
 static const std::string OPENDISTRO_SQL_PLUGIN_NAME = "opendistro-sql";
-static const std::array< std::string, 3 > SQL_PLUGIN_COMPATIBLE_NAMES = {
-    "opendistro-sql", "opendistro_sql", "opensearch-sql"};
+static const std::array< std::string, 2 > SQL_PLUGIN_COMPATIBLE_NAMES = {"opendistro-sql", "opendistro_sql"};
 static const std::string ALLOCATION_TAG = "AWS_SIGV4_AUTH";
 static const std::string SERVICE_NAME = "es";
 static const std::string ESODBC_PROFILE_NAME = "elasticsearchodbc";

--- a/sql-odbc/src/odfesqlodbc/es_communication.cpp
+++ b/sql-odbc/src/odfesqlodbc/es_communication.cpp
@@ -37,6 +37,8 @@ static const std::string SQL_ENDPOINT_CLOSE_CURSOR = "/_opendistro/_sql/close";
 static const std::string PLUGIN_ENDPOINT_FORMAT_JSON =
     "/_cat/plugins?format=json";
 static const std::string OPENDISTRO_SQL_PLUGIN_NAME = "opendistro-sql";
+static const std::array<std::string, 3> SQL_PLUGIN_COMPATIBLE_NAMES =
+    {"opendistro-sql", "opendistro_sql", "opensearch-sql"};
 static const std::string ALLOCATION_TAG = "AWS_SIGV4_AUTH";
 static const std::string SERVICE_NAME = "es";
 static const std::string ESODBC_PROFILE_NAME = "elasticsearchodbc";
@@ -427,13 +429,15 @@ bool ESCommunication::IsSQLPluginInstalled(const std::string& plugin_response) {
         for (auto it : plugin_array) {
             if (it.has("component") && it.has("version")) {
                 std::string plugin_name = it.at("component").as_string();
-                if (!plugin_name.compare(OPENDISTRO_SQL_PLUGIN_NAME)) {
-                    std::string sql_plugin_version =
-                        it.at("version").as_string();
-                    LogMsg(ES_INFO, std::string("Found SQL plugin version '"
-                                                + sql_plugin_version + "'.")
-                                        .c_str());
-                    return true;
+                for(const auto& compatible_name : SQL_PLUGIN_COMPATIBLE_NAMES) {
+                    if (!plugin_name.compare(compatible_name)) {
+                        std::string sql_plugin_version =
+                            it.at("version").as_string();
+                        LogMsg(ES_INFO, std::string("Found SQL plugin version '"
+                                                    + sql_plugin_version + "'.")
+                                            .c_str());
+                        return true;
+                    }
                 }
             } else {
                 m_error_message =

--- a/sql-odbc/src/odfesqlodbc/es_communication.cpp
+++ b/sql-odbc/src/odfesqlodbc/es_communication.cpp
@@ -21,6 +21,7 @@
 // clang-format off
 #include "es_odbc.h"
 #include "mylog.h"
+#include "array"
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/client/RetryStrategy.h>
 #include <aws/core/client/AWSClient.h>
@@ -37,8 +38,8 @@ static const std::string SQL_ENDPOINT_CLOSE_CURSOR = "/_opendistro/_sql/close";
 static const std::string PLUGIN_ENDPOINT_FORMAT_JSON =
     "/_cat/plugins?format=json";
 static const std::string OPENDISTRO_SQL_PLUGIN_NAME = "opendistro-sql";
-static const std::array<std::string, 3> SQL_PLUGIN_COMPATIBLE_NAMES =
-    {"opendistro-sql", "opendistro_sql", "opensearch-sql"};
+static const std::array< std::string, 3 > SQL_PLUGIN_COMPATIBLE_NAMES = {
+    "opendistro-sql", "opendistro_sql", "opensearch-sql"};
 static const std::string ALLOCATION_TAG = "AWS_SIGV4_AUTH";
 static const std::string SERVICE_NAME = "es";
 static const std::string ESODBC_PROFILE_NAME = "elasticsearchodbc";
@@ -429,7 +430,7 @@ bool ESCommunication::IsSQLPluginInstalled(const std::string& plugin_response) {
         for (auto it : plugin_array) {
             if (it.has("component") && it.has("version")) {
                 std::string plugin_name = it.at("component").as_string();
-                for(const auto& compatible_name : SQL_PLUGIN_COMPATIBLE_NAMES) {
+                for (auto compatible_name : SQL_PLUGIN_COMPATIBLE_NAMES) {
                     if (!plugin_name.compare(compatible_name)) {
                         std::string sql_plugin_version =
                             it.at("version").as_string();


### PR DESCRIPTION
*Issue #, if available:*
#783 
#1078 

*Description of changes:*
Added compatible names of sql plugin (`opendistro_sql`, `opendistro-sql`) to allow the odbc to establish connection as long as any version of the sql plugin is installed. Did not add `opensearch-sql` since they share didn't endpoints.
Test and build didn't occur in PR, but has passed in my fork repository: https://github.com/chloe-zh/sql/actions/runs/843650708

Note: this is a temporary workaround to block the users from use our latest odbc driver with their existing ODFE/OpenSearch/AES instances. As @penghuo and I discussed offline, it might be better if we check the exposed endpoint for the connection test rather than check the installed plugin name, so we would probably need to have a deeper fix in this issue.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.