### PR TITLE
Bug Fix, return default ID when log4j ThreadContext is empty

### DIFF
--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/utils/LogUtils.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/utils/LogUtils.java
@@ -18,6 +18,7 @@ package com.amazon.opendistroforelasticsearch.sql.legacy.utils;
 import org.apache.logging.log4j.ThreadContext;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -29,6 +30,8 @@ public class LogUtils {
      * The key of the request id in the context map
      */
     private static final String REQUEST_ID_KEY = "request_id";
+
+    private static final String EMPTY_ID = "ID";
 
     /**
      * Generates a random UUID and adds to the {@link ThreadContext} as the request id.
@@ -48,13 +51,7 @@ public class LogUtils {
      * @return the current request id from {@link ThreadContext}
      */
     public static String getRequestId() {
-
-        final String requestId = ThreadContext.get(REQUEST_ID_KEY);
-        if (requestId == null) {
-            throw new IllegalStateException("Request id not present in current context");
-        }
-
-        return requestId;
+        return Optional.ofNullable(ThreadContext.get(REQUEST_ID_KEY)).orElseGet(() -> EMPTY_ID);
     }
 
     /**

--- a/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/unittest/utils/LogUtilsTest.java
+++ b/legacy/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/unittest/utils/LogUtilsTest.java
@@ -56,10 +56,10 @@ public class LogUtilsTest {
         Assert.assertThat(requestId2, not(equalTo(requestId)));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void getRequestId_doesNotExist() {
 
-        LogUtils.getRequestId();
+        assertEquals("ID", LogUtils.getRequestId());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Peng Huo <penghuo@gmail.com>

*Issue #, if available:*
https://github.com/opensearch-project/sql/issues/537

*Description of changes:*
Bug Fix, return default ID when log4j ThreadContext is empty.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.