### PR TITLE
Patch Release 1.13.2.1

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,8 +17,8 @@ repositories {
 dependencies {
     // https://github.com/google/guava/wiki/CVE-2018-10237
     compile group: 'com.google.guava', name: 'guava', version: '29.0-jre'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
     compile group: 'com.facebook.presto', name: 'presto-matching', version: '0.240'
     compile project(':common')

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     }
     testCompile group: 'com.h2database', name: 'h2', version: '1.4.200'
     testCompile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.28.0'
-    testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
+    testCompile group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
 }
 
 dependencyLicenses.enabled = false

--- a/integ-test/build.gradle
+++ b/integ-test/build.gradle
@@ -30,6 +30,7 @@ configurations.all {
     resolutionStrategy.force 'com.google.guava:guava:29.0-jre'
     resolutionStrategy.force 'com.fasterxml.jackson.core:jackson-core:2.10.5'
     resolutionStrategy.force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4'
+    resolutionStrategy.force 'com.google.code.gson:gson:2.8.9'
 }
 
 dependencies {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -39,7 +39,7 @@ configurations.all {
 }
 
 dependencies {
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
     compile project(":ppl")
     compile project(':legacy')
     compile project(':elasticsearch')

--- a/ppl/build.gradle
+++ b/ppl/build.gradle
@@ -27,10 +27,9 @@ dependencies {
     compile "org.antlr:antlr4-runtime:4.7.1"
     // https://github.com/google/guava/wiki/CVE-2018-10237
     compile group: 'com.google.guava', name: 'guava', version: '29.0-jre'
-    compile group: 'org.elasticsearch', name: 'elasticsearch-x-content', version: "${es_version}"
     compile group: 'org.json', name: 'json', version: '20180813'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.11.1'
     compile project(':common')
     compile project(':core')

--- a/release-notes/opendistro-for-elasticsearch-sql.release-notes-1.13.2.1.md
+++ b/release-notes/opendistro-for-elasticsearch-sql.release-notes-1.13.2.1.md
@@ -1,0 +1,4 @@
+## 2022-7-20 Version 1.13.2.1
+
+### Security Fix
+* [CVE Patch] Version Bump: SpringFramework and GSON ([#1022](https://github.com/opendistro-for-elasticsearch/sql/pull/1178))

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -28,8 +28,8 @@ dependencies {
     // https://github.com/google/guava/wiki/CVE-2018-10237
     implementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
     compile group: 'org.json', name: 'json', version:'20180813'
-    compile group: 'org.springframework', name: 'spring-context', version: '5.2.5.RELEASE'
-    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.5.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context', version: '5.2.20.RELEASE'
+    compile group: 'org.springframework', name: 'spring-beans', version: '5.2.20.RELEASE'
     compile project(':common')
     compile project(':core')
     compile project(':protocol')


### PR DESCRIPTION
*Description of changes:*
* [CVE Patch] Version Bump: SpringFramework and GSON ([#1022](https://github.com/opendistro-for-elasticsearch/sql/pull/1178))


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.