### PR TITLE
[CVE Patch] Version Bump: SpringFramework

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,8 +17,8 @@ repositories {
 dependencies {
     // https://github.com/google/guava/wiki/CVE-2018-10237
     compile group: 'com.google.guava', name: 'guava', version: '29.0-jre'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     compile group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     compile project(':common')

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     }
     testCompile group: 'com.h2database', name: 'h2', version: '1.4.200'
     testCompile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.28.0'
-    testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
+    testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
 }
 
 dependencyLicenses.enabled = false

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -39,7 +39,7 @@ configurations.all {
 }
 
 dependencies {
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
     compile project(":ppl")
     compile project(':legacy')
     compile project(':elasticsearch')

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -27,10 +27,9 @@ dependencies {
     compile "org.antlr:antlr4-runtime:4.7.1"
     // https://github.com/google/guava/wiki/CVE-2018-10237
     compile group: 'com.google.guava', name: 'guava', version: '29.0-jre'
-    compile group: 'org.elasticsearch', name: 'elasticsearch-x-content', version: "${es_version}"
     compile group: 'org.json', name: 'json', version: '20180813'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.11.1'
     compile project(':common')
     compile project(':core')

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -28,8 +28,8 @@ dependencies {
     // https://github.com/google/guava/wiki/CVE-2018-10237
     implementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
     compile group: 'org.json', name: 'json', version:'20180813'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
     compile project(':common')
     compile project(':core')
     compile project(':protocol')


### PR DESCRIPTION
## Description
Version Bump
springframework 5.2.5 -> 5.2.20
com.google.code.gson 2.6.8 -> 2.6.9

## Issues Resolved
CVE-2022-22965

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.